### PR TITLE
Use working dir name as the project name

### DIFF
--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -116,8 +116,17 @@ public class PantsCompileOptionsExecutor {
       //noinspection ConstantConditions
       return PantsUtil.fileNameWithoutExtension(VfsUtil.extractFileName(myOptions.getExternalProjectPath()));
     }
-    final String targetsSuffix = myOptions.getTargetNames().isEmpty() ? ":" : StringUtil.join(myOptions.getTargetNames(), " :");
-    return getProjectRelativePath() + "/:" + targetsSuffix;
+    String projectRelativePath = getProjectRelativePath();
+    String projectName = getWorkingDir().getName();
+    if (!projectRelativePath.equals(".")) {
+      projectName += File.separator + projectRelativePath;
+    }
+
+    if (myOptions.getTargetNames().isEmpty()) {
+      return projectName;
+    } else {
+      return projectName + ":" + StringUtil.join(myOptions.getTargetNames(), " :");
+    }
   }
 
   @NotNull @Nls

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -122,11 +122,10 @@ public class PantsCompileOptionsExecutor {
       projectName += File.separator + projectRelativePath;
     }
 
-    if (myOptions.getTargetNames().isEmpty()) {
-      return projectName;
-    } else {
-      return projectName + ":" + StringUtil.join(myOptions.getTargetNames(), " :");
+    for (String targetName: myOptions.getTargetNames()) {
+      projectName += ":" + targetName;
     }
+    return projectName;
   }
 
   @NotNull @Nls

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -195,6 +195,10 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
     return myCompilerTester;
   }
 
+  protected void assertProjectName(String name) {
+    assertEquals(name, myProject.getName());
+  }
+
   protected void assertScalaLibrary(String moduleName) throws Exception {
     assertModuleLibDep(moduleName, "Pants: org.scala-lang:scala-library:2.10.4");
   }

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsExamplesMultiTargetsIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsExamplesMultiTargetsIntegrationTest.java
@@ -9,6 +9,8 @@ public class OSSPantsExamplesMultiTargetsIntegrationTest extends OSSPantsIntegra
   public void testHello() throws Throwable {
     doImport("examples/src/java/org/pantsbuild/example/hello");
 
+    assertProjectName("pants/examples/src/java/org/pantsbuild/example/hello");
+
     assertModules(
       "examples_src_resources_org_pantsbuild_example_hello_hello",
       "examples_src_java_org_pantsbuild_example_hello_main_main",
@@ -24,6 +26,7 @@ public class OSSPantsExamplesMultiTargetsIntegrationTest extends OSSPantsIntegra
     );
 
     doImport("examples/src/scala/org/pantsbuild/example/hello/BUILD", "hello");
+    assertProjectName("pants/examples/src/scala/org/pantsbuild/example/hello:hello");
 
     assertModules(
       "examples_src_resources_org_pantsbuild_example_hello_hello",

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsFromScriptIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsFromScriptIntegrationTest.java
@@ -9,6 +9,8 @@ public class OSSPantsFromScriptIntegrationTest extends OSSPantsIntegrationTest {
   public void testScript() throws Throwable {
     doImport("intellij-integration/export1.sh");
 
+    assertProjectName("export1");
+
     assertModules(
       "examples_src_resources_org_pantsbuild_example_hello_hello",
       "examples_src_java_org_pantsbuild_example_hello_main_main",


### PR DESCRIPTION
Given a project:
```
development
  + my-project
     - pants.init
     - pants
     + src
        + core
           - BUILD (with two targets: `t1` and `t2`)
```

Here are the new project name rules when importing:
 * `my-project::` -> `my-project`
 * `my-project\src\core::` -> `my-project\src\core`
 * `my-project\src\core:t1` -> `my-project\src\core:t1`