### PR TITLE
Running ng-killall in plugin integration tests tearDown

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -261,6 +261,11 @@ public class PantsUtil {
     return null;
   }
 
+  public static GeneralCommandLine defaultCommandLine(@NotNull Project project) throws PantsException {
+    VirtualFile pantsExecutable = PantsUtil.findPantsExecutable(project);
+    return defaultCommandLine(pantsExecutable.getPath());
+  }
+
   public static GeneralCommandLine defaultCommandLine(@NotNull String projectPath) throws PantsException {
     final File pantsExecutable = PantsUtil.findPantsExecutable(new File(projectPath));
     if (pantsExecutable == null) {

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -163,7 +163,7 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
   }
 
   protected void killNailgun() throws ExecutionException {
-    final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(myProjectRoot.getPath());
+    final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(myProject);
     commandLine.addParameter("ng-killall");
     // Wait for command to finish.
     PantsUtil.getCmdOutput(commandLine, null);

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -3,6 +3,7 @@
 
 package com.twitter.intellij.pants.testFramework;
 
+import com.google.common.base.Joiner;
 import com.intellij.compiler.impl.ModuleCompileScope;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ProgramRunnerUtil;
@@ -336,11 +337,6 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
   }
 
   private List<String> assertCompilerMessages(List<CompilerMessage> messages) {
-    StringBuffer fullMessages = new StringBuffer();
-    for (CompilerMessage msg : messages) {
-      fullMessages.append(msg).append("\n");
-    }
-
     for (CompilerMessage message : messages) {
       final VirtualFile virtualFile = message.getVirtualFile();
       final String prettyMessage =
@@ -352,7 +348,8 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
       switch (message.getCategory()) {
         case ERROR:
           // Always show full error messages.
-          fail("Compilation failed with error: " + fullMessages.toString());
+
+          fail("Compilation failed with error: " + Joiner.on('\n').join(messages));
           break;
         case WARNING:
           System.out.println("Compilation warning: " + prettyMessage);

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -161,6 +161,12 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
     assertTrue("Failed to execute: " + StringUtil.join(args, " "), cmdOutput.getExitCode() == 0);
   }
 
+  protected void killNailgun() throws ExecutionException {
+    final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(myProjectRoot.getPath());
+    commandLine.addParameter("ng-killall");
+    commandLine.createProcess();
+  }
+
   @NotNull
   abstract protected File getProjectFolder();
 
@@ -494,6 +500,9 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
       if (myCompilerTester != null) {
         myCompilerTester.tearDown();
       }
+
+      // Kill nailgun after usage as memory on travis is limited, at a cost of slower later builds.
+      killNailgun();
       cleanProjectRoot();
       Messages.setTestDialog(TestDialog.DEFAULT);
     }

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -164,7 +164,8 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
   protected void killNailgun() throws ExecutionException {
     final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(myProjectRoot.getPath());
     commandLine.addParameter("ng-killall");
-    commandLine.createProcess();
+    // Wait for command to finish.
+    PantsUtil.getCmdOutput(commandLine, null);
   }
 
   @NotNull

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -163,7 +163,9 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
   }
 
   protected void killNailgun() throws ExecutionException {
-    final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(myProject);
+    // NB: the ideal interface here is defaultCommandLine(myProject). However,
+    // not all tests call doImport therefore myProject may not always contain modules.
+    final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(getProjectPath());
     commandLine.addParameter("ng-killall");
     // Wait for command to finish.
     PantsUtil.getCmdOutput(commandLine, null);

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -329,6 +329,11 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
   }
 
   private List<String> assertCompilerMessages(List<CompilerMessage> messages) {
+    StringBuffer fullMessages = new StringBuffer();
+    for (CompilerMessage msg : messages) {
+      fullMessages.append(msg).append("\n");
+    }
+
     for (CompilerMessage message : messages) {
       final VirtualFile virtualFile = message.getVirtualFile();
       final String prettyMessage =
@@ -339,7 +344,8 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
         );
       switch (message.getCategory()) {
         case ERROR:
-          fail("Compilation failed with error: " + prettyMessage);
+          // Always show full error messages.
+          fail("Compilation failed with error: " + fullMessages.toString());
           break;
         case WARNING:
           System.out.println("Compilation warning: " + prettyMessage);

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsExamplesMultiTargetsIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsExamplesMultiTargetsIntegrationTest.java
@@ -6,13 +6,7 @@ package com.twitter.intellij.pants.integration;
 import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
 
 public class OSSPantsExamplesMultiTargetsIntegrationTest extends OSSPantsIntegrationTest {
-  public void testEmpty() {
-    // Unfortunately this is in junit 3 we need at least one method starts with 'test'.
-    // Remove once https://github.com/pantsbuild/intellij-pants-plugin/issues/133 is addressed.
-  }
-
-  // TODO (peiyu) https://github.com/pantsbuild/intellij-pants-plugin/issues/133
-  public void IGNORE_testHello() throws Throwable {
+  public void testHello() throws Throwable {
     doImport("examples/src/java/org/pantsbuild/example/hello");
 
     assertModules(


### PR DESCRIPTION
`Abnormal build process termination` in #133 was due to: 

* tests:all using rglobs is getting bigger and bigger
* More integration tests are added, https://rbcommons.com/s/twitter/r/3819/ added a few previously missed.

Now after running some number pants commands, the ng processes left on travis reaches a limit
and crashed later java process.

We saw this behavior at Twitter as well. Solution there is to turn on ng only for compile, plus
running ng-killall at the very beginning of remote execution (consists serveral pants runs).

Here added is to run ng-killall in `tearDown` as a cleanup, at a cost of increasing the overall
test time, but that hopefully we can address via #137 