### PR TITLE
[IntelliJ] Update Pants, Caching, Sharding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ jdk:
 
 cache:
   directories:
+    - ${HOME}/.cache/pants
     - .cache/bootstrap # See pants.ini [cache.bootstrap]
     - .cache/pants     # Pants downloaded by scripts/setup-ci-environment.sh
 
@@ -20,13 +21,11 @@ install: ./scripts/setup-ci-environment.sh
 # General policy is to support pants for the past 10 releases and the latest master.
 env:
   matrix:
-    - IJ_ULTIMATE=false
+    - IJ_ULTIMATE=false PANTS_TEST_JUNIT_TEST_SHARD=0/2
+    - IJ_ULTIMATE=false PANTS_TEST_JUNIT_TEST_SHARD=1/2
     - IJ_ULTIMATE=true
-    - PANTS_SHA="release_1.2.0rc3" TEST_SET=jvm-integration
-    - PANTS_SHA="release_1.2.0dev11" TEST_SET=jvm-integration
-    - PANTS_SHA="release_1.2.0dev10" TEST_SET=jvm-integration
-    - PANTS_SHA="release_1.2.0dev8" TEST_SET=jvm-integration
-    - PANTS_SHA="release_1.2.0-dev6" TEST_SET=jvm-integration
+    - PANTS_SHA="release_1.3.0dev1" TEST_SET=jvm-integration
+    - PANTS_SHA="release_1.2.0" TEST_SET=jvm-integration
     - PANTS_SHA="release_1.1.0" TEST_SET=jvm-integration
 
 script:

--- a/pants.ini
+++ b/pants.ini
@@ -5,7 +5,7 @@ local_artifact_cache = %(buildroot)s/.cache
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [GLOBAL]
-pants_version: 1.2.0rc3
+pants_version: 1.2.0
 print_exception_stacktrace: True
 pants_ignore: +[
     'out/',


### PR DESCRIPTION
* Update IntelliJ to run against Pants major releases, current unstable releases, and master.
* Divide the first shard into 2, because it has more than 2x of the tests than other shard.
* Cache {HOME}/.cache/pants like pants repo does.
* Update Pants to 1.2.0