### PR TITLE
fix stale pants flags to load sources and docs for intelij pants plugin

### DIFF
--- a/common/com/twitter/intellij/pants/PantsBundle.properties
+++ b/common/com/twitter/intellij/pants/PantsBundle.properties
@@ -17,7 +17,7 @@ pants.settings.text.hint=Hint
 pants.settings.text.path.hint=Choose a folder to load all targets recursively
 pants.settings.text.targets=Choose targets\:
 pants.settings.text.with.dependents=Load dependents transitively
-pants.settings.text.with.sources=Load sources for libraries
+pants.settings.text.with.sources.and.docs=Load sources and docs for libraries
 pants.settings.text.update.channel=Use Beta Channel for Pants Plugin Updates
 
 pants.project.generated.with.old.version=Project ''{0}'' was imported with a different version of the plugin. Do you want to refresh it right now?

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -1,7 +1,7 @@
 // Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-package com.twitter.intellij.pants.jps.incremental;
+package com.twitter.intellij.pants.jps.incremental; 
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -1,7 +1,7 @@
 // Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-package com.twitter.intellij.pants.jps.incremental; 
+package com.twitter.intellij.pants.jps.incremental;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -26,7 +26,6 @@ import com.twitter.intellij.pants.model.PantsCompileOptions;
 import com.twitter.intellij.pants.model.PantsExecutionOptions;
 import com.twitter.intellij.pants.service.project.model.TargetAddressInfo;
 import com.twitter.intellij.pants.settings.PantsExecutionSettings;
-import com.twitter.intellij.pants.settings.PantsProjectSettings;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -115,7 +115,7 @@ public class PantsCompileOptionsExecutor {
       workingDir,
       options,
       resolveJars,
-      executionOptions != null && executionOptions.isLibsWithSources(),
+      executionOptions != null && executionOptions.isLibsWithSourcesAndDocs(),
       executionOptions != null && executionOptions.isCompileWithIntellij()
     );
   }

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -26,6 +26,7 @@ import com.twitter.intellij.pants.model.PantsCompileOptions;
 import com.twitter.intellij.pants.model.PantsExecutionOptions;
 import com.twitter.intellij.pants.service.project.model.TargetAddressInfo;
 import com.twitter.intellij.pants.settings.PantsExecutionSettings;
+import com.twitter.intellij.pants.settings.PantsProjectSettings;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -112,8 +113,10 @@ public class PantsCompileOptionsExecutor {
       throw new ExternalSystemException(PantsBundle.message("pants.error.no.pants.executable.by.path", options.getExternalProjectPath()));
     }
     return new PantsCompileOptionsExecutor(
-      workingDir, options,
-      resolveJars, executionOptions != null && executionOptions.isLibsWithSources(),
+      workingDir,
+      options,
+      resolveJars,
+      executionOptions != null && executionOptions.isLibsWithSources(),
       executionOptions != null && executionOptions.isCompileWithIntellij()
     );
   }
@@ -145,8 +148,8 @@ public class PantsCompileOptionsExecutor {
     myWorkingDir = workingDir;
     myOptions = compilerOptions;
     myResolveJars = resolveJars;
-    myCompileWithIntellij = compileWithIntellij;
     myResolveSourcesForJars = resolveSourcesForJars;
+    myCompileWithIntellij = compileWithIntellij;
   }
 
   public String getProjectRelativePath() {
@@ -277,9 +280,10 @@ public class PantsCompileOptionsExecutor {
     }
 
     commandLine.addParameter("export");
-    if (!myResolveJars) {
-      commandLine.addParameter("--no-libraries");
+    if (myResolveSourcesForJars){
+      commandLine.addParameter("--export-libraries-sources");
     }
+
     commandLine.addParameters(getAllTargetAddresses());
 
     if (getOptions().isWithDependees()) {

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -46,7 +46,7 @@ public class PantsCompileOptionsExecutor {
   private final File myWorkingDir;
   private final boolean myResolveJars;
   private final boolean myCompileWithIntellij;
-  private final boolean myResolveSourcesForJars;
+  private final boolean myResolveSourcesAndDocsForJars;
 
   /**
    *  Add help-default goal to Pants to get all defaults in machine readable format
@@ -141,13 +141,13 @@ public class PantsCompileOptionsExecutor {
     @NotNull File workingDir,
     @NotNull PantsCompileOptions compilerOptions,
     boolean resolveJars,
-    boolean resolveSourcesForJars,
+    boolean resolveSourcesAndDocsForJars,
     boolean compileWithIntellij
   ) {
     myWorkingDir = workingDir;
     myOptions = compilerOptions;
     myResolveJars = resolveJars;
-    myResolveSourcesForJars = resolveSourcesForJars;
+    myResolveSourcesAndDocsForJars = resolveSourcesAndDocsForJars;
     myCompileWithIntellij = compileWithIntellij;
   }
 
@@ -271,7 +271,7 @@ public class PantsCompileOptionsExecutor {
     // in unit test mode it's always preview but we need to know libraries
     // because some jvm_binary targets are actually Scala ones and we need to
     // set a proper com.twitter.intellij.pants.compiler output folder
-    if (myResolveJars && myResolveSourcesForJars) {
+    if (myResolveJars && myResolveSourcesAndDocsForJars) {
       commandLine.addParameter("resolve.ivy");
       commandLine.addParameter("--confs=default");
       commandLine.addParameter("--confs=sources");
@@ -279,8 +279,9 @@ public class PantsCompileOptionsExecutor {
     }
 
     commandLine.addParameter("export");
-    if (myResolveSourcesForJars){
+    if (myResolveSourcesAndDocsForJars){
       commandLine.addParameter("--export-libraries-sources");
+      commandLine.addParameter("--export-libraries-javadocs");
     }
 
     commandLine.addParameters(getAllTargetAddresses());

--- a/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
@@ -4,7 +4,6 @@
 package com.twitter.intellij.pants.settings;
 
 import com.intellij.openapi.externalSystem.model.settings.ExternalSystemExecutionSettings;
-import com.intellij.util.containers.ContainerUtilRt;
 import com.twitter.intellij.pants.model.PantsExecutionOptions;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,18 +13,18 @@ import java.util.List;
 public class PantsExecutionSettings extends ExternalSystemExecutionSettings implements PantsExecutionOptions {
   private final boolean myWithDependees;
   private final boolean myCompileWithIntellij;
-  private final boolean myLibsWithSources;
+  private final boolean myLibsWithSourcesAndDocs;
   private List<String> myTargetNames;
 
   public PantsExecutionSettings() {
     this(Collections.<String>emptyList(), false, false, true);
   }
 
-  public PantsExecutionSettings(List<String> targetNames, boolean withDependees, boolean compileWithIntellij, boolean libsWithSources) {
+  public PantsExecutionSettings(List<String> targetNames, boolean withDependees, boolean compileWithIntellij, boolean libsWithSourcesAndDocs) {
     myTargetNames = targetNames;
     myWithDependees = withDependees;
     myCompileWithIntellij = compileWithIntellij;
-    myLibsWithSources = libsWithSources;
+    myLibsWithSourcesAndDocs = libsWithSourcesAndDocs;
   }
 
   @NotNull
@@ -42,8 +41,8 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     return myCompileWithIntellij;
   }
 
-  public boolean isLibsWithSources() {
-    return myLibsWithSources;
+  public boolean isLibsWithSourcesAndDocs() {
+    return myLibsWithSourcesAndDocs;
   }
 
   @Override
@@ -56,7 +55,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
 
     if (myWithDependees != settings.myWithDependees) return false;
     if (myCompileWithIntellij != settings.myCompileWithIntellij) return false;
-    if (myLibsWithSources != settings.myLibsWithSources) return false;
+    if (myLibsWithSourcesAndDocs != settings.myLibsWithSourcesAndDocs) return false;
     if (myTargetNames != null ? !myTargetNames.equals(settings.myTargetNames) : settings.myTargetNames != null) return false;
 
     return true;
@@ -68,7 +67,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     result = 31 * result + (myWithDependees ? 1 : 0);
     result = 31 * result + (myTargetNames != null ? myTargetNames.hashCode() : 0);
     result = 31 * result + (myCompileWithIntellij ? 1 : 0);
-    result = 31 * result + (myLibsWithSources ? 1 : 0);
+    result = 31 * result + (myLibsWithSourcesAndDocs ? 1 : 0);
     return result;
   }
 }

--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
@@ -53,7 +53,7 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
       content.add(myWithDependeesCheckBox, ExternalSystemUiUtil.getFillLineConstraints(indentLevel));
     }
 
-    myLibsWithSourcesCheckBox = new JBCheckBox(PantsBundle.message("pants.settings.text.with.sources"));
+    myLibsWithSourcesCheckBox = new JBCheckBox(PantsBundle.message("pants.settings.text.with.sources.and.docs"));
     myLibsWithSourcesCheckBox.setSelected(false);
     content.add(myLibsWithSourcesCheckBox, ExternalSystemUiUtil.getFillLineConstraints(indentLevel));
 


### PR DESCRIPTION
Fix the issue where 3rdparty sources cannot be resolved by intellij because the flags are staled.
This change also includes loading docs along with sources once the "load sources and docs for libraries" box is checked. 