### PR TITLE
UX enhancement: auto zoom in at the target/directory imported

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -66,11 +66,9 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     task2executor.put(id, executor);
     final DataNode<ProjectData> projectDataNode = resolveProjectInfoImpl(id, executor, listener, isPreviewMode);
     task2executor.remove(id);
-    // Non-blocking function
-
     Project ideProject = id.findProject();
     if (ideProject != null && !ApplicationManager.getApplication().isUnitTestMode()) {
-      switchToProjectFilesTreeView(ideProject, projectPath);
+      queueSwitchToProjectFilesTreeView(ideProject, projectPath);
     }
     return projectDataNode;
   }
@@ -161,23 +159,23 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     return executor != null && executor.cancelAllProcesses();
   }
 
-  private void switchToProjectFilesTreeView(final Project project, final String projectPath) {
+  private void queueSwitchToProjectFilesTreeView(final Project project, final String projectPath) {
     ApplicationManager.getApplication().invokeLater(new Runnable() {
       @Override
       public void run() {
         if (ProjectView.getInstance(project).getPaneIds().contains(ProjectFilesViewPane.ID)) {
           ProjectView.getInstance(project).changeView(ProjectFilesViewPane.ID);
-          focusOnImportedDirectory(project, projectPath);
+          queueSelectImportedDirectory(project, projectPath);
         }
         else {
-          // Reschedule checking if ProjectFilesTreeView is ready
-          switchToProjectFilesTreeView(project, projectPath);
+          // Reschedule checking whether ProjectFilesTreeView is ready
+          queueSwitchToProjectFilesTreeView(project, projectPath);
         }
       }
     });
   }
 
-  private void focusOnImportedDirectory(final Project project, final String projectPath) {
+  private void queueSelectImportedDirectory(final Project project, final String projectPath) {
     ApplicationManager.getApplication().invokeLater(new Runnable() {
       @Override
       public void run() {
@@ -192,8 +190,8 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
           }
         }
         else {
-          // Reschedule checking if modules are loaded
-          focusOnImportedDirectory(project, projectPath);
+          // Reschedule checking whether modules are loaded
+          queueSelectImportedDirectory(project, projectPath);
         }
       }
     });

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -67,8 +67,10 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     final DataNode<ProjectData> projectDataNode = resolveProjectInfoImpl(id, executor, listener, isPreviewMode);
     task2executor.remove(id);
     // Non-blocking function
-    if (id.findProject() != null && !ApplicationManager.getApplication().isUnitTestMode()) {
-      switchToProjectFilesTreeView(id.findProject(), projectPath);
+
+    Project ideProject = id.findProject();
+    if (ideProject != null && !ApplicationManager.getApplication().isUnitTestMode()) {
+      switchToProjectFilesTreeView(ideProject, projectPath);
     }
     return projectDataNode;
   }
@@ -166,10 +168,9 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
         if (ProjectView.getInstance(project).getPaneIds().contains(ProjectFilesViewPane.ID)) {
           ProjectView.getInstance(project).changeView(ProjectFilesViewPane.ID);
           focusOnImportedDirectory(project, projectPath);
-          return;
         }
         else {
-          // Launch another UI thread to check ProjectFilesTreeView is ready which will be placed at the end of the UI thread queue
+          // Reschedule checking if ProjectFilesTreeView is ready
           switchToProjectFilesTreeView(project, projectPath);
         }
       }
@@ -189,9 +190,9 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
               break;
             }
           }
-          return;
         }
         else {
+          // Reschedule checking if modules are loaded
           focusOnImportedDirectory(project, projectPath);
         }
       }

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -67,7 +67,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     final DataNode<ProjectData> projectDataNode = resolveProjectInfoImpl(id, executor, listener, isPreviewMode);
     task2executor.remove(id);
     // Non-blocking function
-    if (id.findProject() != null){
+    if (id.findProject() != null) {
       switchToProjectFilesTreeView(id.findProject(), projectPath);
     }
     return projectDataNode;
@@ -87,7 +87,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
       executor.getWorkingDir().getPath() + "/.idea/pants-projects/" + executor.getProjectRelativePath(),
       executor.getProjectPath()
     );
-    final DataNode<ProjectData> projectDataNode = new DataNode<ProjectData> (ProjectKeys.PROJECT, projectData, null);
+    final DataNode<ProjectData> projectDataNode = new DataNode<ProjectData>(ProjectKeys.PROJECT, projectData, null);
 
     if (!isPreviewMode) {
       resolveUsingPantsGoal(id, executor, listener, projectDataNode);
@@ -191,6 +191,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
           for (SelectInTarget selectInTarget : ProjectView.getInstance(project).getSelectInTargets()) {
             if (selectInTarget instanceof PantsProjectPaneSelectInTarget) {
               selectInTarget.selectIn(selectInContext, false);
+              break;
             }
           }
           return;
@@ -201,8 +202,8 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
           }
           catch (InterruptedException e) {
           }
+          focusOnImportedDirectory(project, projectPath);
         }
-        focusOnImportedDirectory(project, projectPath);
       }
     });
   }

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -169,12 +169,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
           return;
         }
         else {
-          // Wait then launch another non-blocking thread to check GUI ready before exiting this UI thread.
-          try {
-            Thread.sleep(1000);
-          }
-          catch (InterruptedException e) {
-          }
+          // Launch another UI thread to check ProjectFilesTreeView is ready which will be placed at the end of the UI thread queue
           switchToProjectFilesTreeView(project, projectPath);
         }
       }
@@ -197,11 +192,6 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
           return;
         }
         else {
-          try {
-            Thread.sleep(1000);
-          }
-          catch (InterruptedException e) {
-          }
           focusOnImportedDirectory(project, projectPath);
         }
       }

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -37,7 +37,6 @@ import com.twitter.intellij.pants.projectview.ProjectFilesViewPane;
 import com.twitter.intellij.pants.service.PantsCompileOptionsExecutor;
 import com.twitter.intellij.pants.settings.PantsExecutionSettings;
 import com.twitter.intellij.pants.util.PantsConstants;
-import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -163,6 +163,9 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     ApplicationManager.getApplication().invokeLater(new Runnable() {
       @Override
       public void run() {
+        if (ProjectView.getInstance(project) == null){
+          return;
+        }
         if (ProjectView.getInstance(project).getPaneIds().contains(ProjectFilesViewPane.ID)) {
           ProjectView.getInstance(project).changeView(ProjectFilesViewPane.ID);
           focusOnImportedDirectory(project, projectPath);

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -67,7 +67,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     final DataNode<ProjectData> projectDataNode = resolveProjectInfoImpl(id, executor, listener, isPreviewMode);
     task2executor.remove(id);
     // Non-blocking function
-    if (id.findProject() != null) {
+    if (id.findProject() != null && !ApplicationManager.getApplication().isUnitTestMode()) {
       switchToProjectFilesTreeView(id.findProject(), projectPath);
     }
     return projectDataNode;
@@ -163,9 +163,6 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     ApplicationManager.getApplication().invokeLater(new Runnable() {
       @Override
       public void run() {
-        if (ProjectView.getInstance(project) == null){
-          return;
-        }
         if (ProjectView.getInstance(project).getPaneIds().contains(ProjectFilesViewPane.ID)) {
           ProjectView.getInstance(project).changeView(ProjectFilesViewPane.ID);
           focusOnImportedDirectory(project, projectPath);


### PR DESCRIPTION
Currently when a target is imported, for example testprojects/tests/java/org/pantsbuild/testproject as below, there is no indication where the project files are unless user remembers the filename to search for. 
![screen shot 2016-01-21 at 12 09 54 pm](https://cloud.githubusercontent.com/assets/596358/12493000/ecd9e916-c037-11e5-85b0-b9777df3247d.png)

This change will automatically open a file directly under the folder imported, so user can click 'scroll from source' to locate its position in any view preferred as below.

![screen shot 2016-01-23 at 1 57 01 am](https://cloud.githubusercontent.com/assets/596358/12529662/aa0e6722-c174-11e5-8752-8ca9eb7e6951.png)
