### PR TITLE
Fix IntelliJ CI test case based on pants dependencies rather than hardcoding module names

### DIFF
--- a/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
@@ -119,7 +119,9 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
     doImport(projectRelativePath);
 
     //Checking whether the modules loaded in the project are the same as pants dependencies
-    assertModules(getModulesNamesFromPantsDependencies(projectRelativePath));
+    String[] moduleNames = getModulesNamesFromPantsDependencies(projectRelativePath);
+    assertTrue(moduleNames.length > 0);
+    assertModules(moduleNames);
 
     assertGenModules(1);
 


### PR DESCRIPTION
https://github.com/pantsbuild/pants/commit/a31e175730dad9b6694204b4de7fbb9906542cbb removed a target under examples/src/java/org/pantsbuild/example/jaxb/main, thus 
    
doImport("examples/src/java/org/pantsbuild/example/jaxb/main");

assertModules(
  "examples_src_resources_org_pantsbuild_example_jaxb_jaxb",
  "examples_src_resources_org_pantsbuild_example_names_names", <- this module is gone
  "examples_src_java_org_pantsbuild_example_jaxb_main_main",
  "examples_src_java_org_pantsbuild_example_jaxb_reader_reader"
);

Pinning pants version at 0.0.59 instead of pulling the latest OSS pants for CI.