### PR TITLE
Honor JDK selected during import for compilation

### DIFF
--- a/common/com/twitter/intellij/pants/PantsBundle.properties
+++ b/common/com/twitter/intellij/pants/PantsBundle.properties
@@ -18,6 +18,7 @@ pants.settings.text.path.hint=Choose a folder to load all targets recursively
 pants.settings.text.targets=Choose targets\:
 pants.settings.text.with.dependents=Load dependents transitively
 pants.settings.text.with.sources.and.docs=Load sources and docs for libraries
+pants.settings.text.with.jdk.enforcement=Enforce Project JDK selected during import for Pants compilation
 pants.settings.text.update.channel=Use Beta Channel for Pants Plugin Updates
 
 pants.project.generated.with.old.version=Project ''{0}'' was imported with a different version of the plugin. Do you want to refresh it right now?

--- a/common/com/twitter/intellij/pants/PantsBundle.properties
+++ b/common/com/twitter/intellij/pants/PantsBundle.properties
@@ -18,7 +18,7 @@ pants.settings.text.path.hint=Choose a folder to load all targets recursively
 pants.settings.text.targets=Choose targets\:
 pants.settings.text.with.dependents=Load dependents transitively
 pants.settings.text.with.sources.and.docs=Load sources and docs for libraries
-pants.settings.text.with.jdk.enforcement=Enforce Project JDK selected during import for Pants compilation
+pants.settings.text.with.jdk.enforcement=Use IDEA Project JDK for Pants compilation
 pants.settings.text.update.channel=Use Beta Channel for Pants Plugin Updates
 
 pants.project.generated.with.old.version=Project ''{0}'' was imported with a different version of the plugin. Do you want to refresh it right now?

--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -37,6 +37,7 @@ public class PantsConstants {
   public static final String PANTS_TARGET_ADDRESS_INFOS_KEY = "pants.target.address.infos";
 
   public static final String PANTS_EXPORT_CLASSPATH_NAMING_STYLE_OPTION = "export-classpath.use_old_naming_style";
+  public static final String PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION = "--jvm-distributions-paths";
 
   public static Set<String> SUPPORTED_TARGET_TYPES = new THashSet<String>(
     Arrays.asList(

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -608,8 +608,7 @@ public class PantsUtil {
 
   /**
    * @param project JpsProject
-   * @return Path to JDK if exists, else null
-   * because users will know --jvm-distributions-paths flag is passed but there is trouble find the jdk path
+   * @return Path to IDEA Porject JDK if exists, else null
    */
   @Nullable
   public static String getJdkPathFromExternalBuilder(@NotNull JpsProject project) {
@@ -624,8 +623,12 @@ public class PantsUtil {
     return null;
   }
 
+  /**
+   * @return Path to IDEA Porject JDK if exists, else null
+   */
   @Nullable
   public static String getJdkPathFromIntelliJCore() {
+    // Followed example in com.twitter.intellij.pants.testFramework.PantsIntegrationTestCase.setUpInWriteAction()
     final Sdk sdk = JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk();
     String javaHome = null;
     if (sdk.getHomeDirectory() != null) {
@@ -634,6 +637,11 @@ public class PantsUtil {
     return javaHome;
   }
 
+  /**
+   * @param jdkPath path to IDEA Project JDK
+   * @return --jvm-distributions-paths with the parameter if jdkPath is not null,
+   * otherwise the flag with empty parameter so user can tell there is issue finding the IDEA project JDK.
+   */
   @NotNull
   public static String getJvmDistributionPathParameter(@Nullable final String jdkPath) {
     if (jdkPath != null) {

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -608,7 +608,7 @@ public class PantsUtil {
   public static String getJvmDistributionPathParameter(final String jdkPath) {
     HashMap<String, List<String>> distributionFlag = new HashMap<String, List<String>>();
     distributionFlag.put(System.getProperty("os.name").toLowerCase(), Arrays.asList(jdkPath));
-    return "--jvm-distributions-paths=" + (new Gson()).toJson(distributionFlag);
+    return PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION + "=" + new Gson().toJson(distributionFlag);
   }
 
   class SimpleExportResult {
@@ -622,7 +622,7 @@ public class PantsUtil {
     try {
       final ProcessOutput processOutput = PantsUtil.getProcessOutput(commandline, null);
       final String stdOut = processOutput.getStdout();
-      SimpleExportResult simpleExportResult = (new Gson()).fromJson(stdOut, SimpleExportResult.class);
+      SimpleExportResult simpleExportResult = new Gson().fromJson(stdOut, SimpleExportResult.class);
       return versionCompare(simpleExportResult.getVersion(), "1.0.5") >= 0;
     }
     catch (ExecutionException e) {

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -591,14 +591,18 @@ public class PantsUtil {
     return getOutput(command.createProcess(), processAdapter);
   }
 
-  public static String getJdkParameter(final ProjectJdkTable jdkTable) {
-    jdkTable.getAllJdks();
-    String javaHome = ((JavaAwareProjectJdkTableImpl)jdkTable).getInternalJdk().getHomeDirectory().getParent().getPath();
+  public static String getJdkParameter() {
+    String javaHome = ((JavaAwareProjectJdkTableImpl)ProjectJdkTable.getInstance()).getInternalJdk().getHomeDirectory().getParent().getPath();
+    return getJdkDistributionFlag(javaHome);
+  }
+
+
+  public static String getJdkDistributionFlag(final String jdkPath) {
     HashMap<String, List<String>> distributionFlag = new HashMap<String, List<String>>();
-    distributionFlag.put(System.getProperty("os.name").toLowerCase(), Arrays.asList(javaHome));
+    distributionFlag.put(System.getProperty("os.name").toLowerCase(), Arrays.asList(jdkPath));
     return "--jvm-distributions-paths=" + (new Gson()).toJson(distributionFlag);
   }
-}
+
 
   public static String getPantsOptions(final String pantsExecutable) {
     final GeneralCommandLine exportCommandline = defaultCommandLine(pantsExecutable);

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -25,8 +25,6 @@ import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
-import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.io.FileUtil;
@@ -58,8 +56,7 @@ public class PantsUtil {
   public static VirtualFile findBUILDFile(@Nullable VirtualFile vFile) {
     if (vFile == null) {
       return null;
-    }
-    else if (vFile.isDirectory()) {
+    } else if (vFile.isDirectory()) {
       return ContainerUtil.find(
         vFile.getChildren(),
         new Condition<VirtualFile>() {
@@ -270,7 +267,7 @@ public class PantsUtil {
   }
 
   public static String removeWhitespace(@NotNull String text) {
-    return text.replaceAll("\\s", "");
+    return text.replaceAll("\\s","");
   }
 
   public static boolean isGeneratableFile(@NotNull String path) {
@@ -284,16 +281,14 @@ public class PantsUtil {
            FileUtilRt.extensionEquals(path, PantsConstants.PROTOBUF_EXT);
   }
 
-  @NotNull
-  @Nls
+  @NotNull @Nls
   public static String getCanonicalModuleName(@NotNull @NonNls String targetName) {
     // Do not use ':' because it is used as a separator in a classpath
     // while running the app. As well as path separators
     return replaceDelimitersInTargetName(targetName, '_');
   }
 
-  @NotNull
-  @Nls
+  @NotNull @Nls
   public static String getCanonicalTargetId(@NotNull @NonNls String targetName) {
     return replaceDelimitersInTargetName(targetName, '.');
   }
@@ -349,7 +344,7 @@ public class PantsUtil {
   }
 
   public static boolean isResource(PantsSourceType sourceType) {
-    return sourceType == PantsSourceType.RESOURCE || sourceType == PantsSourceType.TEST_RESOURCE;
+    return sourceType == PantsSourceType.RESOURCE  || sourceType == PantsSourceType.TEST_RESOURCE;
   }
 
   @Nullable
@@ -375,8 +370,7 @@ public class PantsUtil {
   public static VirtualFile findBUILDFileForModule(@NotNull Module module) {
     final String linkedPantsBUILD = getPathFromAddress(module, ExternalSystemConstants.LINKED_PROJECT_PATH_KEY);
     final String linkedPantsBUILDUrl = linkedPantsBUILD != null ? VfsUtil.pathToUrl(linkedPantsBUILD) : null;
-    final VirtualFile virtualFile =
-      linkedPantsBUILDUrl != null ? VirtualFileManager.getInstance().findFileByUrl(linkedPantsBUILDUrl) : null;
+    final VirtualFile virtualFile = linkedPantsBUILDUrl != null ? VirtualFileManager.getInstance().findFileByUrl(linkedPantsBUILDUrl) : null;
     if (virtualFile == null) {
       return null;
     }
@@ -561,10 +555,10 @@ public class PantsUtil {
     return Boolean.valueOf(System.getProperty("pants.compiler.isolated.strategy"));
   }
 
-  @Contract(pure = true)
+  @Contract(pure=true)
   public static <T> boolean forall(@NotNull Iterable<T> iterable, @NotNull Condition<T> condition) {
     for (T value : iterable) {
-      if (!condition.value(value)) {
+      if(!condition.value(value)) {
         return false;
       }
     }
@@ -572,7 +566,7 @@ public class PantsUtil {
   }
 
   @NotNull
-  public static <T> List<T> findChildren(@NotNull DataNode<?> dataNode, @NotNull Key<T> key) {
+  public static  <T> List<T> findChildren(@NotNull DataNode<?> dataNode, @NotNull Key<T> key) {
     return ContainerUtil.mapNotNull(
       ExternalSystemApiUtil.findAll(dataNode, key),
       new Function<DataNode<T>, T>() {
@@ -591,19 +585,6 @@ public class PantsUtil {
     return getOutput(command.createProcess(), processAdapter);
   }
 
-  public static String getJdkParameter() {
-    String javaHome = ((JavaAwareProjectJdkTableImpl)ProjectJdkTable.getInstance()).getInternalJdk().getHomeDirectory().getParent().getPath();
-    return getJdkDistributionFlag(javaHome);
-  }
-
-
-  public static String getJdkDistributionFlag(final String jdkPath) {
-    HashMap<String, List<String>> distributionFlag = new HashMap<String, List<String>>();
-    distributionFlag.put(System.getProperty("os.name").toLowerCase(), Arrays.asList(jdkPath));
-    return "--jvm-distributions-paths=" + (new Gson()).toJson(distributionFlag);
-  }
-
-
   public static String getPantsOptions(final String pantsExecutable) {
     final GeneralCommandLine exportCommandline = defaultCommandLine(pantsExecutable);
     exportCommandline.addParameters("options", "--no-colors");
@@ -617,6 +598,16 @@ public class PantsUtil {
     }
   }
 
+  public static String getJvmDistributionPathParameter() {
+    String javaHome = ((JavaAwareProjectJdkTableImpl)ProjectJdkTable.getInstance()).getInternalJdk().getHomeDirectory().getParent().getPath();
+    return getJvmDistributionPathParameter(javaHome);
+  }
+
+  public static String getJvmDistributionPathParameter(final String jdkPath) {
+    HashMap<String, List<String>> distributionFlag = new HashMap<String, List<String>>();
+    distributionFlag.put(System.getProperty("os.name").toLowerCase(), Arrays.asList(jdkPath));
+    return "--jvm-distributions-paths=" + (new Gson()).toJson(distributionFlag);
+  }
 
   class SimpleExportResult {
     public String version;

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -25,7 +25,7 @@ import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Condition;
@@ -43,6 +43,11 @@ import com.twitter.intellij.pants.PantsException;
 import com.twitter.intellij.pants.model.PantsSourceType;
 import com.twitter.intellij.pants.model.PantsTargetAddress;
 import org.jetbrains.annotations.*;
+import org.jetbrains.jps.model.JpsProject;
+import org.jetbrains.jps.model.java.JpsJavaSdkType;
+import org.jetbrains.jps.model.library.JpsLibrary;
+import org.jetbrains.jps.model.library.impl.sdk.JpsSdkImpl;
+import org.jetbrains.jps.model.library.sdk.JpsSdkReference;
 
 import java.io.File;
 import java.io.IOException;
@@ -600,15 +605,45 @@ public class PantsUtil {
     }
   }
 
-  public static String getJvmDistributionPathParameter() {
-    String javaHome = ((JavaAwareProjectJdkTableImpl)ProjectJdkTable.getInstance()).getInternalJdk().getHomeDirectory().getParent().getPath();
-    return getJvmDistributionPathParameter(javaHome);
+
+  /**
+   * @param project JpsProject
+   * @return Path to JDK if exists, else null
+   * because users will know --jvm-distributions-paths flag is passed but there is trouble find the jdk path
+   */
+  @Nullable
+  public static String getJdkPathFromExternalBuilder(@NotNull JpsProject project) {
+    JpsSdkReference sdkReference = project.getSdkReferencesTable().getSdkReference(JpsJavaSdkType.INSTANCE);
+    if (sdkReference != null) {
+      String sdkName = sdkReference.getSdkName();
+      JpsLibrary lib = project.getModel().getGlobal().getLibraryCollection().findLibrary(sdkName);
+      if (lib != null && lib.getProperties() instanceof JpsSdkImpl) {
+        return ((JpsSdkImpl)lib.getProperties()).getHomePath();
+      }
+    }
+    return null;
   }
 
-  public static String getJvmDistributionPathParameter(final String jdkPath) {
-    HashMap<String, List<String>> distributionFlag = new HashMap<String, List<String>>();
-    distributionFlag.put(System.getProperty("os.name").toLowerCase(), Arrays.asList(jdkPath));
-    return PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION + "=" + new Gson().toJson(distributionFlag);
+  @Nullable
+  public static String getJdkPathFromIntelliJCore() {
+    final Sdk sdk = JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk();
+    String javaHome = null;
+    if (sdk.getHomeDirectory() != null) {
+      javaHome = sdk.getHomeDirectory().getParent().getPath();
+    }
+    return javaHome;
+  }
+
+  @NotNull
+  public static String getJvmDistributionPathParameter(@Nullable final String jdkPath) {
+    if (jdkPath != null) {
+      HashMap<String, List<String>> distributionFlag = new HashMap<String, List<String>>();
+      distributionFlag.put(System.getProperty("os.name").toLowerCase(), Arrays.asList(jdkPath));
+      return PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION + "=" + new Gson().toJson(distributionFlag);
+    }
+    else {
+      return PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION + "={}";
+    }
   }
 
   class SimpleExportResult {

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -608,7 +608,7 @@ public class PantsUtil {
 
   /**
    * @param project JpsProject
-   * @return Path to IDEA Porject JDK if exists, else null
+   * @return Path to IDEA Project JDK if exists, else null
    */
   @Nullable
   public static String getJdkPathFromExternalBuilder(@NotNull JpsProject project) {
@@ -624,7 +624,7 @@ public class PantsUtil {
   }
 
   /**
-   * @return Path to IDEA Porject JDK if exists, else null
+   * @return Path to IDEA Project JDK if exists, else null
    */
   @Nullable
   public static String getJdkPathFromIntelliJCore() {
@@ -643,14 +643,14 @@ public class PantsUtil {
    * otherwise the flag with empty parameter so user can tell there is issue finding the IDEA project JDK.
    */
   @NotNull
-  public static String getJvmDistributionPathParameter(@Nullable final String jdkPath) {
+  public static String getJvmDistributionPathParameter(@Nullable final String jdkPath) throws Exception {
     if (jdkPath != null) {
       HashMap<String, List<String>> distributionFlag = new HashMap<String, List<String>>();
       distributionFlag.put(System.getProperty("os.name").toLowerCase(), Arrays.asList(jdkPath));
       return PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION + "=" + new Gson().toJson(distributionFlag);
     }
     else {
-      return PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION + "={}";
+      throw new Exception("No IDEA Project JDK Found");
     }
   }
 

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -25,6 +25,8 @@ import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.io.FileUtil;
@@ -56,7 +58,8 @@ public class PantsUtil {
   public static VirtualFile findBUILDFile(@Nullable VirtualFile vFile) {
     if (vFile == null) {
       return null;
-    } else if (vFile.isDirectory()) {
+    }
+    else if (vFile.isDirectory()) {
       return ContainerUtil.find(
         vFile.getChildren(),
         new Condition<VirtualFile>() {
@@ -267,7 +270,7 @@ public class PantsUtil {
   }
 
   public static String removeWhitespace(@NotNull String text) {
-    return text.replaceAll("\\s","");
+    return text.replaceAll("\\s", "");
   }
 
   public static boolean isGeneratableFile(@NotNull String path) {
@@ -281,14 +284,16 @@ public class PantsUtil {
            FileUtilRt.extensionEquals(path, PantsConstants.PROTOBUF_EXT);
   }
 
-  @NotNull @Nls
+  @NotNull
+  @Nls
   public static String getCanonicalModuleName(@NotNull @NonNls String targetName) {
     // Do not use ':' because it is used as a separator in a classpath
     // while running the app. As well as path separators
     return replaceDelimitersInTargetName(targetName, '_');
   }
 
-  @NotNull @Nls
+  @NotNull
+  @Nls
   public static String getCanonicalTargetId(@NotNull @NonNls String targetName) {
     return replaceDelimitersInTargetName(targetName, '.');
   }
@@ -344,7 +349,7 @@ public class PantsUtil {
   }
 
   public static boolean isResource(PantsSourceType sourceType) {
-    return sourceType == PantsSourceType.RESOURCE  || sourceType == PantsSourceType.TEST_RESOURCE;
+    return sourceType == PantsSourceType.RESOURCE || sourceType == PantsSourceType.TEST_RESOURCE;
   }
 
   @Nullable
@@ -370,7 +375,8 @@ public class PantsUtil {
   public static VirtualFile findBUILDFileForModule(@NotNull Module module) {
     final String linkedPantsBUILD = getPathFromAddress(module, ExternalSystemConstants.LINKED_PROJECT_PATH_KEY);
     final String linkedPantsBUILDUrl = linkedPantsBUILD != null ? VfsUtil.pathToUrl(linkedPantsBUILD) : null;
-    final VirtualFile virtualFile = linkedPantsBUILDUrl != null ? VirtualFileManager.getInstance().findFileByUrl(linkedPantsBUILDUrl) : null;
+    final VirtualFile virtualFile =
+      linkedPantsBUILDUrl != null ? VirtualFileManager.getInstance().findFileByUrl(linkedPantsBUILDUrl) : null;
     if (virtualFile == null) {
       return null;
     }
@@ -555,10 +561,10 @@ public class PantsUtil {
     return Boolean.valueOf(System.getProperty("pants.compiler.isolated.strategy"));
   }
 
-  @Contract(pure=true)
+  @Contract(pure = true)
   public static <T> boolean forall(@NotNull Iterable<T> iterable, @NotNull Condition<T> condition) {
     for (T value : iterable) {
-      if(!condition.value(value)) {
+      if (!condition.value(value)) {
         return false;
       }
     }
@@ -566,7 +572,7 @@ public class PantsUtil {
   }
 
   @NotNull
-  public static  <T> List<T> findChildren(@NotNull DataNode<?> dataNode, @NotNull Key<T> key) {
+  public static <T> List<T> findChildren(@NotNull DataNode<?> dataNode, @NotNull Key<T> key) {
     return ContainerUtil.mapNotNull(
       ExternalSystemApiUtil.findAll(dataNode, key),
       new Function<DataNode<T>, T>() {
@@ -584,6 +590,15 @@ public class PantsUtil {
   ) throws ExecutionException {
     return getOutput(command.createProcess(), processAdapter);
   }
+
+  public static String getJdkParameter(final ProjectJdkTable jdkTable) {
+    jdkTable.getAllJdks();
+    String javaHome = ((JavaAwareProjectJdkTableImpl)jdkTable).getInternalJdk().getHomeDirectory().getParent().getPath();
+    HashMap<String, List<String>> distributionFlag = new HashMap<String, List<String>>();
+    distributionFlag.put(System.getProperty("os.name").toLowerCase(), Arrays.asList(javaHome));
+    return "--jvm-distributions-paths=" + (new Gson()).toJson(distributionFlag);
+  }
+}
 
   public static String getPantsOptions(final String pantsExecutable) {
     final GeneralCommandLine exportCommandline = defaultCommandLine(pantsExecutable);

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -25,6 +25,8 @@ import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.io.FileUtil;

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -7,6 +7,7 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.*;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Ref;
@@ -149,6 +150,8 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
         commandLine.addParameter(targetAddress);
       }
     }
+
+    commandLine.addParameter(PantsUtil.getJdkParameter(ProjectJdkTable.getInstance()));
 
     // Find out whether "export-classpath-use-old-naming-style" exists
     final boolean hasExportClassPathNamingStyle =

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -162,8 +162,8 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
 
     final JpsProject jpsProject = context.getProjectDescriptor().getProject();
     final JpsPantsProjectExtension pantsProjectExtension = PantsJpsProjectExtensionSerializer.findPantsProjectExtension(jpsProject);
-    if (pantsProjectExtension.getJdkPath() != null) {
-      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(pantsProjectExtension.getJdkPath()));
+    if (pantsProjectExtension.getOptionalJdkPath() != null) {
+      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(pantsProjectExtension.getOptionalJdkPath()));
     }
     commandLine.addParameters("--no-colors");
 

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -7,7 +7,6 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.*;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Ref;
@@ -19,7 +18,6 @@ import com.twitter.intellij.pants.jps.incremental.model.PantsBuildTargetType;
 import com.twitter.intellij.pants.jps.incremental.model.PantsSourceRootDescriptor;
 import com.twitter.intellij.pants.jps.incremental.serialization.PantsJpsProjectExtensionSerializer;
 import com.twitter.intellij.pants.jps.util.PantsJpsUtil;
-import com.twitter.intellij.pants.service.project.model.TargetAddressInfo;
 import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsOutputMessage;
 import com.twitter.intellij.pants.util.PantsUtil;
@@ -151,8 +149,6 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
       }
     }
 
-    commandLine.addParameter(PantsUtil.getJdkParameter(ProjectJdkTable.getInstance()));
-
     // Find out whether "export-classpath-use-old-naming-style" exists
     final boolean hasExportClassPathNamingStyle =
       PantsUtil.getPantsOptions(pantsExecutable).contains(PantsConstants.PANTS_EXPORT_CLASSPATH_NAMING_STYLE_OPTION);
@@ -163,6 +159,10 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
     if (hasExportClassPathNamingStyle && hasTargetIdInExport) {
       commandLine.addParameters("--no-export-classpath-use-old-naming-style");
     }
+
+    final JpsProject jpsProject = context.getProjectDescriptor().getProject();
+    final JpsPantsProjectExtension pantsProjectExtension = PantsJpsProjectExtensionSerializer.findPantsProjectExtension(jpsProject);
+    commandLine.addParameter(PantsUtil.getJdkDistributionFlag(pantsProjectExtension.getJdkPath()));
     commandLine.addParameters("--no-colors");
 
     final Process process;

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -160,10 +160,11 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
       commandLine.addParameters("--no-export-classpath-use-old-naming-style");
     }
 
+    final JpsProject jpsProject = context.getProjectDescriptor().getProject();
     final JpsPantsProjectExtension pantsProjectExtension =
-      PantsJpsProjectExtensionSerializer.findPantsProjectExtension(context.getProjectDescriptor().getProject());
-    if (pantsProjectExtension.getOptionalJdkPath() != null) {
-      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(pantsProjectExtension.getOptionalJdkPath()));
+      PantsJpsProjectExtensionSerializer.findPantsProjectExtension(jpsProject);
+    if (pantsProjectExtension.isUseIdeaProjectJdk()) {
+      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(PantsUtil.getJdkPathFromExternalBuilder(jpsProject)));
     }
     commandLine.addParameter("--no-colors");
 

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -162,7 +162,9 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
 
     final JpsProject jpsProject = context.getProjectDescriptor().getProject();
     final JpsPantsProjectExtension pantsProjectExtension = PantsJpsProjectExtensionSerializer.findPantsProjectExtension(jpsProject);
-    commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(pantsProjectExtension.getJdkPath()));
+    if (pantsProjectExtension.getJdkPath() != null){
+      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(pantsProjectExtension.getJdkPath()));
+    }
     commandLine.addParameters("--no-colors");
 
     final Process process;

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -162,7 +162,7 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
 
     final JpsProject jpsProject = context.getProjectDescriptor().getProject();
     final JpsPantsProjectExtension pantsProjectExtension = PantsJpsProjectExtensionSerializer.findPantsProjectExtension(jpsProject);
-    if (pantsProjectExtension.getJdkPath() != null){
+    if (pantsProjectExtension.getJdkPath() != null) {
       commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(pantsProjectExtension.getJdkPath()));
     }
     commandLine.addParameters("--no-colors");
@@ -170,6 +170,7 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
     final Process process;
     try {
       process = commandLine.createProcess();
+      context.processMessage(new CompilerMessage("pants invocation", BuildMessage.Kind.INFO, commandLine.getCommandLineString()));
     }
     catch (ExecutionException e) {
       throw new ProjectBuildException(e);

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -160,12 +160,12 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
       commandLine.addParameters("--no-export-classpath-use-old-naming-style");
     }
 
-    final JpsProject jpsProject = context.getProjectDescriptor().getProject();
-    final JpsPantsProjectExtension pantsProjectExtension = PantsJpsProjectExtensionSerializer.findPantsProjectExtension(jpsProject);
+    final JpsPantsProjectExtension pantsProjectExtension =
+      PantsJpsProjectExtensionSerializer.findPantsProjectExtension(context.getProjectDescriptor().getProject());
     if (pantsProjectExtension.getOptionalJdkPath() != null) {
       commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(pantsProjectExtension.getOptionalJdkPath()));
     }
-    commandLine.addParameters("--no-colors");
+    commandLine.addParameter("--no-colors");
 
     final Process process;
     try {

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -162,7 +162,7 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
 
     final JpsProject jpsProject = context.getProjectDescriptor().getProject();
     final JpsPantsProjectExtension pantsProjectExtension = PantsJpsProjectExtensionSerializer.findPantsProjectExtension(jpsProject);
-    commandLine.addParameter(PantsUtil.getJdkDistributionFlag(pantsProjectExtension.getJdkPath()));
+    commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(pantsProjectExtension.getJdkPath()));
     commandLine.addParameters("--no-colors");
 
     final Process process;

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -164,7 +164,12 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
     final JpsPantsProjectExtension pantsProjectExtension =
       PantsJpsProjectExtensionSerializer.findPantsProjectExtension(jpsProject);
     if (pantsProjectExtension.isUseIdeaProjectJdk()) {
-      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(PantsUtil.getJdkPathFromExternalBuilder(jpsProject)));
+      try{
+        commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(PantsUtil.getJdkPathFromExternalBuilder(jpsProject)));
+      }
+      catch(Exception e){
+        throw new ProjectBuildException(e);
+      }
     }
     commandLine.addParameter("--no-colors");
 

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/JpsPantsProjectExtension.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/JpsPantsProjectExtension.java
@@ -5,6 +5,7 @@ package com.twitter.intellij.pants.jps.incremental.model;
 
 import com.twitter.intellij.pants.util.PantsConstants;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.model.JpsElement;
 import org.jetbrains.jps.model.JpsElementChildRole;
 import org.jetbrains.jps.model.ex.JpsElementChildRoleBase;
@@ -21,6 +22,6 @@ public interface JpsPantsProjectExtension extends JpsElement {
 
   void setCompileWithIntellij(boolean compileWithIntellij);
 
-  @NotNull
+  @Nullable
   String getJdkPath();
 }

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/JpsPantsProjectExtension.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/JpsPantsProjectExtension.java
@@ -20,4 +20,7 @@ public interface JpsPantsProjectExtension extends JpsElement {
   boolean isCompileWithIntellij();
 
   void setCompileWithIntellij(boolean compileWithIntellij);
+
+  @NotNull
+  String getJdkPath();
 }

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/JpsPantsProjectExtension.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/JpsPantsProjectExtension.java
@@ -23,5 +23,5 @@ public interface JpsPantsProjectExtension extends JpsElement {
   void setCompileWithIntellij(boolean compileWithIntellij);
 
   @Nullable
-  String getOptionalJdkPath();
+  boolean isUseIdeaProjectJdk();
 }

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/JpsPantsProjectExtension.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/JpsPantsProjectExtension.java
@@ -23,5 +23,5 @@ public interface JpsPantsProjectExtension extends JpsElement {
   void setCompileWithIntellij(boolean compileWithIntellij);
 
   @Nullable
-  String getJdkPath();
+  String getOptionalJdkPath();
 }

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/impl/JpsPantsProjectExtensionImpl.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/impl/JpsPantsProjectExtensionImpl.java
@@ -10,22 +10,30 @@ import org.jetbrains.jps.model.ex.JpsElementBase;
 public class JpsPantsProjectExtensionImpl extends JpsElementBase<JpsPantsProjectExtensionImpl> implements JpsPantsProjectExtension {
   private String myPantsExecutablePath;
   private boolean myCompileWithIntellij;
+  private String myJdkPath;
 
-  public JpsPantsProjectExtensionImpl(@NotNull String pantsExecutable, boolean compileWithIntellij) {
+  public JpsPantsProjectExtensionImpl(@NotNull String pantsExecutable, boolean compileWithIntellij, @NotNull String jdkPath) {
     myPantsExecutablePath = pantsExecutable;
     myCompileWithIntellij = compileWithIntellij;
+    myJdkPath = jdkPath;
   }
 
   @NotNull
   @Override
   public JpsPantsProjectExtensionImpl createCopy() {
-    return new JpsPantsProjectExtensionImpl(myPantsExecutablePath, myCompileWithIntellij);
+    return new JpsPantsProjectExtensionImpl(myPantsExecutablePath, myCompileWithIntellij, myJdkPath);
   }
 
   @Override
   public void applyChanges(@NotNull JpsPantsProjectExtensionImpl modified) {
     setPantsExecutablePath(modified.getPantsExecutablePath());
     setCompileWithIntellij(modified.isCompileWithIntellij());
+  }
+
+  @NotNull
+  @Override
+  public String getJdkPath() {
+    return myJdkPath;
   }
 
   @NotNull

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/impl/JpsPantsProjectExtensionImpl.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/impl/JpsPantsProjectExtensionImpl.java
@@ -11,18 +11,18 @@ import org.jetbrains.jps.model.ex.JpsElementBase;
 public class JpsPantsProjectExtensionImpl extends JpsElementBase<JpsPantsProjectExtensionImpl> implements JpsPantsProjectExtension {
   private String myPantsExecutablePath;
   private boolean myCompileWithIntellij;
-  private String myJdkPath;
+  private String myOptionalJdkPath;
 
-  public JpsPantsProjectExtensionImpl(@NotNull String pantsExecutable, boolean compileWithIntellij, @Nullable String jdkPath) {
+  public JpsPantsProjectExtensionImpl(@NotNull String pantsExecutable, boolean compileWithIntellij, @Nullable String optionalJdkPath) {
     myPantsExecutablePath = pantsExecutable;
     myCompileWithIntellij = compileWithIntellij;
-    myJdkPath = jdkPath;
+    myOptionalJdkPath = optionalJdkPath;
   }
 
   @NotNull
   @Override
   public JpsPantsProjectExtensionImpl createCopy() {
-    return new JpsPantsProjectExtensionImpl(myPantsExecutablePath, myCompileWithIntellij, myJdkPath);
+    return new JpsPantsProjectExtensionImpl(myPantsExecutablePath, myCompileWithIntellij, myOptionalJdkPath);
   }
 
   @Override
@@ -32,9 +32,8 @@ public class JpsPantsProjectExtensionImpl extends JpsElementBase<JpsPantsProject
   }
 
   @Nullable
-  @Override
-  public String getJdkPath() {
-    return myJdkPath;
+  public String getOptionalJdkPath() {
+    return myOptionalJdkPath;
   }
 
   @NotNull

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/impl/JpsPantsProjectExtensionImpl.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/impl/JpsPantsProjectExtensionImpl.java
@@ -5,6 +5,7 @@ package com.twitter.intellij.pants.jps.incremental.model.impl;
 
 import com.twitter.intellij.pants.jps.incremental.model.JpsPantsProjectExtension;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.model.ex.JpsElementBase;
 
 public class JpsPantsProjectExtensionImpl extends JpsElementBase<JpsPantsProjectExtensionImpl> implements JpsPantsProjectExtension {
@@ -12,7 +13,7 @@ public class JpsPantsProjectExtensionImpl extends JpsElementBase<JpsPantsProject
   private boolean myCompileWithIntellij;
   private String myJdkPath;
 
-  public JpsPantsProjectExtensionImpl(@NotNull String pantsExecutable, boolean compileWithIntellij, @NotNull String jdkPath) {
+  public JpsPantsProjectExtensionImpl(@NotNull String pantsExecutable, boolean compileWithIntellij, @Nullable String jdkPath) {
     myPantsExecutablePath = pantsExecutable;
     myCompileWithIntellij = compileWithIntellij;
     myJdkPath = jdkPath;
@@ -30,7 +31,7 @@ public class JpsPantsProjectExtensionImpl extends JpsElementBase<JpsPantsProject
     setCompileWithIntellij(modified.isCompileWithIntellij());
   }
 
-  @NotNull
+  @Nullable
   @Override
   public String getJdkPath() {
     return myJdkPath;

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/impl/JpsPantsProjectExtensionImpl.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/impl/JpsPantsProjectExtensionImpl.java
@@ -11,18 +11,18 @@ import org.jetbrains.jps.model.ex.JpsElementBase;
 public class JpsPantsProjectExtensionImpl extends JpsElementBase<JpsPantsProjectExtensionImpl> implements JpsPantsProjectExtension {
   private String myPantsExecutablePath;
   private boolean myCompileWithIntellij;
-  private String myOptionalJdkPath;
+  private boolean myUseIdeaProjectJdk;
 
-  public JpsPantsProjectExtensionImpl(@NotNull String pantsExecutable, boolean compileWithIntellij, @Nullable String optionalJdkPath) {
+  public JpsPantsProjectExtensionImpl(@NotNull String pantsExecutable, boolean compileWithIntellij, boolean useIdeaProjectJdk) {
     myPantsExecutablePath = pantsExecutable;
     myCompileWithIntellij = compileWithIntellij;
-    myOptionalJdkPath = optionalJdkPath;
+    myUseIdeaProjectJdk = useIdeaProjectJdk;
   }
 
   @NotNull
   @Override
   public JpsPantsProjectExtensionImpl createCopy() {
-    return new JpsPantsProjectExtensionImpl(myPantsExecutablePath, myCompileWithIntellij, myOptionalJdkPath);
+    return new JpsPantsProjectExtensionImpl(myPantsExecutablePath, myCompileWithIntellij, myUseIdeaProjectJdk);
   }
 
   @Override
@@ -31,9 +31,8 @@ public class JpsPantsProjectExtensionImpl extends JpsElementBase<JpsPantsProject
     setCompileWithIntellij(modified.isCompileWithIntellij());
   }
 
-  @Nullable
-  public String getOptionalJdkPath() {
-    return myOptionalJdkPath;
+  public boolean isUseIdeaProjectJdk() {
+    return myUseIdeaProjectJdk;
   }
 
   @NotNull

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
@@ -50,9 +50,9 @@ public class PantsJpsProjectExtensionSerializer extends JpsProjectExtensionSeria
       Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, COMPILE_WITH_INTELLIJ, "false"));
     final boolean useIdeaProjectJdk = Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, ENFORCE_JDK, "false"));
 
-    String jdkPath = useIdeaProjectJdk ? getJpsProjectJdkPath(project): null;
+    String optionalJdkPath = useIdeaProjectJdk ? getJpsProjectJdkPath(project): null;
     final JpsPantsProjectExtension projectExtension =
-      new JpsPantsProjectExtensionImpl(pantsExecutable.getPath(), compileWithIntellij, jdkPath);
+      new JpsPantsProjectExtensionImpl(pantsExecutable.getPath(), compileWithIntellij, optionalJdkPath);
 
     project.getContainer().setChild(JpsPantsProjectExtension.ROLE, projectExtension);
   }

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
@@ -20,7 +20,7 @@ import java.io.File;
 public class PantsJpsProjectExtensionSerializer extends JpsProjectExtensionSerializer {
 
   private static final String COMPILE_WITH_INTELLIJ = "compileWithIntellij";
-  private static final String ENFORCE_JDK = "enforceJdk";
+  private static final String ENFORCE_JDK = "useIdeaProjectJdk";
   private static final String LINKED_PROJECT_SETTINGS = "linkedExternalProjectsSettings";
   private static final String EXTERNAL_PROJECT_PATH = "externalProjectPath";
   private static final String PROJECT_SETTINGS = "PantsProjectSettings";
@@ -48,11 +48,11 @@ public class PantsJpsProjectExtensionSerializer extends JpsProjectExtensionSeria
     }
     final boolean compileWithIntellij =
       Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, COMPILE_WITH_INTELLIJ, "false"));
-    final boolean enforceJdk = Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, ENFORCE_JDK, "false"));
+    final boolean useIdeaProjectJdk = Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, ENFORCE_JDK, "false"));
     final JpsPantsProjectExtension pantsProjectExtension = PantsJpsProjectExtensionSerializer.findPantsProjectExtension(project);
 
     String sdkName = project.getSdkReferencesTable().getSdkReference(JpsJavaSdkType.INSTANCE).getSdkName();
-    String jdkPath = enforceJdk
+    String jdkPath = useIdeaProjectJdk
                      ? ((JpsSdkImpl)project.getModel().getGlobal().getLibraryCollection().findLibrary(sdkName).getProperties())
                        .getHomePath()
                      : null;

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
@@ -11,8 +11,6 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.model.JpsProject;
-import org.jetbrains.jps.model.java.JpsJavaSdkType;
-import org.jetbrains.jps.model.library.impl.sdk.JpsSdkImpl;
 import org.jetbrains.jps.model.serialization.JpsProjectExtensionSerializer;
 
 import java.io.File;
@@ -50,16 +48,11 @@ public class PantsJpsProjectExtensionSerializer extends JpsProjectExtensionSeria
       Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, COMPILE_WITH_INTELLIJ, "false"));
     final boolean useIdeaProjectJdk = Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, ENFORCE_JDK, "false"));
 
-    String optionalJdkPath = useIdeaProjectJdk ? getJpsProjectJdkPath(project): null;
+    String optionalJdkPath = useIdeaProjectJdk ? PantsUtil.getJdkPathFromExternalBuilder(project) : null;
     final JpsPantsProjectExtension projectExtension =
-      new JpsPantsProjectExtensionImpl(pantsExecutable.getPath(), compileWithIntellij, optionalJdkPath);
+      new JpsPantsProjectExtensionImpl(pantsExecutable.getPath(), compileWithIntellij, useIdeaProjectJdk);
 
     project.getContainer().setChild(JpsPantsProjectExtension.ROLE, projectExtension);
-  }
-
-  private String getJpsProjectJdkPath(@NotNull JpsProject project) {
-    String sdkName = project.getSdkReferencesTable().getSdkReference(JpsJavaSdkType.INSTANCE).getSdkName();
-    return ((JpsSdkImpl)project.getModel().getGlobal().getLibraryCollection().findLibrary(sdkName).getProperties()).getHomePath();
   }
 
   @Override

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
@@ -49,17 +49,17 @@ public class PantsJpsProjectExtensionSerializer extends JpsProjectExtensionSeria
     final boolean compileWithIntellij =
       Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, COMPILE_WITH_INTELLIJ, "false"));
     final boolean useIdeaProjectJdk = Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, ENFORCE_JDK, "false"));
-    final JpsPantsProjectExtension pantsProjectExtension = PantsJpsProjectExtensionSerializer.findPantsProjectExtension(project);
 
-    String sdkName = project.getSdkReferencesTable().getSdkReference(JpsJavaSdkType.INSTANCE).getSdkName();
-    String jdkPath = useIdeaProjectJdk
-                     ? ((JpsSdkImpl)project.getModel().getGlobal().getLibraryCollection().findLibrary(sdkName).getProperties())
-                       .getHomePath()
-                     : null;
+    String jdkPath = useIdeaProjectJdk ? getJpsProjectJdkPath(project): null;
     final JpsPantsProjectExtension projectExtension =
       new JpsPantsProjectExtensionImpl(pantsExecutable.getPath(), compileWithIntellij, jdkPath);
 
     project.getContainer().setChild(JpsPantsProjectExtension.ROLE, projectExtension);
+  }
+
+  private String getJpsProjectJdkPath(@NotNull JpsProject project) {
+    String sdkName = project.getSdkReferencesTable().getSdkReference(JpsJavaSdkType.INSTANCE).getSdkName();
+    return ((JpsSdkImpl)project.getModel().getGlobal().getLibraryCollection().findLibrary(sdkName).getProperties()).getHomePath();
   }
 
   @Override

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
@@ -11,6 +11,8 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.model.JpsProject;
+import org.jetbrains.jps.model.java.JpsJavaSdkType;
+import org.jetbrains.jps.model.library.impl.sdk.JpsSdkImpl;
 import org.jetbrains.jps.model.serialization.JpsProjectExtensionSerializer;
 
 import java.io.File;
@@ -45,9 +47,11 @@ public class PantsJpsProjectExtensionSerializer extends JpsProjectExtensionSeria
     }
     final boolean compileWithIntellij =
       Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, COMPILE_WITH_INTELLIJ, "false"));
+    String sdkName = project.getSdkReferencesTable().getSdkReference(JpsJavaSdkType.INSTANCE).getSdkName();
+    String jdkPath = ((JpsSdkImpl) project.getModel().getGlobal().getLibraryCollection().findLibrary(sdkName).getProperties()).getHomePath();
 
     final JpsPantsProjectExtension projectExtension =
-      new JpsPantsProjectExtensionImpl(pantsExecutable.getPath(), compileWithIntellij);
+      new JpsPantsProjectExtensionImpl(pantsExecutable.getPath(), compileWithIntellij, jdkPath);
 
     project.getContainer().setChild(JpsPantsProjectExtension.ROLE, projectExtension);
   }

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
@@ -19,10 +19,11 @@ import java.io.File;
 
 public class PantsJpsProjectExtensionSerializer extends JpsProjectExtensionSerializer {
 
-  private static final String COMPILE_WITH_INTELLIJ   = "compileWithIntellij";
+  private static final String COMPILE_WITH_INTELLIJ = "compileWithIntellij";
+  private static final String ENFORCE_JDK = "enforceJdk";
   private static final String LINKED_PROJECT_SETTINGS = "linkedExternalProjectsSettings";
-  private static final String EXTERNAL_PROJECT_PATH   = "externalProjectPath";
-  private static final String PROJECT_SETTINGS        = "PantsProjectSettings";
+  private static final String EXTERNAL_PROJECT_PATH = "externalProjectPath";
+  private static final String PROJECT_SETTINGS = "PantsProjectSettings";
 
   @Nullable
   public static JpsPantsProjectExtension findPantsProjectExtension(@NotNull JpsProject project) {
@@ -47,9 +48,14 @@ public class PantsJpsProjectExtensionSerializer extends JpsProjectExtensionSeria
     }
     final boolean compileWithIntellij =
       Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, COMPILE_WITH_INTELLIJ, "false"));
-    String sdkName = project.getSdkReferencesTable().getSdkReference(JpsJavaSdkType.INSTANCE).getSdkName();
-    String jdkPath = ((JpsSdkImpl) project.getModel().getGlobal().getLibraryCollection().findLibrary(sdkName).getProperties()).getHomePath();
+    final boolean enforceJdk = Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, ENFORCE_JDK, "false"));
+    final JpsPantsProjectExtension pantsProjectExtension = PantsJpsProjectExtensionSerializer.findPantsProjectExtension(project);
 
+    String sdkName = project.getSdkReferencesTable().getSdkReference(JpsJavaSdkType.INSTANCE).getSdkName();
+    String jdkPath = enforceJdk
+                     ? ((JpsSdkImpl)project.getModel().getGlobal().getLibraryCollection().findLibrary(sdkName).getProperties())
+                       .getHomePath()
+                     : null;
     final JpsPantsProjectExtension projectExtension =
       new JpsPantsProjectExtensionImpl(pantsExecutable.getPath(), compileWithIntellij, jdkPath);
 

--- a/src/com/twitter/intellij/pants/PantsManager.java
+++ b/src/com/twitter/intellij/pants/PantsManager.java
@@ -124,13 +124,13 @@ public class PantsManager implements
       @NotNull
       public PantsExecutionSettings getExecutionsSettingsFromPath(@NotNull Project ideProject, @NotNull String projectPath) {
         boolean compileWithIntellij = PantsSettings.getInstance(ideProject).isCompileWithIntellij();
-        boolean isEnforceJdk = PantsSettings.getInstance(ideProject).isEnforceJdk();
+        boolean isUseIdeaProjectJdk = PantsSettings.getInstance(ideProject).isUseIdeaProjectJdk();
 
         final PantsTargetAddress absoluteTargetAddress = PantsTargetAddress.fromString(projectPath, true);
 
         if (absoluteTargetAddress != null) {
           return new PantsExecutionSettings(
-            Collections.singletonList(absoluteTargetAddress.getTargetName()), false, compileWithIntellij, true, isEnforceJdk
+            Collections.singletonList(absoluteTargetAddress.getTargetName()), false, compileWithIntellij, true, isUseIdeaProjectJdk
           );
         }
 
@@ -143,7 +143,7 @@ public class PantsManager implements
                                       ((PantsProjectSettings)projectSettings).isWithDependees();
         final boolean libsWithSources = projectSettings instanceof PantsProjectSettings &&
                                         ((PantsProjectSettings)projectSettings).isLibsWithSources();
-        return new PantsExecutionSettings(targets, withDependees, compileWithIntellij, libsWithSources, isEnforceJdk);
+        return new PantsExecutionSettings(targets, withDependees, compileWithIntellij, libsWithSources, isUseIdeaProjectJdk);
       }
     };
   }

--- a/src/com/twitter/intellij/pants/PantsManager.java
+++ b/src/com/twitter/intellij/pants/PantsManager.java
@@ -124,12 +124,13 @@ public class PantsManager implements
       @NotNull
       public PantsExecutionSettings getExecutionsSettingsFromPath(@NotNull Project ideProject, @NotNull String projectPath) {
         boolean compileWithIntellij = PantsSettings.getInstance(ideProject).isCompileWithIntellij();
+        boolean isEnforceJdk = PantsSettings.getInstance(ideProject).isEnforceJdk();
 
         final PantsTargetAddress absoluteTargetAddress = PantsTargetAddress.fromString(projectPath, true);
 
         if (absoluteTargetAddress != null) {
           return new PantsExecutionSettings(
-            Collections.singletonList(absoluteTargetAddress.getTargetName()), false, compileWithIntellij, true
+            Collections.singletonList(absoluteTargetAddress.getTargetName()), false, compileWithIntellij, true, isEnforceJdk
           );
         }
 
@@ -142,8 +143,7 @@ public class PantsManager implements
                                       ((PantsProjectSettings)projectSettings).isWithDependees();
         final boolean libsWithSources = projectSettings instanceof PantsProjectSettings &&
                                         ((PantsProjectSettings)projectSettings).isLibsWithSources();
-
-        return new PantsExecutionSettings(targets, withDependees, compileWithIntellij, libsWithSources);
+        return new PantsExecutionSettings(targets, withDependees, compileWithIntellij, libsWithSources, isEnforceJdk);
       }
     };
   }

--- a/src/com/twitter/intellij/pants/config/PantsProjectCompilerConfigurable.java
+++ b/src/com/twitter/intellij/pants/config/PantsProjectCompilerConfigurable.java
@@ -58,14 +58,17 @@ public class PantsProjectCompilerConfigurable extends BaseConfigurable implement
 
   @Override
   public boolean isModified() {
-    return PantsSettings.getInstance(myProject).isCompileWithIntellij() != myCompilerForm.isCompileWithIntellij();
+    return PantsSettings.getInstance(myProject).isCompileWithIntellij() != myCompilerForm.isCompileWithIntellij()
+      || PantsSettings.getInstance(myProject).isEnforceJdk() != myCompilerForm.isEnforceJdk();
   }
 
   @Override
   public void apply() throws ConfigurationException {
     final PantsSettings pantsSettings = PantsSettings.getInstance(myProject);
     final boolean refreshNeeded = pantsSettings.isCompileWithIntellij() != myCompilerForm.isCompileWithIntellij();
+    //final boolean refreshNeeded = isModified();
     pantsSettings.setCompileWithIntellij(myCompilerForm.isCompileWithIntellij());
+    pantsSettings.setEnforceJdk(myCompilerForm.isEnforceJdk());
     if (refreshNeeded) {
       PantsUtil.refreshAllProjects(myProject);
     }
@@ -74,6 +77,7 @@ public class PantsProjectCompilerConfigurable extends BaseConfigurable implement
   @Override
   public void reset() {
     myCompilerForm.setCompileWithIntellij(PantsSettings.getInstance(myProject).isCompileWithIntellij());
+    myCompilerForm.setEnforceJdk(PantsSettings.getInstance(myProject).isEnforceJdk());
   }
 
   @Override

--- a/src/com/twitter/intellij/pants/config/PantsProjectCompilerConfigurable.java
+++ b/src/com/twitter/intellij/pants/config/PantsProjectCompilerConfigurable.java
@@ -59,16 +59,15 @@ public class PantsProjectCompilerConfigurable extends BaseConfigurable implement
   @Override
   public boolean isModified() {
     return PantsSettings.getInstance(myProject).isCompileWithIntellij() != myCompilerForm.isCompileWithIntellij()
-      || PantsSettings.getInstance(myProject).isEnforceJdk() != myCompilerForm.isEnforceJdk();
+      || PantsSettings.getInstance(myProject).isUseIdeaProjectJdk() != myCompilerForm.isUseIdeaProjectJdk();
   }
 
   @Override
   public void apply() throws ConfigurationException {
     final PantsSettings pantsSettings = PantsSettings.getInstance(myProject);
     final boolean refreshNeeded = pantsSettings.isCompileWithIntellij() != myCompilerForm.isCompileWithIntellij();
-    //final boolean refreshNeeded = isModified();
     pantsSettings.setCompileWithIntellij(myCompilerForm.isCompileWithIntellij());
-    pantsSettings.setEnforceJdk(myCompilerForm.isEnforceJdk());
+    pantsSettings.setUseIdeaProjectJdk(myCompilerForm.isUseIdeaProjectJdk());
     if (refreshNeeded) {
       PantsUtil.refreshAllProjects(myProject);
     }
@@ -77,7 +76,7 @@ public class PantsProjectCompilerConfigurable extends BaseConfigurable implement
   @Override
   public void reset() {
     myCompilerForm.setCompileWithIntellij(PantsSettings.getInstance(myProject).isCompileWithIntellij());
-    myCompilerForm.setEnforceJdk(PantsSettings.getInstance(myProject).isEnforceJdk());
+    myCompilerForm.setUseIdeaProjectJdk(PantsSettings.getInstance(myProject).isUseIdeaProjectJdk());
   }
 
   @Override

--- a/src/com/twitter/intellij/pants/config/PantsProjectCompilerForm.form
+++ b/src/com/twitter/intellij/pants/config/PantsProjectCompilerForm.form
@@ -37,7 +37,7 @@
               <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
-          <component id="18268" class="javax.swing.JCheckBox" binding="myEnforceJdkCheckBox" default-binding="true">
+          <component id="18268" class="javax.swing.JCheckBox" binding="myUseIdeaProjectJdkCheckBox" default-binding="true">
             <constraints>
               <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>

--- a/src/com/twitter/intellij/pants/config/PantsProjectCompilerForm.form
+++ b/src/com/twitter/intellij/pants/config/PantsProjectCompilerForm.form
@@ -3,12 +3,12 @@
   <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="591" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="61df5" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="61df5" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -37,6 +37,15 @@
               <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
+          <component id="18268" class="javax.swing.JCheckBox" binding="myEnforceJdkCheckBox" default-binding="true">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <text resource-bundle="com/twitter/intellij/pants/PantsBundle" key="pants.settings.text.with.jdk.enforcement"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <vspacer id="a37a">

--- a/src/com/twitter/intellij/pants/config/PantsProjectCompilerForm.java
+++ b/src/com/twitter/intellij/pants/config/PantsProjectCompilerForm.java
@@ -15,7 +15,7 @@ public class PantsProjectCompilerForm {
   private JPanel myMainPanel;
   private JComboBox myCompilerComboBox;
   private JTextPane myDescriptionTextPane;
-  private JCheckBox myEnforceJdkCheckBox;
+  private JCheckBox myUseIdeaProjectJdkCheckBox;
 
   private final CompilerValue myPantsCompiler =
     new CompilerValue(PantsBundle.message("pants.compile.pants.compiler"), PantsBundle.message("pants.compile.pants.compiler.description"));
@@ -29,7 +29,7 @@ public class PantsProjectCompilerForm {
         public void actionPerformed(ActionEvent e) {
           Object selectedItem = myCompilerComboBox.getSelectedItem();
           if (selectedItem instanceof CompilerValue) {
-            myEnforceJdkCheckBox.setEnabled(((CompilerValue) selectedItem).getName().equals(myPantsCompiler.getName()));
+            myUseIdeaProjectJdkCheckBox.setEnabled(((CompilerValue) selectedItem).getName().equals(myPantsCompiler.getName()));
           }
           myDescriptionTextPane.setText(
             selectedItem instanceof CompilerValue ? ((CompilerValue)selectedItem).getDescription() : ""
@@ -45,12 +45,12 @@ public class PantsProjectCompilerForm {
     return myMainPanel;
   }
 
-  public boolean isEnforceJdk() {
-    return myEnforceJdkCheckBox.isSelected();
+  public boolean isUseIdeaProjectJdk() {
+    return myUseIdeaProjectJdkCheckBox.isSelected();
   }
 
-  public void setEnforceJdk(boolean enforceJdk){
-      myEnforceJdkCheckBox.setSelected(enforceJdk);
+  public void setUseIdeaProjectJdk(boolean useIdeaProjectJdk){
+      myUseIdeaProjectJdkCheckBox.setSelected(useIdeaProjectJdk);
   }
 
   public JComboBox getCompilerComboBox() {
@@ -64,10 +64,10 @@ public class PantsProjectCompilerForm {
   public void setCompileWithIntellij(boolean compileWithIntellij) {
     if (compileWithIntellij) {
       myCompilerComboBox.setSelectedItem(myIJCompiler);
-      myEnforceJdkCheckBox.setEnabled(false);
+      myUseIdeaProjectJdkCheckBox.setEnabled(false);
     } else {
       myCompilerComboBox.setSelectedItem(myPantsCompiler);
-      myEnforceJdkCheckBox.setEnabled(true);
+      myUseIdeaProjectJdkCheckBox.setEnabled(true);
     }
   }
 

--- a/src/com/twitter/intellij/pants/config/PantsProjectCompilerForm.java
+++ b/src/com/twitter/intellij/pants/config/PantsProjectCompilerForm.java
@@ -15,6 +15,7 @@ public class PantsProjectCompilerForm {
   private JPanel myMainPanel;
   private JComboBox myCompilerComboBox;
   private JTextPane myDescriptionTextPane;
+  private JCheckBox myEnforceJdkCheckBox;
 
   private final CompilerValue myPantsCompiler =
     new CompilerValue(PantsBundle.message("pants.compile.pants.compiler"), PantsBundle.message("pants.compile.pants.compiler.description"));
@@ -27,6 +28,9 @@ public class PantsProjectCompilerForm {
         @Override
         public void actionPerformed(ActionEvent e) {
           Object selectedItem = myCompilerComboBox.getSelectedItem();
+          if (selectedItem instanceof CompilerValue) {
+            myEnforceJdkCheckBox.setEnabled(((CompilerValue) selectedItem).getName().equals(myPantsCompiler.getName()));
+          }
           myDescriptionTextPane.setText(
             selectedItem instanceof CompilerValue ? ((CompilerValue)selectedItem).getDescription() : ""
           );
@@ -41,6 +45,14 @@ public class PantsProjectCompilerForm {
     return myMainPanel;
   }
 
+  public boolean isEnforceJdk() {
+    return myEnforceJdkCheckBox.isSelected();
+  }
+
+  public void setEnforceJdk(boolean enforceJdk){
+      myEnforceJdkCheckBox.setSelected(enforceJdk);
+  }
+
   public JComboBox getCompilerComboBox() {
     return myCompilerComboBox;
   }
@@ -52,8 +64,10 @@ public class PantsProjectCompilerForm {
   public void setCompileWithIntellij(boolean compileWithIntellij) {
     if (compileWithIntellij) {
       myCompilerComboBox.setSelectedItem(myIJCompiler);
+      myEnforceJdkCheckBox.setEnabled(false);
     } else {
       myCompilerComboBox.setSelectedItem(myPantsCompiler);
+      myEnforceJdkCheckBox.setEnabled(true);
     }
   }
 

--- a/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
+++ b/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
@@ -88,7 +88,9 @@ public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExe
       commandLine.addParameter(jvmOptionsFlag + "=" + debuggerSetup);
     }
 
-    commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter());
+    if (settings.isEnforceJdk()) {
+      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter());
+    }
 
     listener.onTaskOutput(id, commandLine.getCommandLineString(PantsConstants.PANTS), true);
     try {

--- a/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
+++ b/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
@@ -3,7 +3,6 @@
 
 package com.twitter.intellij.pants.service.task;
 
-import com.google.gson.Gson;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.ProcessAdapter;
@@ -14,7 +13,6 @@ import com.intellij.openapi.externalSystem.model.ExternalSystemException;
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId;
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener;
 import com.intellij.openapi.externalSystem.task.AbstractExternalSystemTaskManager;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Pair;
 import com.intellij.util.containers.ContainerUtil;
@@ -23,12 +21,12 @@ import com.twitter.intellij.pants.model.PantsTargetAddress;
 import com.twitter.intellij.pants.settings.PantsExecutionSettings;
 import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
-import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExecutionSettings> {
   public static final Map<String, String> goal2JvmOptionsFlag = ContainerUtil.newHashMap(
@@ -90,7 +88,7 @@ public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExe
       commandLine.addParameter(jvmOptionsFlag + "=" + debuggerSetup);
     }
 
-    commandLine.addParameter(PantsUtil.getJdkParameter(ProjectJdkTable.getInstance()));
+    commandLine.addParameter(PantsUtil.getJdkParameter());
 
     listener.onTaskOutput(id, commandLine.getCommandLineString(PantsConstants.PANTS), true);
     try {

--- a/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
+++ b/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
@@ -89,7 +89,12 @@ public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExe
     }
 
     if (settings.isUseIdeaProjectJdk()) {
-      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(PantsUtil.getJdkPathFromIntelliJCore()));
+      try{
+        commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(PantsUtil.getJdkPathFromIntelliJCore()));
+      }
+      catch(Exception e){
+        throw new ExternalSystemException(e);
+      }
     }
 
     listener.onTaskOutput(id, commandLine.getCommandLineString(PantsConstants.PANTS), true);

--- a/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
+++ b/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
@@ -3,6 +3,7 @@
 
 package com.twitter.intellij.pants.service.task;
 
+import com.google.gson.Gson;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.ProcessAdapter;
@@ -13,6 +14,7 @@ import com.intellij.openapi.externalSystem.model.ExternalSystemException;
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId;
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener;
 import com.intellij.openapi.externalSystem.task.AbstractExternalSystemTaskManager;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Pair;
 import com.intellij.util.containers.ContainerUtil;
@@ -21,12 +23,12 @@ import com.twitter.intellij.pants.model.PantsTargetAddress;
 import com.twitter.intellij.pants.settings.PantsExecutionSettings;
 import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
+import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExecutionSettings> {
   public static final Map<String, String> goal2JvmOptionsFlag = ContainerUtil.newHashMap(
@@ -60,7 +62,8 @@ public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExe
       for (String targetName : settings.getTargetNames()) {
         commandLine.addParameter(relativeProjectPath + ":" + targetName);
       }
-    } else {
+    }
+    else {
       commandLine.addParameter(relativeProjectPath + File.separator + "::");
     }
     commandLine.addParameters(scriptParameters);
@@ -86,6 +89,8 @@ public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExe
       }
       commandLine.addParameter(jvmOptionsFlag + "=" + debuggerSetup);
     }
+
+    commandLine.addParameter(PantsUtil.getJdkParameter(ProjectJdkTable.getInstance()));
 
     listener.onTaskOutput(id, commandLine.getCommandLineString(PantsConstants.PANTS), true);
     try {

--- a/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
+++ b/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
@@ -88,7 +88,7 @@ public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExe
       commandLine.addParameter(jvmOptionsFlag + "=" + debuggerSetup);
     }
 
-    commandLine.addParameter(PantsUtil.getJdkParameter());
+    commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter());
 
     listener.onTaskOutput(id, commandLine.getCommandLineString(PantsConstants.PANTS), true);
     try {

--- a/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
+++ b/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
@@ -89,7 +89,7 @@ public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExe
     }
 
     if (settings.isUseIdeaProjectJdk()) {
-      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter());
+      commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(PantsUtil.getJdkPathFromIntelliJCore()));
     }
 
     listener.onTaskOutput(id, commandLine.getCommandLineString(PantsConstants.PANTS), true);

--- a/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
+++ b/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
@@ -88,7 +88,7 @@ public class PantsTaskManager extends AbstractExternalSystemTaskManager<PantsExe
       commandLine.addParameter(jvmOptionsFlag + "=" + debuggerSetup);
     }
 
-    if (settings.isEnforceJdk()) {
+    if (settings.isUseIdeaProjectJdk()) {
       commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter());
     }
 

--- a/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
@@ -16,19 +16,19 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
   private final boolean myLibsWithSourcesAndDocs;
 
 
-  private final boolean myEnforceJdk;
+  private final boolean myUseIdeaProjectJdk;
   private List<String> myTargetNames;
 
   public PantsExecutionSettings() {
     this(Collections.<String>emptyList(), false, false, true,false);
   }
 
-  public PantsExecutionSettings(List<String> targetNames, boolean withDependees, boolean compileWithIntellij, boolean libsWithSourcesAndDocs, boolean enforceJdk) {
+  public PantsExecutionSettings(List<String> targetNames, boolean withDependees, boolean compileWithIntellij, boolean libsWithSourcesAndDocs, boolean useIdeaProjectJdk) {
     myTargetNames = targetNames;
     myWithDependees = withDependees;
     myCompileWithIntellij = compileWithIntellij;
     myLibsWithSourcesAndDocs = libsWithSourcesAndDocs;
-    myEnforceJdk = enforceJdk;
+    myUseIdeaProjectJdk = useIdeaProjectJdk;
   }
 
   @NotNull
@@ -49,8 +49,8 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     return myLibsWithSourcesAndDocs;
   }
 
-  public boolean isEnforceJdk() {
-    return myEnforceJdk;
+  public boolean isUseIdeaProjectJdk() {
+    return myUseIdeaProjectJdk;
   }
 
   @Override
@@ -60,7 +60,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     if (!super.equals(o)) return false;
 
     PantsExecutionSettings settings = (PantsExecutionSettings)o;
-    if (myEnforceJdk != settings.myEnforceJdk) return false;
+    if (myUseIdeaProjectJdk != settings.myUseIdeaProjectJdk) return false;
     if (myWithDependees != settings.myWithDependees) return false;
     if (myCompileWithIntellij != settings.myCompileWithIntellij) return false;
     if (myLibsWithSourcesAndDocs != settings.myLibsWithSourcesAndDocs) return false;
@@ -76,7 +76,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     result = 31 * result + (myTargetNames != null ? myTargetNames.hashCode() : 0);
     result = 31 * result + (myCompileWithIntellij ? 1 : 0);
     result = 31 * result + (myLibsWithSourcesAndDocs ? 1 : 0);
-    result = 31 * result + (myEnforceJdk ? 1 : 0);
+    result = 31 * result + (myUseIdeaProjectJdk ? 1 : 0);
     return result;
   }
 }

--- a/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
@@ -20,7 +20,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
   private List<String> myTargetNames;
 
   public PantsExecutionSettings() {
-    this(Collections.<String>emptyList(), false, false, true,false);
+    this(Collections.<String>emptyList(), false, false, true, false);
   }
 
   public PantsExecutionSettings(List<String> targetNames, boolean withDependees, boolean compileWithIntellij, boolean libsWithSourcesAndDocs, boolean useIdeaProjectJdk) {

--- a/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
@@ -14,17 +14,21 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
   private final boolean myWithDependees;
   private final boolean myCompileWithIntellij;
   private final boolean myLibsWithSourcesAndDocs;
+
+
+  private final boolean myEnforceJdk;
   private List<String> myTargetNames;
 
   public PantsExecutionSettings() {
-    this(Collections.<String>emptyList(), false, false, true);
+    this(Collections.<String>emptyList(), false, false, true,false);
   }
 
-  public PantsExecutionSettings(List<String> targetNames, boolean withDependees, boolean compileWithIntellij, boolean libsWithSourcesAndDocs) {
+  public PantsExecutionSettings(List<String> targetNames, boolean withDependees, boolean compileWithIntellij, boolean libsWithSourcesAndDocs, boolean enforceJdk) {
     myTargetNames = targetNames;
     myWithDependees = withDependees;
     myCompileWithIntellij = compileWithIntellij;
     myLibsWithSourcesAndDocs = libsWithSourcesAndDocs;
+    myEnforceJdk = enforceJdk;
   }
 
   @NotNull
@@ -45,6 +49,10 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     return myLibsWithSourcesAndDocs;
   }
 
+  public boolean isEnforceJdk() {
+    return myEnforceJdk;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -52,7 +60,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     if (!super.equals(o)) return false;
 
     PantsExecutionSettings settings = (PantsExecutionSettings)o;
-
+    if (myEnforceJdk != settings.myEnforceJdk) return false;
     if (myWithDependees != settings.myWithDependees) return false;
     if (myCompileWithIntellij != settings.myCompileWithIntellij) return false;
     if (myLibsWithSourcesAndDocs != settings.myLibsWithSourcesAndDocs) return false;
@@ -68,6 +76,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     result = 31 * result + (myTargetNames != null ? myTargetNames.hashCode() : 0);
     result = 31 * result + (myCompileWithIntellij ? 1 : 0);
     result = 31 * result + (myLibsWithSourcesAndDocs ? 1 : 0);
+    result = 31 * result + (myEnforceJdk ? 1 : 0);
     return result;
   }
 }

--- a/src/com/twitter/intellij/pants/settings/PantsSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsSettings.java
@@ -34,19 +34,19 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
   }
 
   protected boolean myCompileWithIntellij = false;
-  protected boolean myEnforceJdk = false;
+  protected boolean myUseIdeaProjectJdk = false;
   protected int myResolverVersion = 0;
 
   public PantsSettings(@NotNull Project project) {
     super(PantsSettingsListener.TOPIC, project);
   }
 
-  public void setEnforceJdk(boolean enforceJdk) {
-    myEnforceJdk = enforceJdk;
+  public void setUseIdeaProjectJdk(boolean useIdeaProjectJdk) {
+    myUseIdeaProjectJdk = useIdeaProjectJdk;
   }
 
-  public boolean isEnforceJdk() {
-    return myEnforceJdk;
+  public boolean isUseIdeaProjectJdk() {
+    return myUseIdeaProjectJdk;
   }
 
   public boolean isCompileWithIntellij() {
@@ -79,7 +79,7 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
   protected void copyExtraSettingsFrom(@NotNull PantsSettings settings) {
     setCompileWithIntellij(settings.isCompileWithIntellij());
     setResolverVersion(settings.getResolverVersion());
-    setEnforceJdk(settings.isEnforceJdk());
+    setUseIdeaProjectJdk(settings.isUseIdeaProjectJdk());
   }
 
   @Override
@@ -93,7 +93,7 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
     final MyState state = new MyState();
     state.setCompileWithIntellij(isCompileWithIntellij());
     state.setResolverVersion(getResolverVersion());
-    state.setEnforceJdk(isEnforceJdk());
+    state.setUseIdeaProjectJdk(isUseIdeaProjectJdk());
     fillState(state);
     return state;
   }
@@ -103,14 +103,14 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
     super.loadState(state);
     setCompileWithIntellij(state.isCompileWithIntellij());
     setResolverVersion(state.getResolverVersion());
-    setEnforceJdk(state.isEnforceJdk());
+    setUseIdeaProjectJdk(state.isUseIdeaProjectJdk());
   }
 
   public static class MyState implements State<PantsProjectSettings> {
     Set<PantsProjectSettings> myLinkedExternalProjectsSettings = ContainerUtilRt.newTreeSet();
 
     boolean myCompileWithIntellij = false;
-    boolean myEnforceJdk = false;
+    boolean myUseIdeaProjectJdk = false;
     int myResolverVersion = 0;
 
     @AbstractCollection(surroundWithTag = false, elementTypes = {PantsProjectSettings.class})
@@ -118,12 +118,12 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
       return myLinkedExternalProjectsSettings;
     }
 
-    public void setEnforceJdk(boolean enforceJdk) {
-      myEnforceJdk = enforceJdk;
+    public void setUseIdeaProjectJdk(boolean useIdeaProjectJdk) {
+      myUseIdeaProjectJdk = useIdeaProjectJdk;
     }
 
-    public boolean isEnforceJdk() {
-      return myEnforceJdk;
+    public boolean isUseIdeaProjectJdk() {
+      return myUseIdeaProjectJdk;
     }
 
     public void setLinkedExternalProjectsSettings(Set<PantsProjectSettings> settings) {

--- a/src/com/twitter/intellij/pants/settings/PantsSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsSettings.java
@@ -34,10 +34,19 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
   }
 
   protected boolean myCompileWithIntellij = false;
+  protected boolean myEnforceJdk = false;
   protected int myResolverVersion = 0;
 
   public PantsSettings(@NotNull Project project) {
     super(PantsSettingsListener.TOPIC, project);
+  }
+
+  public void setEnforceJdk(boolean enforceJdk) {
+    myEnforceJdk = enforceJdk;
+  }
+
+  public boolean isEnforceJdk() {
+    return myEnforceJdk;
   }
 
   public boolean isCompileWithIntellij() {
@@ -70,6 +79,7 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
   protected void copyExtraSettingsFrom(@NotNull PantsSettings settings) {
     setCompileWithIntellij(settings.isCompileWithIntellij());
     setResolverVersion(settings.getResolverVersion());
+    setEnforceJdk(settings.isEnforceJdk());
   }
 
   @Override
@@ -83,6 +93,7 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
     final MyState state = new MyState();
     state.setCompileWithIntellij(isCompileWithIntellij());
     state.setResolverVersion(getResolverVersion());
+    state.setEnforceJdk(isEnforceJdk());
     fillState(state);
     return state;
   }
@@ -92,18 +103,27 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
     super.loadState(state);
     setCompileWithIntellij(state.isCompileWithIntellij());
     setResolverVersion(state.getResolverVersion());
+    setEnforceJdk(state.isEnforceJdk());
   }
 
   public static class MyState implements State<PantsProjectSettings> {
     Set<PantsProjectSettings> myLinkedExternalProjectsSettings = ContainerUtilRt.newTreeSet();
 
     boolean myCompileWithIntellij = false;
-
+    boolean myEnforceJdk = false;
     int myResolverVersion = 0;
 
     @AbstractCollection(surroundWithTag = false, elementTypes = {PantsProjectSettings.class})
     public Set<PantsProjectSettings> getLinkedExternalProjectsSettings() {
       return myLinkedExternalProjectsSettings;
+    }
+
+    public void setEnforceJdk(boolean enforceJdk) {
+      myEnforceJdk = enforceJdk;
+    }
+
+    public boolean isEnforceJdk() {
+      return myEnforceJdk;
     }
 
     public void setLinkedExternalProjectsSettings(Set<PantsProjectSettings> settings) {

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
@@ -201,7 +201,7 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
     List<String> output = makeProject();
     assertTrue(StringUtil.join(output,"\n").contains(PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION));
 
-    modify("org.pantsbuild.example.hello.greet.GreetingTest");
+    modify("org.pantsbuild.example.hello.greet.Greeting");
     settings.setUseIdeaProjectJdk(false);
     output = makeProject();
     assertFalse(StringUtil.join(output,"\n").contains(PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION));

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
@@ -8,12 +8,16 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingAnsiEscapesAwareProcessHandler;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessOutput;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.twitter.intellij.pants.settings.PantsSettings;
 import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.jps.incremental.ProjectBuildException;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest {
@@ -182,6 +186,25 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
     );
 
     makeModules("intellij-integration_src_java_org_pantsbuild_testproject_resources1_resources1");
+  }
+
+  public void testCompileWithProjectJdk() throws Throwable {
+    doImport("examples/src/java/org/pantsbuild/example/hello/greet");
+
+    assertModules(
+      "examples_src_java_org_pantsbuild_example_hello_greet_greet"
+    );
+
+    PantsSettings settings = PantsSettings.getInstance(myProject);
+    settings.setUseIdeaProjectJdk(true);
+    settings.setCompileWithIntellij(false);
+    List<String> output = makeProject();
+    assertTrue(StringUtil.join(output,"\n").contains(PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION));
+
+    modify("org.pantsbuild.example.hello.greet.GreetingTest");
+    settings.setUseIdeaProjectJdk(false);
+    output = makeProject();
+    assertFalse(StringUtil.join(output,"\n").contains(PantsConstants.PANTS_JVM_DISTRIBUTIONS_PATHS_OPTION));
   }
 
   private String[] getModulesNamesFromPantsDependencies(String targetName) throws ProjectBuildException {


### PR DESCRIPTION
Currently the JDK selected during import stage is only used as code reference and does not factor into pants compilation which uses the system default JDK version. This change will let the plugin honor the JDK selected by using --jvm-distributions-paths