### PR TITLE
Revert "Release 1.4.10"

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
       </ul>
       ]]>
   </change-notes>
-  <version>1.4.10</version>
+  <version>1.4.9</version>
   <vendor>Twitter, Inc.</vendor>
 
   <!--if you are changing since-build don't forget to change it in .travis.yml file as well-->


### PR DESCRIPTION
Reverts pantsbuild/intellij-pants-plugin#225 because it is supposed to be a major version bump for IntelliJ 2016.3