### PR TITLE
Fix view switch thread handle loss

### DIFF
--- a/.idea/runConfigurations/Pants.xml
+++ b/.idea/runConfigurations/Pants.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Pants" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType" factoryName="Plugin" singleton="true">
     <module name="intellij-pants-plugin" />
-    <option name="VM_PARAMETERS" value="-Xmx1024m -Xms256m -XX:MaxPermSize=250m -ea -Didea.is.internal=true -Dpants.system.in.process=true -Dpants.dev.run=true" />
+    <option name="VM_PARAMETERS" value="-Xmx2048m -Xms256m -XX:MaxPermSize=250m -ea -Didea.is.internal=true -Dpants.system.in.process=true -Dpants.dev.run=true" />
     <option name="PROGRAM_PARAMETERS" value="" />
     <log_file path="$USER_HOME$/Library/Caches/IdeaIC15/plugins-sandbox/system/log/idea.log" checked="true" skipped="true" show_all="false" alias="IDEA LOG" />
     <RunnerSettings RunnerId="Debug">

--- a/.idea/runConfigurations/Pants.xml
+++ b/.idea/runConfigurations/Pants.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Pants" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType" factoryName="Plugin" singleton="true">
     <module name="intellij-pants-plugin" />
-    <option name="VM_PARAMETERS" value="-Xmx2048m -Xms256m -XX:MaxPermSize=250m -ea -Didea.is.internal=true -Dpants.system.in.process=true -Dpants.dev.run=true" />
+    <option name="VM_PARAMETERS" value="-Xmx1024m -Xms256m -XX:MaxPermSize=250m -ea -Didea.is.internal=true -Dpants.system.in.process=true -Dpants.dev.run=true" />
     <option name="PROGRAM_PARAMETERS" value="" />
     <log_file path="$USER_HOME$/Library/Caches/IdeaIC15/plugins-sandbox/system/log/idea.log" checked="true" skipped="true" show_all="false" alias="IDEA LOG" />
     <RunnerSettings RunnerId="Debug">

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -53,8 +53,8 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
   private final Map<ExternalSystemTaskId, PantsCompileOptionsExecutor> task2executor =
     new ConcurrentHashMap<ExternalSystemTaskId, PantsCompileOptionsExecutor>();
 
-  private ScheduledFuture<?> viewSwitchHandle;
-  private ScheduledFuture<?> directoryFocusHandle;
+  private volatile ScheduledFuture<?> viewSwitchHandle;
+  private volatile ScheduledFuture<?> directoryFocusHandle;
 
   @Nullable
   @Override
@@ -179,6 +179,9 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
   }
 
   private void queueSwitchToProjectFilesTreeView(final Project project, final String projectPath) {
+    if (viewSwitchHandle != null && !viewSwitchHandle.isDone()) {
+      return;
+    }
     viewSwitchHandle = PantsUtil.scheduledThreadPool.scheduleAtFixedRate(new Runnable() {
       @Override
       public void run() {
@@ -198,6 +201,9 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
   }
 
   private void queueFocusOnImportDirectory(final Project project, final String projectPath) {
+    if (directoryFocusHandle != null && !directoryFocusHandle.isDone()) {
+      return;
+    }
     directoryFocusHandle = PantsUtil.scheduledThreadPool.scheduleAtFixedRate(new Runnable() {
       @Override
       public void run() {


### PR DESCRIPTION
The thread handles for view switching are overwritten because multiple projects try to refresh at the same time, so some cannot end because they self loop unless explicitly cancelled. This change blocks any view switch request if there is one ongoing via semaphores.