### PR TITLE
Get targets to compile based on target.is_synthetic instead of target.address

### DIFF
--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -3,13 +3,18 @@
 
 package com.twitter.intellij.pants.model;
 
+import com.google.gson.reflect.TypeToken;
 import com.intellij.openapi.util.text.StringUtil;
 import com.twitter.intellij.pants.util.PantsUtil;
-import com.twitter.intellij.pants.model.Globs;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Type;
+import java.util.HashSet;
+
 public class TargetAddressInfo {
+  // This is constant type for Gson to figure the data type to deserialize
+  public static final Type TYPE = new TypeToken<HashSet<TargetAddressInfo>>(){}.getType();
   /**
    * Target addresses.
    */

--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -3,7 +3,6 @@
 
 package com.twitter.intellij.pants.model;
 
-import com.google.gson.reflect.TypeToken;
 import com.intellij.openapi.util.text.StringUtil;
 import com.twitter.intellij.pants.util.PantsUtil;
 import com.twitter.intellij.pants.model.Globs;

--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -6,6 +6,7 @@ package com.twitter.intellij.pants.model;
 import com.google.gson.reflect.TypeToken;
 import com.intellij.openapi.util.text.StringUtil;
 import com.twitter.intellij.pants.util.PantsUtil;
+import com.twitter.intellij.pants.model.Globs;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,8 +39,7 @@ public class TargetAddressInfo {
   private String pants_target_type = null;
 
   private boolean is_code_gen;
-
-
+  
   private boolean is_synthetic;
 
   private String id;

--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -10,15 +10,8 @@ import com.twitter.intellij.pants.model.Globs;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Type;
-import java.util.HashSet;
 
 public class TargetAddressInfo {
-  /**
-   * Constant type for gson to figure out the data type to deserialize
-   */
-  public static final Type TYPE = new TypeToken<HashSet<TargetAddressInfo>>(){}.getType();
-
   /**
    * Target addresses.
    */
@@ -39,7 +32,7 @@ public class TargetAddressInfo {
   private String pants_target_type = null;
 
   private boolean is_code_gen;
-  
+
   private boolean is_synthetic;
 
   private String id;

--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -31,9 +31,16 @@ public class TargetAddressInfo {
 
   private boolean is_code_gen;
 
+
+  private boolean is_synthetic;
+
   private String id;
 
   public TargetAddressInfo() {
+  }
+
+  public boolean is_synthetic() {
+    return is_synthetic;
   }
 
   public String getId() {

--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -13,8 +13,11 @@ import java.lang.reflect.Type;
 import java.util.HashSet;
 
 public class TargetAddressInfo {
-  // This is constant type for Gson to figure the data type to deserialize
+  /**
+   * Constant type for gson to figure out the data type to deserialize
+   */
   public static final Type TYPE = new TypeToken<HashSet<TargetAddressInfo>>(){}.getType();
+
   /**
    * Target addresses.
    */

--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -3,12 +3,16 @@
 
 package com.twitter.intellij.pants.util;
 
+import com.google.gson.reflect.TypeToken;
 import com.intellij.openapi.externalSystem.model.ProjectSystemId;
 import com.intellij.util.text.CaseInsensitiveStringHashingStrategy;
+import com.twitter.intellij.pants.model.TargetAddressInfo;
 import gnu.trove.THashSet;
 import org.jetbrains.annotations.NotNull;
 
+import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 
@@ -50,4 +54,9 @@ public class PantsConstants {
       ),
     CaseInsensitiveStringHashingStrategy.INSTANCE
   );
+
+  /**
+   * Constant type for gson to figure out the data type to deserialize
+   */
+  public static final Type TARGET_ADDRESS_INFO_HASHSET_TYPE = new TypeToken<HashSet<TargetAddressInfo>>(){}.getType();
 }

--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-
 public class PantsConstants {
   public static final String PANTS = "pants";
   public static final String PLUGIN_ID = "com.intellij.plugins.pants";

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -36,9 +36,7 @@ import org.jetbrains.jps.model.JpsProject;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor, PantsBuildTarget> {
   private static final Logger LOG = Logger.getInstance(PantsTargetBuilder.class);
@@ -113,7 +111,7 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
     if (JavaBuilderUtil.isForcedRecompilationAllJavaModules(context)) {
       commandLine.addParameters("clean-all");
     }
-    final List<String> allNonGenTargetAddresses = filterGenTargets(target.getTargetAddressInfoSet());
+    final List<String> allNonGenTargetAddresses = getUniqueNonSyntheticTargetAddresses(target.getTargetAddressInfoSet());
 
     final String recompileMessage = String.format("Recompiling all %s targets", allNonGenTargetAddresses.size());
     context.processMessage(
@@ -138,10 +136,10 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
     final JpsPantsProjectExtension pantsProjectExtension =
       PantsJpsProjectExtensionSerializer.findPantsProjectExtension(jpsProject);
     if (pantsProjectExtension.isUseIdeaProjectJdk()) {
-      try{
+      try {
         commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(PantsUtil.getJdkPathFromExternalBuilder(jpsProject)));
       }
-      catch(Exception e){
+      catch (Exception e) {
         throw new ProjectBuildException(e);
       }
     }
@@ -185,14 +183,14 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
     return hasDirtyTargets.get();
   }
 
-  private List<String> filterGenTargets(@NotNull Collection<TargetAddressInfo> targetAddressInfoCollection) {
-    List<String> addresses = Collections.emptyList();
-    for (TargetAddressInfo targetAddressInfo: targetAddressInfoCollection) {
+  private List<String> getUniqueNonSyntheticTargetAddresses(@NotNull Collection<TargetAddressInfo> targetAddressInfoCollection) {
+    Set<String> uniqueAddresses = new HashSet<String>();
+    for (TargetAddressInfo targetAddressInfo : targetAddressInfoCollection) {
       if (!targetAddressInfo.is_synthetic()) {
-        addresses.add(targetAddressInfo.getTargetAddress());
+        uniqueAddresses.add(targetAddressInfo.getTargetAddress());
       }
     }
-    return addresses;
+    return new ArrayList<String>(uniqueAddresses);
   }
 
   @NotNull

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/PantsTargetBuilder.java
@@ -111,15 +111,14 @@ public class PantsTargetBuilder extends TargetBuilder<PantsSourceRootDescriptor,
     if (JavaBuilderUtil.isForcedRecompilationAllJavaModules(context)) {
       commandLine.addParameters("clean-all");
     }
-    final List<String> allNonGenTargetAddresses = getUniqueNonSyntheticTargetAddresses(target.getTargetAddressInfoSet());
-
-    final String recompileMessage = String.format("Recompiling all %s targets", allNonGenTargetAddresses.size());
+    final List<String> allUniqueNonSyntheticTargetAddresses = getUniqueNonSyntheticTargetAddresses(target.getTargetAddressInfoSet());
+    final String recompileMessage = String.format("Recompiling all %s targets", allUniqueNonSyntheticTargetAddresses.size());
     context.processMessage(
       new CompilerMessage(PantsConstants.PANTS, BuildMessage.Kind.INFO, recompileMessage)
     );
     context.processMessage(new ProgressMessage(recompileMessage));
     commandLine.addParameters(goals);
-    commandLine.addParameters(allNonGenTargetAddresses);
+    commandLine.addParameters(allUniqueNonSyntheticTargetAddresses);
 
     // Find out whether "export-classpath-use-old-naming-style" exists
     final boolean hasExportClassPathNamingStyle =

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/PantsBuildTarget.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/PantsBuildTarget.java
@@ -79,14 +79,14 @@ public class PantsBuildTarget extends BuildTarget<PantsSourceRootDescriptor> {
         @Override
         public boolean process(ModuleBuildTarget target) {
           final JpsPantsModuleExtension moduleExtension = PantsJpsModelSerializerExtension.findPantsModuleExtension(target.getModule());
-          final Set<String> targetAddresses = moduleExtension != null ?
-                                              moduleExtension.getTargetAddresses() : Collections.<String>emptySet();
+          final Set<TargetAddressInfo> targetAddressInfoSet = moduleExtension != null ?
+                                              moduleExtension.getTargetAddressInfoSet() : Collections.<TargetAddressInfo>emptySet();
           final List<JavaSourceRootDescriptor> descriptors = target.computeRootDescriptors(model, index, ignoredFileIndex, dataPaths);
           for (JavaSourceRootDescriptor javaSourceRootDescriptor : descriptors) {
             result.add(
               new PantsSourceRootDescriptor(
                 PantsBuildTarget.this,
-                targetAddresses,
+                targetAddressInfoSet,
                 javaSourceRootDescriptor.getRootFile(),
                 javaSourceRootDescriptor.isGenerated(),
                 javaSourceRootDescriptor.getExcludedRoots()
@@ -138,11 +138,6 @@ public class PantsBuildTarget extends BuildTarget<PantsSourceRootDescriptor> {
   @NotNull
   public String getPantsExecutable() {
     return myPantsExecutable;
-  }
-
-  @NotNull
-  public Set<String> getTargetAddresses() {
-    return myTargetAddresses;
   }
 
   @NotNull

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/PantsSourceRootDescriptor.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/model/PantsSourceRootDescriptor.java
@@ -4,6 +4,7 @@
 package com.twitter.intellij.pants.jps.incremental.model;
 
 import com.intellij.openapi.util.io.FileUtil;
+import com.twitter.intellij.pants.model.TargetAddressInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jps.builders.BuildRootDescriptor;
 
@@ -16,27 +17,30 @@ public class PantsSourceRootDescriptor extends BuildRootDescriptor {
   public final boolean myGeneratedSources;
   @NotNull
   private final Set<File> myExcludes;
-  private final Set<String> myTargetAddress;
   @NotNull
   private final PantsBuildTarget myTarget;
 
+  private final Set<TargetAddressInfo> myTargetAddressInfoSet;
+
+
+
   public PantsSourceRootDescriptor(
     @NotNull PantsBuildTarget target,
-    @NotNull Set<String> targetAddress,
+    @NotNull Set<TargetAddressInfo> targetAddressInfoSet,
     @NotNull File root,
     boolean isGenerated,
     @NotNull Set<File> excludes
   ) {
     myTarget = target;
-    myTargetAddress = targetAddress;
+    myTargetAddressInfoSet = targetAddressInfoSet;
     myRoot = root;
     myGeneratedSources = isGenerated;
     myExcludes = excludes;
   }
 
   @NotNull
-  public Set<String> getTargetAddresses() {
-    return myTargetAddress;
+  public Set<TargetAddressInfo> getTargetAddressInfoSet() {
+    return myTargetAddressInfoSet;
   }
 
   @NotNull
@@ -80,7 +84,7 @@ public class PantsSourceRootDescriptor extends BuildRootDescriptor {
     if (myGeneratedSources != that.myGeneratedSources) return false;
     if (!myRoot.equals(that.myRoot)) return false;
     if (!myExcludes.equals(that.myExcludes)) return false;
-    if (myTargetAddress != null ? !myTargetAddress.equals(that.myTargetAddress) : that.myTargetAddress != null) return false;
+    if (myTargetAddressInfoSet != null ? !myTargetAddressInfoSet.equals(that.myTargetAddressInfoSet) : that.myTargetAddressInfoSet != null) return false;
     return myTarget.equals(that.myTarget);
   }
 
@@ -89,7 +93,7 @@ public class PantsSourceRootDescriptor extends BuildRootDescriptor {
     int result = myRoot.hashCode();
     result = 31 * result + (myGeneratedSources ? 1 : 0);
     result = 31 * result + myExcludes.hashCode();
-    result = 31 * result + (myTargetAddress != null ? myTargetAddress.hashCode() : 0);
+    result = 31 * result + (myTargetAddressInfoSet != null ? myTargetAddressInfoSet.hashCode() : 0);
     result = 31 * result + myTarget.hashCode();
     return result;
   }

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsModelSerializerExtension.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsModelSerializerExtension.java
@@ -62,7 +62,7 @@ public class PantsJpsModelSerializerExtension extends JpsModelSerializerExtensio
     final String linkedProjectPath = rootElement.getAttributeValue(LINKED_PROJECT_PATH_KEY);
     final String targetAddressesValue = StringUtil.nullize(rootElement.getAttributeValue(PantsConstants.PANTS_TARGET_ADDRESSES_KEY));
     final String addressInfosJson = StringUtil.nullize(rootElement.getAttributeValue(PantsConstants.PANTS_TARGET_ADDRESS_INFOS_KEY));
-    Set<TargetAddressInfo> targetInfoSet = gson.fromJson(addressInfosJson, TargetAddressInfo.TYPE);
+    Set<TargetAddressInfo> targetInfoSet = gson.fromJson(addressInfosJson, PantsConstants.TARGET_ADDRESS_INFO_HASHSET_TYPE);
 
     if (PantsConstants.PANTS.equals(externalSystemId) && targetAddressesValue != null && linkedProjectPath != null) {
       final Set<String> targetAddresses = new HashSet<String>(StringUtil.split(targetAddressesValue, ","));

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsModelSerializerExtension.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsModelSerializerExtension.java
@@ -62,7 +62,8 @@ public class PantsJpsModelSerializerExtension extends JpsModelSerializerExtensio
     final String linkedProjectPath = rootElement.getAttributeValue(LINKED_PROJECT_PATH_KEY);
     final String targetAddressesValue = StringUtil.nullize(rootElement.getAttributeValue(PantsConstants.PANTS_TARGET_ADDRESSES_KEY));
     final String addressInfosJson = StringUtil.nullize(rootElement.getAttributeValue(PantsConstants.PANTS_TARGET_ADDRESS_INFOS_KEY));
-    Set<TargetAddressInfo> targetInfoSet = gson.fromJson(addressInfosJson, HashSet.class);
+    Set<TargetAddressInfo> targetInfoSet = gson.fromJson(addressInfosJson, TargetAddressInfo.TYPE);
+
     if (PantsConstants.PANTS.equals(externalSystemId) && targetAddressesValue != null && linkedProjectPath != null) {
       final Set<String> targetAddresses = new HashSet<String>(StringUtil.split(targetAddressesValue, ","));
       final JpsPantsModuleExtensionImpl moduleExtensionElement =

--- a/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/incremental/serialization/PantsJpsProjectExtensionSerializer.java
@@ -48,7 +48,6 @@ public class PantsJpsProjectExtensionSerializer extends JpsProjectExtensionSeria
       Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, COMPILE_WITH_INTELLIJ, "false"));
     final boolean useIdeaProjectJdk = Boolean.valueOf(JDOMExternalizerUtil.readField(componentTag, ENFORCE_JDK, "false"));
 
-    String optionalJdkPath = useIdeaProjectJdk ? PantsUtil.getJdkPathFromExternalBuilder(project) : null;
     final JpsPantsProjectExtension projectExtension =
       new JpsPantsProjectExtensionImpl(pantsExecutable.getPath(), compileWithIntellij, useIdeaProjectJdk);
 

--- a/jps-plugin/com/twitter/intellij/pants/jps/util/PantsJpsUtil.java
+++ b/jps-plugin/com/twitter/intellij/pants/jps/util/PantsJpsUtil.java
@@ -9,6 +9,7 @@ import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
 import com.twitter.intellij.pants.jps.incremental.model.JpsPantsModuleExtension;
 import com.twitter.intellij.pants.jps.incremental.serialization.PantsJpsModelSerializerExtension;
+import com.twitter.intellij.pants.model.TargetAddressInfo;
 import com.twitter.intellij.pants.util.PantsConstants;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jps.model.module.JpsModule;
@@ -17,26 +18,16 @@ import java.util.Collection;
 import java.util.List;
 
 public class PantsJpsUtil {
-  public static boolean containsGenTarget(@NotNull Collection<String> addresses) {
+  public static boolean containsGenTarget(@NotNull Collection<TargetAddressInfo> targetAddressInfoSet) {
     return ContainerUtil.exists(
-      addresses,
-      new Condition<String>() {
+      targetAddressInfoSet,
+      new Condition<TargetAddressInfo>() {
         @Override
-        public boolean value(String value) {
-          return isGenTarget(value);
+        public boolean value(TargetAddressInfo value) {
+          return value.is_synthetic();
         }
       }
     );
-  }
-
-  public static boolean isGenTarget(@NotNull String address) {
-    return StringUtil.startsWithIgnoreCase(address, ".pants.d") ||
-           StringUtil.startsWithIgnoreCase(address, PantsConstants.PANTS_PROJECT_MODULE_ID_PREFIX) ||
-           // Checking "_synthetic_resources" is a temporary fix. It also needs to match the postfix added from pants in
-           // src.python.pants.backend.python.targets.python_target.PythonTarget#_synthetic_resources_target
-           // TODO: The long term solution is collect non-synthetic targets at pre-compile stage
-           // https://github.com/pantsbuild/intellij-pants-plugin/issues/83
-           address.toLowerCase().endsWith("_synthetic_resources");
   }
 
   public static boolean containsPantsModules(Collection<JpsModule> modules) {

--- a/src/com/twitter/intellij/pants/execution/PantsClasspathRunConfigurationExtension.java
+++ b/src/com/twitter/intellij/pants/execution/PantsClasspathRunConfigurationExtension.java
@@ -121,7 +121,7 @@ public class PantsClasspathRunConfigurationExtension extends RunConfigurationExt
   @NotNull
   public static List<String> findPublishedClasspath(@NotNull Module module, boolean hasTargetIdInExport) {
     final List<String> result = ContainerUtil.newArrayList();
-    Set<TargetAddressInfo> targetInfoSet = gson.fromJson(module.getOptionValue(PantsConstants.PANTS_TARGET_ADDRESS_INFOS_KEY), TargetAddressInfo.TYPE);
+    Set<TargetAddressInfo> targetInfoSet = gson.fromJson(module.getOptionValue(PantsConstants.PANTS_TARGET_ADDRESS_INFOS_KEY), PantsConstants.TARGET_ADDRESS_INFO_HASHSET_TYPE);
     // The new way to find classpath by target id
     if (hasTargetIdInExport && targetInfoSet != null && targetInfoSet.size() > 0 && targetInfoSet.iterator().next().getId() != null) {
       for (TargetAddressInfo ta : targetInfoSet) {

--- a/src/com/twitter/intellij/pants/execution/PantsClasspathRunConfigurationExtension.java
+++ b/src/com/twitter/intellij/pants/execution/PantsClasspathRunConfigurationExtension.java
@@ -121,10 +121,7 @@ public class PantsClasspathRunConfigurationExtension extends RunConfigurationExt
   @NotNull
   public static List<String> findPublishedClasspath(@NotNull Module module, boolean hasTargetIdInExport) {
     final List<String> result = ContainerUtil.newArrayList();
-    // This is type for Gson to figure the data type to deserialize
-    final Type type = new TypeToken<HashSet<TargetAddressInfo>>() {
-    }.getType();
-    Set<TargetAddressInfo> targetInfoSet = gson.fromJson(module.getOptionValue(PantsConstants.PANTS_TARGET_ADDRESS_INFOS_KEY), type);
+    Set<TargetAddressInfo> targetInfoSet = gson.fromJson(module.getOptionValue(PantsConstants.PANTS_TARGET_ADDRESS_INFOS_KEY), TargetAddressInfo.TYPE);
     // The new way to find classpath by target id
     if (hasTargetIdInExport && targetInfoSet != null && targetInfoSet.size() > 0 && targetInfoSet.iterator().next().getId() != null) {
       for (TargetAddressInfo ta : targetInfoSet) {


### PR DESCRIPTION
Earlier the plugin determines whether to compile a target (aka is synthetic) based on its address (e.g. whether it contains ".pants.d", "_synthetic_reousrs", etc), which is not reliable. This change utilizes is_synethtic" in pants export, which is the correct way to do it.

Since "is_synthetic" was not merged to OSS before 0.0.70 and it does not have the option to fallback to the old scheme if is_synthetic unavailable from pants export, this RB may need to wait a bit. That is why CI fails for 0.0.69 and before.
