### PR TITLE
Fix threading assertion error

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportBuilder.java
+++ b/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportBuilder.java
@@ -4,6 +4,7 @@
 package com.twitter.intellij.pants.service.project.wizard;
 
 import com.intellij.ide.util.projectWizard.WizardContext;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
 import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManager;
@@ -75,7 +76,7 @@ public class PantsProjectImportBuilder extends AbstractExternalProjectImportBuil
    * Find if pants sdk is already configured, return the existing sdk if it exists,
    * otherwise add to the config and return.
    */
-  private Sdk addIfNotExists(Sdk pantsSdk) {
+  private Sdk addIfNotExists(final Sdk pantsSdk) {
     final JavaSdk javaSdk = JavaSdk.getInstance();
     List<Sdk> sdks = ProjectJdkTable.getInstance().getSdksOfType(javaSdk);
     for (Sdk sdk : sdks) {
@@ -83,7 +84,12 @@ public class PantsProjectImportBuilder extends AbstractExternalProjectImportBuil
         return sdk;
       }
     }
-    ProjectJdkTable.getInstance().addJdk(pantsSdk);
+    ApplicationManager.getApplication().runWriteAction(new Runnable() {
+      @Override
+      public void run() {
+        ProjectJdkTable.getInstance().addJdk(pantsSdk);
+      }
+    });
     return pantsSdk;
   }
 }


### PR DESCRIPTION
Data structures in the IntelliJ Platform are covered by a single reader/writer
lock.  Writing data is only allowed from the UI thread, and write operations
always need to be wrapped in a write action with
`ApplicationManager.getApplication().runWriteAction()`. [1]

In this case, the following assertion error would happen if no jdk is defined.
```
Assertion failed: Write access is allowed inside write-action only (see com.intellij.openapi.application.Application.runWriteAction())
java.lang.Throwable
	at com.intellij.openapi.diagnostic.Logger.assertTrue(Logger.java:144)
	at com.intellij.openapi.application.impl.ApplicationImpl.assertWriteAccessAllowed(ApplicationImpl.java:1360)
	at com.intellij.openapi.projectRoots.impl.ProjectJdkTableImpl.addJdk(ProjectJdkTableImpl.java:199)
	at com.twitter.intellij.pants.service.project.wizard.PantsProjectImportBuilder.addIfNotExists(PantsProjectImportBuilder.java:86)
	at com.twitter.intellij.pants.service.project.wizard.PantsProjectImportBuilder.applyExtraSettings(PantsProjectImportBuilder.java:70)
	at com.intellij.openapi.externalSystem.service.project.wizard.AbstractExternalProjectImportBuilder.applyProjectSettings(AbstractExternalProjectImportBuilder.java:346)
```

[1] http://www.jetbrains.org/intellij/sdk/docs/basics/architectural_overview/general_threading_rules.html