### PR TITLE
[plugin] release 1.4.1 for IDEA 2016

### DIFF
--- a/.idea/runConfigurations/Pants.xml
+++ b/.idea/runConfigurations/Pants.xml
@@ -3,7 +3,7 @@
     <module name="intellij-pants-plugin" />
     <option name="VM_PARAMETERS" value="-Xmx4096m -Xms256m -ea -Didea.is.internal=true -Dpants.system.in.process=true -Dpants.dev.run=true" />
     <option name="PROGRAM_PARAMETERS" value="" />
-    <log_file path="$USER_HOME$/Desktop/IJ/2016_1_1_system/plugins-sandbox/system/log/idea.log" checked="true" skipped="true" show_all="false" alias="IDEA LOG" />
+    <log_file path="$USER_HOME$/Library/Caches/IdeaIC2016.1/plugins-sandbox/system/log/idea.log" checked="true" skipped="true" show_all="false" alias="IDEA LOG" />
     <RunnerSettings RunnerId="Debug">
       <option name="DEBUG_PORT" value="" />
       <option name="TRANSPORT" value="0" />

--- a/.idea/runConfigurations/Pants.xml
+++ b/.idea/runConfigurations/Pants.xml
@@ -3,7 +3,7 @@
     <module name="intellij-pants-plugin" />
     <option name="VM_PARAMETERS" value="-Xmx4096m -Xms256m -ea -Didea.is.internal=true -Dpants.system.in.process=true -Dpants.dev.run=true" />
     <option name="PROGRAM_PARAMETERS" value="" />
-    <log_file path="$USER_HOME$/Library/Caches/IdeaIC2016.1/plugins-sandbox/system/log/idea.log" checked="true" skipped="true" show_all="false" alias="IDEA LOG" />
+    <log_file path="$USER_HOME$/Desktop/IJ/2016_1_1_system/plugins-sandbox/system/log/idea.log" checked="true" skipped="true" show_all="false" alias="IDEA LOG" />
     <RunnerSettings RunnerId="Debug">
       <option name="DEBUG_PORT" value="" />
       <option name="TRANSPORT" value="0" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,167 @@
+For contributing to the project, continue reading below.
+
+### How the plugin works
+
+The plugin uses `pants resolve export <list of imported targets>` command to get an information
+about an imported project. `pants resolve export <list of imported targets>` command returns information
+about all targets that are needed to be imported for the project in JSON format. It contains information about all dependencies of a target
+as well as the same information for each dependency. Then the plugin creates an IntelliJ module for each target, configures
+dependencies(modules and libraries) and source roots.
+
+Let's check an output of `./pants export examples/src/java/org/pantsbuild/example/hello/main:main-bin` command:
+
+```json
+{
+    "libraries": {},
+    "targets": {
+        "examples/src/java/org/pantsbuild/example/hello/greet:greet": {
+            "is_code_gen": false,
+            "target_type": "SOURCE",
+            "libraries": [],
+            "pants_target_type": "java_library",
+            "targets": [],
+            "roots": [
+                {
+                    "source_root": "/Users/fkorotkov/workspace/pants/examples/src/java/org/pantsbuild/example/hello/greet",
+                    "package_prefix": "org.pantsbuild.example.hello.greet"
+                }
+            ]
+        },
+        "examples/src/java/org/pantsbuild/example/hello/main:main-bin": {
+            "is_code_gen": false,
+            "target_type": "SOURCE",
+            "libraries": [],
+            "pants_target_type": "jvm_binary",
+            "targets": [
+                "examples/src/java/org/pantsbuild/example/hello/greet:greet",
+                "examples/src/resources/org/pantsbuild/example/hello:hello"
+            ],
+            "roots": [
+                {
+                    "source_root": "/Users/fkorotkov/workspace/pants/examples/src/java/org/pantsbuild/example/hello/main",
+                    "package_prefix": "org.pantsbuild.example.hello.main"
+                }
+            ]
+        },
+        "examples/src/resources/org/pantsbuild/example/hello:hello": {
+            "is_code_gen": false,
+            "target_type": "RESOURCE",
+            "libraries": [],
+            "pants_target_type": "resources",
+            "targets": [],
+            "roots": [
+                {
+                    "source_root": "/Users/fkorotkov/workspace/pants/examples/src/resources/org/pantsbuild/example/hello",
+                    "package_prefix": "org.pantsbuild.example.hello"
+                }
+            ]
+        }
+    }
+}
+```
+
+The plugin will create three modules. One for the imported target, examples/src/java/com/pants/examples/hello/main:main-bin
+and two for the targets it depends on. It also will configure source roots for the modules and will use `target_type`
+and `is_code_gen` fields to figure out types of source roots(there are several types of source roots: sources,
+test sources, resources, test resources, generated sources, etc).
+
+## Contributing Guidelines:
+
+* Checkout the code
+
+        git clone https://github.com/pantsbuild/intellij-pants-plugin
+
+* Create a new branch off master to make your changes
+
+        git checkout -b $FEATURE_BRANCH
+
+* Push your branch and pass travis ci
+
+
+* Post your first review ([setup instructions](http://pantsbuild.github.io/howto_contribute.html#code-review))
+
+        ./rbt post -o -g
+
+* Iterating over the review
+
+        ./rbt post -o -r <RB_ID>
+
+* Committing your change to master
+
+        git checkout master
+        git pull
+        ./rbt patch -c <RB_ID>
+
+### IntelliJ project setup:
+
+* Download and open IntelliJ IDEA 2016 Community Edition
+* Install Python, Scala Plugins
+* Open the project via File -> Open, then select the plugin source folder. Do not import the plugin source as pants project because the plugin does not work on itself.
+* Use IntelliJ IDEA 2016 Community Edition as IDEA IC SDK. Project Structure(Cmd + ;) -> SDK -> '+' button -> IntelliJ Platform Plugin SDK
+* Setup the SDK's classpath
+  * Add the following to the SDK's classpath
+    * `~/Library/Application Support/IdeaIC2016/python/lib/python.jar`
+    * `~/Library/Application Support/IdeaIC2016/Scala/lib/scala-plugin.jar`
+    * `~/Library/Application Support/IdeaIC2016/Scala/lib/jps/*.jar`
+    * `/Applications/IntelliJ IDEA 2016 CE.app/Contents/plugins/junit/lib/idea-junit.jar`
+* Set Scala 2.11.2 as your Scala SDK
+* Make sure that your project is set to configure bytecode compatible with 1.8.  Preferences -> Compiler -> Java Compiler -> Project bytecode version
+* Run plugin configuration 'Pants' to verify your setup. It should launch a separate IntelliJ app.
+
+### Release process:
+* Create a new release branch from the latest master. E.g. `git checkout -b 1.3.14`
+* In plugin.xml:
+  * Update `<version>`. E.g. `1.3.14`
+  * Make sure of since/until build number for target IDEA versions.
+  * Add the changes to `<change-notes>`.
+* Submit review with green Travis CI.
+* Once shipit, patch the change in master and push to upstream.
+* Create git tag with release number in master. E.g. `git tag release_1.3.14`
+* Push the tag. E.g. `git push upstream release_1.3.14`. Fill out the release notes on github.
+* Distribution:
+  * Create an account at https://account.jetbrains.com/login. Request access to the plugin repo via https://pantsbuild.github.io/howto_contribute.html#join-the-conversation.
+  * Build -> Build Artifacts -> pants -> rebuild. Artifacts will be in `out/artifacts/pants`.
+  * Zip `out/artifacts/pants` folder into `pants.zip`.
+  * Validate the plugin manually in IntelliJ: Preferences -> Plugins -> Install from disk -> pick newly created `pants.zip`.
+  * Upload `pants.zip` to https://plugins.jetbrains.com/plugin/7412.
+
+### Debugging the Plugin from local pants development:
+
+* To debug tests execute:
+
+        ./scripts/run-tests-ci.sh --jvm-test-debug
+
+  It will listen for a debugger on 5005 port by default.
+
+  Create a Remote Run Configuration in IntelliJ. By default it uses 5005 port as well.
+
+  Hit debug button to connect to Pants.
+
+* If you want to debug plugin using your local development pants, you can do so by using the property `pants.executable.path`.
+  Add this configuration to Pants Run config.
+  e.g.
+
+        -Dpants.executable.path=/path/to/pants_dev/pants
+
+* To debug JPS compiler use:
+
+        -Dcompiler.process.debug.port=PORT
+
+* Remember to bootstrap pants in the project repository inside which you want to test the plugin.
+
+        cd ~/workspace/example_project
+        /path/to/pants_dev/pants goals
+
+  This will bootstrap pants and resolve all the dependencies or else you will get an `ExecutionException` exception for exceeding 30s timeout.
+
+# Running plugin tests with Pants
+
+1. `./scripts/prepare-environment.sh`
+2. `./scripts/setup-ci-environment.sh`
+3. `./scripts/run-tests-ci.sh`
+
+#### Explanation:
+* `./scripts/prepare-environment.sh` defines the test suite parameters such as `IJ_VERSION` and `IJ_BUILD_NUMBER`, which then will be used by `./scripts/setup-ci-environment.sh` for setup.
+
+* Indiviual test or target set can be run as the following, and the parameters are also used by .travis.yml:
+  * `TEST_SET=integration ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest#testJaxb`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ test sources, resources, test resources, generated sources, etc).
 
   This will bootstrap pants and resolve all the dependencies or else you will get an `ExecutionException` exception for exceeding 30s timeout.
 
-# Running plugin tests with Pants
+# Running plugin CI tests with Pants
 
 1. `./scripts/prepare-environment.sh`
 2. `./scripts/setup-ci-environment.sh`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,18 @@ test sources, resources, test resources, generated sources, etc).
   * Validate the plugin manually in IntelliJ: Preferences -> Plugins -> Install from disk -> pick newly created `pants.zip`.
   * Upload `pants.zip` to https://plugins.jetbrains.com/plugin/7412.
 
+# Running plugin CI tests with Pants
+
+1. `./scripts/prepare-environment.sh`
+2. `./scripts/setup-ci-environment.sh`
+3. `./scripts/run-tests-ci.sh`
+
+#### Explanation:
+* `./scripts/prepare-environment.sh` defines the test suite parameters such as `IJ_VERSION` and `IJ_BUILD_NUMBER`, which then will be used by `./scripts/setup-ci-environment.sh` for setup.
+
+* Indiviual test or target set can be run as the following, and the parameters are also used by .travis.yml:
+  * `TEST_SET=integration ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest#testJaxb`
+
 ### Debugging the Plugin from local pants development:
 
 * To debug tests execute:
@@ -153,15 +165,3 @@ test sources, resources, test resources, generated sources, etc).
         /path/to/pants_dev/pants goals
 
   This will bootstrap pants and resolve all the dependencies or else you will get an `ExecutionException` exception for exceeding 30s timeout.
-
-# Running plugin CI tests with Pants
-
-1. `./scripts/prepare-environment.sh`
-2. `./scripts/setup-ci-environment.sh`
-3. `./scripts/run-tests-ci.sh`
-
-#### Explanation:
-* `./scripts/prepare-environment.sh` defines the test suite parameters such as `IJ_VERSION` and `IJ_BUILD_NUMBER`, which then will be used by `./scripts/setup-ci-environment.sh` for setup.
-
-* Indiviual test or target set can be run as the following, and the parameters are also used by .travis.yml:
-  * `TEST_SET=integration ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest#testJaxb`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ test sources, resources, test resources, generated sources, etc).
 #### Explanation:
 * `./scripts/prepare-environment.sh` defines the test suite parameters such as `IJ_VERSION` and `IJ_BUILD_NUMBER`, which then will be used by `./scripts/setup-ci-environment.sh` for setup.
 
-* Indiviual test or target set can be run as the following, and the parameters are also used by .travis.yml:
+* Individual test or target set can be run as the following, and the parameters are also used by .travis.yml:
   * `TEST_SET=integration ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest#testJaxb`
 
 ### Debugging the Plugin from local pants development:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,11 +2,16 @@ Created by running `git shortlog -nse | cut -f2- | sort` and then
 manually trimming duplicates and editing missing names.
 
 Alexander Johnson <ajohnson@twitter.com>
+Andy Reitz <ajr9@po.cwru.edu>
 Eric Ayers <zundel@squareup.com>
 Fedor Korotkov <fedor.korotkov@gmail.com>
 Johan Oskarsson <johan@twitter.com>
+John Sirois <john.sirois@gmail.com>
 Jonathan Conveney <jcoveney@gmail.com>
+Kris Wilson <kwilson@twopensource.com>
 Nick Howard <nhoward@twitter.com>
+Peiyu Wang <wangpeiyu@gmail.com>
+Raushaniya Maksudova <rmaksudova@parallels.com>
+Stu Hood <stuhood@twitter.com>
 Tejal Desai <tdesai@twitter.com>
 Yi Cheng <wisechengyi@gmail.com>
-Peiyu Wang <wangpeiyu@gmail.com>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,5 @@ Johan Oskarsson <johan@twitter.com>
 Jonathan Conveney <jcoveney@gmail.com>
 Nick Howard <nhoward@twitter.com>
 Tejal Desai <tdesai@twitter.com>
+Yi Cheng <wisechengyi@gmail.com>
+Peiyu Wang <wangpeiyu@gmail.com>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,17 +1,17 @@
 Created by running `git shortlog -nse | cut -f2- | sort` and then
 manually trimming duplicates and editing missing names.
 
-Alexander Johnson <ajohnson@twitter.com>
-Andy Reitz <ajr9@po.cwru.edu>
-Eric Ayers <zundel@squareup.com>
-Fedor Korotkov <fedor.korotkov@gmail.com>
-Johan Oskarsson <johan@twitter.com>
-John Sirois <john.sirois@gmail.com>
-Jonathan Conveney <jcoveney@gmail.com>
-Kris Wilson <kwilson@twopensource.com>
-Nick Howard <nhoward@twitter.com>
-Peiyu Wang <wangpeiyu@gmail.com>
-Raushaniya Maksudova <rmaksudova@parallels.com>
-Stu Hood <stuhood@twitter.com>
-Tejal Desai <tdesai@twitter.com>
-Yi Cheng <wisechengyi@gmail.com>
+Alexander Johnson
+Andy Reitz
+Eric Ayers
+Fedor Korotkov
+Johan Oskarsson
+John Sirois
+Jonathan Conveney
+Kris Wilson
+Nick Howard
+Peiyu Wang
+Raushaniya Maksudova
+Stu Hood
+Tejal Desai
+Yi Cheng

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ Compilation options can be configured in Preferences -> Build, Execution, Deploy
   You can right click on tests and run tests.
 
 ### Report Bugs
-+If you encounter any bug, please check for existing issues or file a new one on [the project page](https://github.com/pantsbuild/intellij-pants-plugin/issues).
+If you encounter any bug, please check for existing issues or file a new one on [the project page](https://github.com/pantsbuild/intellij-pants-plugin/issues).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # intellij-pants-plugin
 
 * The intellij-pants-plugin supports importing, compiling and testing [Pants](http://pantsbuild.github.io/) projects.
-* Scala and Java projects are supported, and Python projects are not supported but works in terms of code navigation and assistance.
+* Scala and Java projects are fully supported. Python projects are not supported but work in terms of code navigation and assistance.
 * As of 5/5/2016, latest version of the plugin only works with IntelliJ IDEA 2016.1.1 and up.
 
 ## User documentation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * The intellij-pants-plugin supports importing, compiling and testing [Pants](http://pantsbuild.github.io/) projects.
 * Scala and Java projects are fully supported. Python projects are not supported but work in terms of code navigation and assistance.
-* As of 5/5/2016, latest version of the plugin only works with IntelliJ IDEA 2016.1.1 and up.
+* As of 5/5/2016, latest version of the plugin supports IntelliJ IDEA 2016.1.1 and up for both Community Edition and Ultimate Edition.
 * The plugin supports up to 10 most recent [Pants releases](https://pantsbuild.github.io/changelog.html).
 
 ## User documentation

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # intellij-pants-plugin
 
-* The intellij-pants-plugin supports importing, compiling and testing [pants](http://pantsbuild.github.io/) projects.
-* The plugin only supports Scala and Java projects.
-* As of 12/10/2015, latest version of the plugin only works with IntelliJ IDEA 15.0.0 and >=15.0.2. Do not use 15.0.1.
+* The intellij-pants-plugin supports importing, compiling and testing [Pants](http://pantsbuild.github.io/) projects.
+* Scala and Java projects are supported, and Python projects are not supported but works in terms of code navigation and assistance.
+* As of 5/5/2016, latest version of the plugin only works with IntelliJ IDEA 2016.1.1 and up.
 
 ## User documentation
 
@@ -11,25 +11,25 @@ Please use “Plugins” tab: (Main menu: Settings | Plugins) to install the plu
 Find "Pants Support" plugin. Install and Restart IntelliJ.
 
 #### Importing an entire project directory
-  * Use Main menu: File -> Import Project(in IJ 14.1+: File -> New -> Project From Existing Sources)
+  * Use Main menu: File -> New -> Project From Existing Sources
   * Select project directory
      ![Import project from directory](images/import_dir1.png)
   * Choose "Pants" on the next screen
   * Make sure the check box "All Targets in the directory" is enabled and proceed with the wizard
 
 #### Importing targets from a BUILD File
-  * Use Main menu: File -> Import Project(in IJ 14.1+: File -> New -> Project From Existing Sources)
+  * Use Main menu: File -> New -> Project From Existing Sources
   * Select a Build File from within the project
      ![Import project from BUILD file](images/import_file1.png)
   * Check the targets you want to Import and proceed with the wizard. (Please wait for the targets to show up)
      ![Choose Targets](images/import_file2.png)
 
 #### Importing targets from a script
-  * Use Main menu: File -> Import Project(in IJ 14.1+: File -> New -> Project From Existing Sources)
+  * Use Main menu: File -> New -> Project From Existing Sources
   * Select an executable that will use export goal to produce a desirable project structure.
     See [an integration test](testData/testprojects/intellij-integration/export1.sh) as an example.
 
-#### Importing several BUILD files/directories(works in IntelliJ 14.1+)
+#### Importing multiple BUILD files/directories
   * Import the first directory/BUILD file
   * Use File -> New -> Module From Existing Sources to import next directories/BUILD files
 
@@ -51,7 +51,7 @@ The plugin can invoke any Pants commands via Pants Tasks.
     ![Bundle Task](images/tasks/bundle_task.png)
 
 #### Predefined Pants Tasks for test targets
-The plugin can preconfigure test Tasks from a context.
+The plugin can also generate test configurations.
 
 For example if a test class is opened then with a right click it's easy to create a task to run and debug
     ![Run Configuration Producer](images/tasks/create_task_from_context_single.png)
@@ -61,14 +61,9 @@ With a right click in Project View it's easy to create a test task to run all te
     ![Run Configuration Producer](images/tasks/create_task_from_context_all.png)
 
 ### Compilation
-The plugin provides two ways to compile your project:
-* via pants' compile goal (Default)
-  The plugin will use `pants compile <list of targets>` to compile your project once a `Make` command is invoked.
+* Pants' compile goal (Default)
+  The plugin will use `pants compile <list of targets>` to compile your project once a `Make` or `PantsCompile` command is invoked.
   ![Compilation via compile goal ](images/compilation_via_compile_goal.png)
-* via IntelliJ's scala/java compilers
-  Because the plugin configured all modules' dependencies IntelliJ can use this information to build and run your project without
-  invoking pants. Using just internal representation of the project's model. We recommend to use first option to be consistent with
-  command line invocation.
 
 Compilation options can be configured in Preferences -> Build, Execution, Deployment -> Compiler -> Pants:
 ![Compilation Options](images/compilation_options.png)
@@ -81,192 +76,14 @@ Compilation options can be configured in Preferences -> Build, Execution, Deploy
   ![Project Files Tree View](images/project_files_tree_view.png)
   "Project Files Tree View" also provides an ability to filter out files that weren't loaded during project generation.
   ![Show Only Loaded Files](images/show_only_loaded_files.jpg)
-* BUILD File code assistance
-  The plugin provides auto completion for target names in a BUILD file such as `jar_library`, `scala_library`, etc.
-  As well as completion for dependencies' addresses.
 * Project Regeneration using IntelliJ Action.
   If you add a dependency to your project, you can re-resolve project using IntelliJ Action in background.
   Use Main Menu: Help -> Find Action or Short hand Cmd+Shift+A and select Action "Refresh all External Projects"
   Remember to check "Include non-menu actions"
   ![Refresh Project](images/refresh_action.png)
-* Compiling within IntelliJ
 * Running tests within IntelliJ
   You can right click on tests and run tests.
-* Open dependents of targets
-  To perform a refactoring of a common target you need to change all targets that depend on the given target.
-  To load such dependents using the plugin simply open Preferences -> Build Tools -> Pants and check Load Dependents Transitively.
-  ![Load Dependents](images/load_dependents.png)
 
 ### Report Bugs
 If you see any bugs please file a github issue on the project page.
-Attach your `idea.log` ([location instructions](https://intellij-support.jetbrains.com/entries/23352446-Locating-IDE-log-files))
-
-For contributing to the project, continue reading below.
-
-### How the plugin works
-
-The plugin uses `pants resolve export <list of imported targets>` command to get an information
-about an imported project. `pants resolve export <list of imported targets>` command returns information
-about all targets that are needed to be imported for the project in JSON format. It contains information about all dependencies of a target
-as well as the same information for each dependency. Then the plugin creates an IntelliJ module for each target, configures
-dependencies(modules and libraries) and source roots.
-
-Let's check an output of `./pants export examples/src/java/org/pantsbuild/example/hello/main:main-bin` command:
-
-```json
-{
-    "libraries": {},
-    "targets": {
-        "examples/src/java/org/pantsbuild/example/hello/greet:greet": {
-            "is_code_gen": false,
-            "target_type": "SOURCE",
-            "libraries": [],
-            "pants_target_type": "java_library",
-            "targets": [],
-            "roots": [
-                {
-                    "source_root": "/Users/fkorotkov/workspace/pants/examples/src/java/org/pantsbuild/example/hello/greet",
-                    "package_prefix": "org.pantsbuild.example.hello.greet"
-                }
-            ]
-        },
-        "examples/src/java/org/pantsbuild/example/hello/main:main-bin": {
-            "is_code_gen": false,
-            "target_type": "SOURCE",
-            "libraries": [],
-            "pants_target_type": "jvm_binary",
-            "targets": [
-                "examples/src/java/org/pantsbuild/example/hello/greet:greet",
-                "examples/src/resources/org/pantsbuild/example/hello:hello"
-            ],
-            "roots": [
-                {
-                    "source_root": "/Users/fkorotkov/workspace/pants/examples/src/java/org/pantsbuild/example/hello/main",
-                    "package_prefix": "org.pantsbuild.example.hello.main"
-                }
-            ]
-        },
-        "examples/src/resources/org/pantsbuild/example/hello:hello": {
-            "is_code_gen": false,
-            "target_type": "RESOURCE",
-            "libraries": [],
-            "pants_target_type": "resources",
-            "targets": [],
-            "roots": [
-                {
-                    "source_root": "/Users/fkorotkov/workspace/pants/examples/src/resources/org/pantsbuild/example/hello",
-                    "package_prefix": "org.pantsbuild.example.hello"
-                }
-            ]
-        }
-    }
-}
-```
-
-The plugin will create three modules. One for the imported target, examples/src/java/com/pants/examples/hello/main:main-bin
-and two for the targets it depends on. It also will configure source roots for the modules and will use `target_type`
-and `is_code_gen` fields to figure out types of source roots(there are several types of source roots: sources,
-test sources, resources, test resources, generated sources, etc).
-
-## Contributing Guidelines:
-
-* Checkout the code
-
-        git clone https://github.com/pantsbuild/intellij-pants-plugin
-
-* Create a new branch off master to make your changes
-
-        git checkout -b $FEATURE_BRANCH
-
-* Push your branch and pass travis ci
-
-
-* Post your first review ([setup instructions](http://pantsbuild.github.io/howto_contribute.html#code-review))
-
-        ./rbt post -o -g
-
-* Iterating over the review
-
-        ./rbt post -o -r <RB_ID>
-
-* Committing your change to master
-
-        git checkout master
-        git pull
-        ./rbt patch -c <RB_ID>
-
-### IntelliJ project setup:
-
-* Download and open IntelliJ IDEA 15 Community Edition
-* Install Python, Scala, and Gradle Plugins
-* Open the project via File -> Open, then select the plugin source folder. Do not import the plugin source as pants project because the plugin does not work on itself.
-* Use IntelliJ IDEA 15 Community Edition as IDEA IC SDK. Project Structure(Cmd + ;) -> SDK -> '+' button -> IntelliJ Platform Plugin SDK
-* Setup the SDK's classpath
-  * Add the following to the SDK's classpath
-    * `~/Library/Application Support/IdeaIC15/python/lib/python.jar`
-    * `~/Library/Application Support/IdeaIC15/Scala/lib/scala-plugin.jar`
-    * `~/Library/Application Support/IdeaIC15/Scala/lib/jps/*.jar`
-    * `/Applications/IntelliJ IDEA 15 CE.app/Contents/plugins/gradle/lib/gradle.jar`
-    * `/Applications/IntelliJ IDEA 15 CE.app/Contents/plugins/junit/lib/idea-junit.jar`
-* Set Scala 2.11.2 as your Scala SDK
-* Make sure that your project is set to configure bytecode compatible with 1.6.  Preferences -> Compiler -> Java Compiler -> Project bytecode version
-* Run tests to verify your installation
-
-### Release process:
-* Create a new release branch from the latest master. E.g. `git checkout -b 1.3.14`
-* In plugin.xml:
-  * Update `<version>`. E.g. `1.3.14`
-  * Make sure of since/until build number for target IDEA versions.
-  * Add the changes to `<change-notes>`.
-* Submit review with green Travis CI.
-* Once shipit, patch the change in master and push to upstream.
-* Create git tag with release number in master. E.g. `git tag release_1.3.14`
-* Push the tag. E.g. `git push upstream release_1.3.14`. Fill out the release notes on github.
-* Distribution:
-  * Create an account at https://account.jetbrains.com/login. Request access to the plugin repo via https://pantsbuild.github.io/howto_contribute.html#join-the-conversation.
-  * Build -> Build Artifacts -> pants -> rebuild. Artifacts will be in `out/artifacts/pants`.
-  * Zip `out/artifacts/pants` folder into `pants.zip`.
-  * Validate the plugin manually in IntelliJ: Preferences -> Plugins -> Install from disk -> pick newly created `pants.zip`.
-  * Upload `pants.zip` to https://plugins.jetbrains.com/plugin/7412.
-
-### Debugging the Plugin from local pants development:
-
-* To debug tests execute:
-
-        ./scripts/run-tests-ci.sh --jvm-test-debug
-
-  It will listen for a debugger on 5005 port by default.
-
-  Create a Remote Run Configuration in IntelliJ. By default it uses 5005 port as well.
-
-  Hit debug button to connect to Pants.
-
-* If you want to debug plugin using your local development pants, you can do so by using the property `pants.executable.path`.
-  Add this configuration to Pants Run config.
-  e.g.
-
-        -Dpants.executable.path=/path/to/pants_dev/pants
-
-* To debug JPS compiler use:
-
-        -Dcompiler.process.debug.port=PORT
-
-* Remember to bootstrap pants in the project repository inside which you want to test the plugin.
-
-        cd ~/workspace/example_project
-        /path/to/pants_dev/pants goals
-
-  This will bootstrap pants and resolve all the dependencies or else you will get an `ExecutionException` exception for exceeding 30s timeout.
-
-# Running plugin tests with Pants
-
-* Use `./scripts/setup-ci-environment.sh` with targeted `IJ_VERSION` and `IJ_BUILD_NUMBER`
-  environment variables from `.travis.yml` file to load everything for running tests. For example:
-
-        IJ_VERSION="15.0" IJ_BUILD_NUMBER="143.381" ./scripts/setup-ci-environment.sh
-
-* Execute `./scripts/run-tests-ci.sh` from command-line.
-* Running individual test. For example:
-
-        ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest#testJaxb
-
+Attach the error stacktrace or `idea.log` ([location instructions](https://intellij-support.jetbrains.com/entries/23352446-Locating-IDE-log-files))

--- a/README.md
+++ b/README.md
@@ -85,5 +85,4 @@ Compilation options can be configured in Preferences -> Build, Execution, Deploy
   You can right click on tests and run tests.
 
 ### Report Bugs
-If you see any bugs please file a github issue on the project page.
-Attach the error stacktrace or `idea.log` ([location instructions](https://intellij-support.jetbrains.com/entries/23352446-Locating-IDE-log-files))
++If you encounter any bug, please check for existing issues or file a new one on [the project page](https://github.com/pantsbuild/intellij-pants-plugin/issues).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 * The intellij-pants-plugin supports importing, compiling and testing [Pants](http://pantsbuild.github.io/) projects.
 * Scala and Java projects are fully supported. Python projects are not supported but work in terms of code navigation and assistance.
 * As of 5/5/2016, latest version of the plugin only works with IntelliJ IDEA 2016.1.1 and up.
+* The plugin supports up to 10 most recent [Pants releases](https://pantsbuild.github.io/changelog.html).
 
 ## User documentation
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -8,6 +8,13 @@
   <change-notes>
     <![CDATA[
 
+      <p>1.4.1</p>
+      <ul>
+        <li>IntelliJ IDEA 2016 Compatbility.</li>
+        <li>Classpaths loading efficiency and hygiene improvement.</li>
+        <li>Pants options parsing optimization.</li>
+      </ul>
+
       <p>1.3.15</p>
       <ul>
         <li>Performance
@@ -225,7 +232,7 @@
       </ul>
       ]]>
   </change-notes>
-  <version>1.3.15</version>
+  <version>1.4.1</version>
   <vendor>Twitter, Inc.</vendor>
 
   <!--if you are changing since-build don't forget to change it in .travis.yml file as well-->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -10,8 +10,8 @@
 
       <p>1.4.1</p>
       <ul>
-        <li>IntelliJ IDEA 2016 Compatbility.</li>
-        <li>Classpaths loading efficiency and hygiene improvement.</li>
+        <li>IntelliJ IDEA 2016 Compatibility.</li>
+        <li>Classpath loading efficiency and hygiene improvement.</li>
         <li>Pants options parsing optimization.</li>
       </ul>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -10,9 +10,7 @@
 
       <p>1.4.1</p>
       <ul>
-        <li>IntelliJ IDEA 2016 Compatibility.</li>
-        <li>Classpath loading efficiency and hygiene improvement.</li>
-        <li>Pants options parsing optimization.</li>
+        <li><a href="https://github.com/pantsbuild/intellij-pants-plugin/releases">Please see release notes.</a></li>
       </ul>
 
       <p>1.3.15</p>


### PR DESCRIPTION
* mark version 1.4.1 and change notes
* separte contributing.md from readme.md
* update readme.md for 2016
* remove build file assistance, load dependees as we know they dont work well.
* remove intellij compile (gone a while ago).

There is more to refine the README in terms of examples and workflow. This RB only gets rid of the incorrect parts.