### PR TITLE
Improve the setup script when copying jdk libs

### DIFF
--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -2,7 +2,12 @@
 source scripts/prepare-ci-environment.sh
 mkdir -p .cache/intellij/$FULL_IJ_BUILD_NUMBER
 
-if [ ! -d .cache/jdk-libs ]; then
+if [ -z $JAVA_HOME ]; then
+  echo "Please set JAVA_HOME"
+  exit 1
+fi
+
+if [ ! -f .cache/jdk-libs/sa-jdi.jar ] || [ ! -f .cache/jdk-libs/tools.jar ] ; then
   echo "Copying JDK libs..."
   mkdir -p .cache/jdk-libs
   cp "$JAVA_HOME/lib/sa-jdi.jar" "$JAVA_HOME/lib/tools.jar" .cache/jdk-libs


### PR DESCRIPTION
Before that change, if the copy operation would fail the `.cache/jdk-libs`
directory would still get created, making subsequent execution skip that
phase. It happened to me that JAVA_HOME wasn't defined for instance.