### PR TITLE
Have regression cover the last 10 releases of pants; use git tag to specify the pants version to load instead of sha 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ env:
     - PANTS_SHA="release_0.0.58" TEST_SET=integration
     - PANTS_SHA="release_0.0.57" TEST_SET=integration
     - PANTS_SHA="release_0.0.56" TEST_SET=integration
-    - PANTS_SHA="release_0.0.55" TEST_SET=integration
 
 script:
   - ./scripts/run-tests-ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,16 @@ env:
     - IJ_ULTIMATE=false
     - IJ_ULTIMATE=true
     - USE_PANTS_TO_COMPILE=false
-    - PANTS_SHA="release_0.0.64" TEST_SET=integration # 0.0.60
-    - PANTS_SHA="release_0.0.63" TEST_SET=integration # 0.0.60
-    - PANTS_SHA="release_0.0.62" TEST_SET=integration # 0.0.60
-    - PANTS_SHA="release_0.0.61" TEST_SET=integration # 0.0.60
-    - PANTS_SHA="release_0.0.60" TEST_SET=integration # 0.0.60
-    - PANTS_SHA="release_0.0.59" TEST_SET=integration # 0.0.60
-    - PANTS_SHA="release_0.0.58" TEST_SET=integration # 0.0.60
-    - PANTS_SHA="release_0.0.57" TEST_SET=integration # 0.0.60
-    - PANTS_SHA="release_0.0.56" TEST_SET=integration # 0.0.60
-    - PANTS_SHA="release_0.0.55" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.64" TEST_SET=integration
+    - PANTS_SHA="release_0.0.63" TEST_SET=integration
+    - PANTS_SHA="release_0.0.62" TEST_SET=integration
+    - PANTS_SHA="release_0.0.61" TEST_SET=integration
+    - PANTS_SHA="release_0.0.60" TEST_SET=integration
+    - PANTS_SHA="release_0.0.59" TEST_SET=integration
+    - PANTS_SHA="release_0.0.58" TEST_SET=integration
+    - PANTS_SHA="release_0.0.57" TEST_SET=integration
+    - PANTS_SHA="release_0.0.56" TEST_SET=integration
+    - PANTS_SHA="release_0.0.55" TEST_SET=integration
 
 script:
   - ./scripts/run-tests-ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,22 @@ notifications:
 
 install: ./scripts/setup-ci-environment.sh
 
+# General policy is to support pants for the past 10 releases and the current master
 env:
   matrix:
     - IJ_ULTIMATE=false
     - IJ_ULTIMATE=true
     - USE_PANTS_TO_COMPILE=false
-    - PANTS_SHA=bf5e1d8 TEST_SET=integration # 0.0.54
-    - PANTS_SHA=11d89c9 TEST_SET=integration # 0.0.53
-    - PANTS_SHA=4719e0d TEST_SET=integration # 0.0.52
-    - PANTS_SHA=78d5bb8 TEST_SET=integration # 0.0.51
-    - PANTS_SHA=8ae0612 TEST_SET=integration # 0.0.50
-    - PANTS_SHA=31fba06 TEST_SET=integration # 0.0.49
-    - PANTS_SHA=953cb12 TEST_SET=integration # 0.0.48
-    - PANTS_SHA=1fd2293 TEST_SET=integration # 0.0.47
+    - PANTS_SHA="release_0.0.64" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.63" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.62" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.61" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.60" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.59" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.58" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.57" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.56" TEST_SET=integration # 0.0.60
+    - PANTS_SHA="release_0.0.55" TEST_SET=integration # 0.0.60
 
 script:
   - ./scripts/run-tests-ci.sh


### PR DESCRIPTION
@zundel mentioned to specify a policy regarding how far back the regression test should go, and I think 10 releases make sense which goes back about 2-3 months.