### PR TITLE
reorganize setup script; add hash check for downloaded packages; disable cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ sudo: false
 language: java
 jdk:
   - oraclejdk7
-cache:
-  directories:
-  - .cache/intellij
-  - .cache/bootstrap
+#cache:
+#  directories:
+#  - .cache/intellij
+#  - .cache/bootstrap
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ sudo: false
 language: java
 jdk:
   - oraclejdk7
-#cache:
-#  directories:
-#  - .cache/intellij
-#  - .cache/bootstrap
 
 notifications:
   email:
@@ -25,6 +21,7 @@ env:
     - IJ_ULTIMATE=false
     - IJ_ULTIMATE=true
     - USE_PANTS_TO_COMPILE=false
+    - PANTS_SHA="release_0.0.65" TEST_SET=integration
     - PANTS_SHA="release_0.0.64" TEST_SET=integration
     - PANTS_SHA="release_0.0.63" TEST_SET=integration
     - PANTS_SHA="release_0.0.62" TEST_SET=integration

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-pants_version: 0.0.65
+pants_version: 0.0.55
 
 local_artifact_cache = %(buildroot)s/.cache
 

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-pants_version: 0.0.55
+pants_version: 0.0.56
 
 local_artifact_cache = %(buildroot)s/.cache
 

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-pants_version: 0.0.56
+pants_version: 0.0.65
 
 local_artifact_cache = %(buildroot)s/.cache
 

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -13,9 +13,9 @@ export IJ_BUILD_NUMBER="143.381"
 
 get_md5(){
   if [[ $OSTYPE == *"darwin"* ]]; then
-    echo  $(md5 $1| awk -F " " '{print $4}')
+    echo  $(md5 $1| awk '{print $NF}')
   else
-    echo  $(md5sum $1| awk -F " " '{print $1}')
+    echo  $(md5sum $1| awk '{print $1}')
   fi
 }
 

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -12,11 +12,11 @@ export IJ_VERSION="15.0"
 export IJ_BUILD_NUMBER="143.381"
 
 get_md5(){
-if [[ $OSTYPE == *"darwin"* ]]; then
-  echo  $(md5 $1| awk -F " " '{print $4}')
-else
-  echo  $(md5sum $1| awk -F " " '{print $1}')
-fi
+  if [[ $OSTYPE == *"darwin"* ]]; then
+    echo  $(md5 $1| awk -F " " '{print $4}')
+  else
+    echo  $(md5sum $1| awk -F " " '{print $1}')
+  fi
 }
 
 if [[ $IJ_ULTIMATE == "true" ]]; then

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -5,6 +5,7 @@ set -e
 export CWD=$(pwd)
 export IJ_VERSION="15.0"
 export IJ_BUILD_NUMBER="143.381"
+export EXPECTED_IJ_MD5="947403b117cc7fc3d5ab22eda7def557"
 
 export FULL_IJ_BUILD_NUMBER="IC-${IJ_BUILD_NUMBER}"
 export IJ_BUILD="IC-${IJ_VERSION}"

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -11,6 +11,14 @@ export CWD=$(pwd)
 export IJ_VERSION="15.0"
 export IJ_BUILD_NUMBER="143.381"
 
+get_md5(){
+if [[ $OSTYPE == *"darwin"* ]]; then
+  echo  $(md5 $1| awk -F " " '{print $4}')
+else
+  echo  $(md5sum $1| awk -F " " '{print $1}')
+fi
+}
+
 if [[ $IJ_ULTIMATE == "true" ]]; then
   export IJ_BUILD="IU-${IJ_VERSION}"
   export FULL_IJ_BUILD_NUMBER="IU-${IJ_BUILD_NUMBER}"

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -2,17 +2,32 @@
 
 set -e
 
+# Important: to update the build number of intellij, you need to update the following hashes:
+# Intellij tarball for Community and Ultimate Edition
+# Scala plugin
+# Python plugin for Community and Ultimate Edition
+
 export CWD=$(pwd)
 export IJ_VERSION="15.0"
 export IJ_BUILD_NUMBER="143.381"
-export EXPECTED_IJ_MD5="947403b117cc7fc3d5ab22eda7def557"
 
-export FULL_IJ_BUILD_NUMBER="IC-${IJ_BUILD_NUMBER}"
-export IJ_BUILD="IC-${IJ_VERSION}"
 if [[ $IJ_ULTIMATE == "true" ]]; then
   export IJ_BUILD="IU-${IJ_VERSION}"
   export FULL_IJ_BUILD_NUMBER="IU-${IJ_BUILD_NUMBER}"
+  export EXPECTED_IJ_MD5="4da955e200b6e1b4f82ca81871cd01c0"
+  export PYTHON_PLUGIN_ID="Pythonid"
+  export PYTHON_PLUGIN_MD5="ce2e050387e45cd690774bdd5fc171eb"
+else
+  export IJ_BUILD="IC-${IJ_VERSION}"
+  export FULL_IJ_BUILD_NUMBER="IC-${IJ_BUILD_NUMBER}"
+  export EXPECTED_IJ_MD5="947403b117cc7fc3d5ab22eda7def557"
+  export PYTHON_PLUGIN_ID="PythonCore"
+  export PYTHON_PLUGIN_MD5="023aa42811f0dd9c15a8400ff6256b7f"
 fi
+
+# we will use Community ids to download plugins.
+export SCALA_PLUGIN_ID="org.intellij.scala"
+export SCALA_PLUGIN_MD5="b5bff7d6a30246498aa9daf08490c986"
 
 export INTELLIJ_PLUGINS_HOME="$CWD/.cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins"
 export INTELLIJ_HOME="$CWD/.cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist"
@@ -45,3 +60,4 @@ append_intellij_jvm_options() {
 
   echo $cmd
 }
+

--- a/scripts/run-tests-ci.sh
+++ b/scripts/run-tests-ci.sh
@@ -21,7 +21,7 @@ fi
 popd
 popd
 
-args="test tests:${TEST_SET:-all} $(append_intellij_jvm_options test-junit) $@"
+args="clean-all test tests:${TEST_SET:-all} $(append_intellij_jvm_options test-junit) $@"
 
 echo "Running ./pants $args"
 ./pants $args

--- a/scripts/run-tests-ci.sh
+++ b/scripts/run-tests-ci.sh
@@ -21,7 +21,7 @@ fi
 popd
 popd
 
-args="clean-all test tests:${TEST_SET:-all} $(append_intellij_jvm_options test-junit) $@"
+args="test tests:${TEST_SET:-all} $(append_intellij_jvm_options test-junit) $@"
 
 echo "Running ./pants $args"
 ./pants $args

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -14,7 +14,7 @@ if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
     exit 1
   fi
   {
-    tar zxf --overwrite $IJ_TAR_NAME &&
+    tar zxf $IJ_TAR_NAME &&
     UNPACKED_IDEA=$(find . -name 'idea-I*' | head -n 1) &&
     mv "$UNPACKED_IDEA" ".cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist" &&
     rm -rf $IJ_TAR_NAME

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -7,14 +7,14 @@ mkdir -p .cache/intellij/$FULL_IJ_BUILD_NUMBER
 if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
   IJ_TAR_NAME=idea${IJ_BUILD}.tar.gz
   echo "Loading $IJ_BUILD..."
-  wget -O $IJ_TAR_NAME http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz
+  wget -O $IJ_TAR_NAME "http://download.jetbrains.com/idea/$IJ_TAR_NAME"
   if [ $(md5sum $IJ_TAR_NAME  | awk -F " " '{print $1}') != $EXPECTED_IJ_MD5 ];
   then
     echo "IJ tar md5 incorrect" >&2
     exit 1
   fi
   {
-    tar zxf $IJ_TAR_NAME &&
+    tar zxf --overwrite $IJ_TAR_NAME &&
     UNPACKED_IDEA=$(find . -name 'idea-I*' | head -n 1) &&
     mv "$UNPACKED_IDEA" ".cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist" &&
     rm -rf $IJ_TAR_NAME

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -12,19 +12,19 @@ fi
 mkdir -p .cache/intellij/$FULL_IJ_BUILD_NUMBER
 
 if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
+  IJ_TAR_NAME=idea${IJ_BUILD}.tar.gz
   echo "Loading $IJ_BUILD..."
-  wget http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz
-  tar_md5=$(md5sum idea${IJ_BUILD}.tar.gz  | awk -F " " '{print $1}')
+  wget -O $IJ_TAR_NAME http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz
+  tar_md5=$(md5sum $IJ_TAR_NAME  | awk -F " " '{print $1}')
   if [ $tar_md5 != $EXPECTED_IJ_MD5 ];
   then
     echo "IJ tar md5 incorrect" >&2
     exit 1
   fi
   {
-  tar zxf idea${IJ_BUILD}.tar.gz &&
-  rm -rf idea${IJ_BUILD}.tar.gz &&
-  UNPACKED_IDEA=$(find . -name 'idea-I*' | head -n 1) &&
-  mv "$UNPACKED_IDEA" ".cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist"
+    tar zxf $IJ_TAR_NAME &&
+    mv "$IJ_TAR_NAME" ".cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist" &&
+    rm -rf $IJ_TAR_NAME
   } || {
     echo "Failed to untar IntelliJ" >&2
     rm -rf .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist
@@ -39,10 +39,10 @@ if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins ]; then
 
   wget -O Scala.zip "https://plugins.jetbrains.com/pluginManager/?action=download&id=$SCALA_PLUGIN_ID&build=$FULL_IJ_BUILD_NUMBER"
   unzip Scala.zip
-  rm -rf Scala.zip
+  #rm -rf Scala.zip
   wget -O python.zip "https://plugins.jetbrains.com/pluginManager/?action=download&id=$PYTHON_PLUGIN_ID&build=$FULL_IJ_BUILD_NUMBER"
   unzip python.zip
-  rm -rf python.zip
+  #rm -rf python.zip
 
   popd
   mv plugins ".cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins"

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -14,7 +14,7 @@ mkdir -p .cache/intellij/$FULL_IJ_BUILD_NUMBER
 if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
   {
   echo "Loading $IJ_BUILD..." &&
-  #wget http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz &&
+  wget http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz &&
   tar_md5=$(md5sum idea${IJ_BUILD}.tar.gz  | awk -F " " '{print $1}') &&
   if [ $tar_md5 != $EXPECTED_IJ_MD5 ];
   then

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -12,22 +12,21 @@ fi
 mkdir -p .cache/intellij/$FULL_IJ_BUILD_NUMBER
 
 if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
-  {
-  echo "Loading $IJ_BUILD..." &&
-  wget http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz &&
-  tar_md5=$(md5sum idea${IJ_BUILD}.tar.gz  | awk -F " " '{print $1}') &&
+  echo "Loading $IJ_BUILD..."
+  wget http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz
+  tar_md5=$(md5sum idea${IJ_BUILD}.tar.gz  | awk -F " " '{print $1}')
   if [ $tar_md5 != $EXPECTED_IJ_MD5 ];
   then
     echo "IJ tar md5 incorrect" >&2
     exit 1
-  fi &&
-  rm -rf idea${IJ_BUILD}.tar.gz &&
+  fi
+  {
   tar zxf idea${IJ_BUILD}.tar.gz &&
   rm -rf idea${IJ_BUILD}.tar.gz &&
   UNPACKED_IDEA=$(find . -name 'idea-I*' | head -n 1) &&
   mv "$UNPACKED_IDEA" ".cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist"
   } || {
-    echo "Failed to download/untar IntelliJ" >&2
+    echo "Failed to untar IntelliJ" >&2
     rm -rf .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist
     exit 1
   }

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -2,21 +2,13 @@
 
 source scripts/prepare-ci-environment.sh
 
-# we will use Community ids to download plugins.
-SCALA_PLUGIN_ID="org.intellij.scala"
-PYTHON_PLUGIN_ID="PythonCore"
-if [[ $IJ_ULTIMATE == "true" ]]; then
-  PYTHON_PLUGIN_ID="Pythonid"
-fi
-
 mkdir -p .cache/intellij/$FULL_IJ_BUILD_NUMBER
 
 if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
   IJ_TAR_NAME=idea${IJ_BUILD}.tar.gz
   echo "Loading $IJ_BUILD..."
   wget -O $IJ_TAR_NAME http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz
-  tar_md5=$(md5sum $IJ_TAR_NAME  | awk -F " " '{print $1}')
-  if [ $tar_md5 != $EXPECTED_IJ_MD5 ];
+  if [ $(md5sum $IJ_TAR_NAME  | awk -F " " '{print $1}') != $EXPECTED_IJ_MD5 ];
   then
     echo "IJ tar md5 incorrect" >&2
     exit 1
@@ -38,11 +30,22 @@ if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins ]; then
   pushd plugins
 
   wget -O Scala.zip "https://plugins.jetbrains.com/pluginManager/?action=download&id=$SCALA_PLUGIN_ID&build=$FULL_IJ_BUILD_NUMBER"
+  if [ $(md5sum Scala.zip  | awk -F " " '{print $1}') != $SCALA_PLUGIN_MD5 ];
+  then
+    echo "Scala plugin md5 incorrect" >&2
+    exit 1
+  fi
   unzip Scala.zip
-  #rm -rf Scala.zip
+  rm -rf Scala.zip
+
   wget -O python.zip "https://plugins.jetbrains.com/pluginManager/?action=download&id=$PYTHON_PLUGIN_ID&build=$FULL_IJ_BUILD_NUMBER"
+  if [ $(md5sum python.zip  | awk -F " " '{print $1}') != $PYTHON_PLUGIN_MD5 ];
+  then
+    echo "Scala plugin md5 incorrect" >&2
+    exit 1
+  fi
   unzip python.zip
-  #rm -rf python.zip
+  rm -rf python.zip
 
   popd
   mv plugins ".cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins"

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -12,12 +12,25 @@ fi
 mkdir -p .cache/intellij/$FULL_IJ_BUILD_NUMBER
 
 if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
-  echo "Loading $IJ_BUILD..."
-  wget http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz
-  tar zxf idea${IJ_BUILD}.tar.gz
-  rm -rf idea${IJ_BUILD}.tar.gz
-  UNPACKED_IDEA=$(find . -name 'idea-I*' | head -n 1)
+  {
+  echo "Loading $IJ_BUILD..." &&
+  #wget http://download.jetbrains.com/idea/idea${IJ_BUILD}.tar.gz &&
+  tar_md5=$(md5sum idea${IJ_BUILD}.tar.gz  | awk -F " " '{print $1}') &&
+  if [ $tar_md5 != $EXPECTED_IJ_MD5 ];
+  then
+    echo "IJ tar md5 incorrect" >&2
+    exit 1
+  fi &&
+  rm -rf idea${IJ_BUILD}.tar.gz &&
+  tar zxf idea${IJ_BUILD}.tar.gz &&
+  rm -rf idea${IJ_BUILD}.tar.gz &&
+  UNPACKED_IDEA=$(find . -name 'idea-I*' | head -n 1) &&
   mv "$UNPACKED_IDEA" ".cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist"
+  } || {
+    echo "Failed to download/untar IntelliJ" >&2
+    rm -rf .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist
+    exit 1
+  }
 fi
 
 if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins ]; then

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 source scripts/prepare-ci-environment.sh
-rm -rf .cache
 mkdir -p .cache/intellij/$FULL_IJ_BUILD_NUMBER
 
 if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -15,7 +15,8 @@ if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
   fi
   {
     tar zxf $IJ_TAR_NAME &&
-    mv "$IJ_TAR_NAME" ".cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist" &&
+    UNPACKED_IDEA=$(find . -name 'idea-I*' | head -n 1) &&
+    mv "$UNPACKED_IDEA" ".cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist" &&
     rm -rf $IJ_TAR_NAME
   } || {
     echo "Failed to untar IntelliJ" >&2
@@ -41,7 +42,7 @@ if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins ]; then
   wget -O python.zip "https://plugins.jetbrains.com/pluginManager/?action=download&id=$PYTHON_PLUGIN_ID&build=$FULL_IJ_BUILD_NUMBER"
   if [ $(md5sum python.zip  | awk -F " " '{print $1}') != $PYTHON_PLUGIN_MD5 ];
   then
-    echo "Scala plugin md5 incorrect" >&2
+    echo "Python plugin md5 incorrect" >&2
     exit 1
   fi
   unzip python.zip

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 source scripts/prepare-ci-environment.sh
-
+rm -rf .cache
 mkdir -p .cache/intellij/$FULL_IJ_BUILD_NUMBER
 
 if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -7,7 +7,7 @@ if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
   IJ_TAR_NAME=idea${IJ_BUILD}.tar.gz
   echo "Loading $IJ_BUILD..."
   wget -O $IJ_TAR_NAME "http://download.jetbrains.com/idea/$IJ_TAR_NAME"
-  if [ $(md5sum $IJ_TAR_NAME  | awk -F " " '{print $1}') != $EXPECTED_IJ_MD5 ];
+  if [ $(get_md5 $IJ_TAR_NAME) != $EXPECTED_IJ_MD5 ];
   then
     echo "IJ tar md5 incorrect" >&2
     exit 1
@@ -16,7 +16,7 @@ if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist ]; then
     tar zxf $IJ_TAR_NAME &&
     UNPACKED_IDEA=$(find . -name 'idea-I*' | head -n 1) &&
     mv "$UNPACKED_IDEA" ".cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist" &&
-    rm -rf $IJ_TAR_NAME
+    rm -f $IJ_TAR_NAME
   } || {
     echo "Failed to untar IntelliJ" >&2
     rm -rf .cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist
@@ -30,22 +30,22 @@ if [ ! -d .cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins ]; then
   pushd plugins
 
   wget -O Scala.zip "https://plugins.jetbrains.com/pluginManager/?action=download&id=$SCALA_PLUGIN_ID&build=$FULL_IJ_BUILD_NUMBER"
-  if [ $(md5sum Scala.zip  | awk -F " " '{print $1}') != $SCALA_PLUGIN_MD5 ];
+  if [ $(get_md5 Scala.zip) != $SCALA_PLUGIN_MD5 ];
   then
     echo "Scala plugin md5 incorrect" >&2
     exit 1
   fi
   unzip Scala.zip
-  rm -rf Scala.zip
+  rm -f Scala.zip
 
   wget -O python.zip "https://plugins.jetbrains.com/pluginManager/?action=download&id=$PYTHON_PLUGIN_ID&build=$FULL_IJ_BUILD_NUMBER"
-  if [ $(md5sum python.zip  | awk -F " " '{print $1}') != $PYTHON_PLUGIN_MD5 ];
+  if [ $(get_md5 python.zip) != $PYTHON_PLUGIN_MD5 ];
   then
     echo "Python plugin md5 incorrect" >&2
     exit 1
   fi
   unzip python.zip
-  rm -rf python.zip
+  rm -f python.zip
 
   popd
   mv plugins ".cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins"


### PR DESCRIPTION
Earlier unchecked packages can cause runtime failure with obscure error messages. This change addresses the setup part, so the errors seen later will not be related to setup. 

This change moves all the env var setup to scripts/prepare-ci-environment.sh, and adds md5 checks into scripts/setup-ci-environment.sh. md5sum is used because it is the same command on linux and osx, whereas sha256 is different.

Cache is also disabled as it only provides 10-20 secs speed up(whole ci runs ~15 min), but adds another layer of compilication.