### PR TITLE
Conform to standard plugin distribution zip format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,4 @@ script:
 
 after_success:
   - scripts/deploy/deploy.sh
+  - find /tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
 
 after_success:
   - scripts/deploy/deploy.sh
-  - find /tmp
+  - find tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - PANTS_SHA="release_1.1.0" TEST_SET=jvm-integration
 
 script:
-  - zip -r
+  - echo '123'
 #  - ./scripts/run-tests-ci.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ env:
     - PANTS_SHA="release_1.1.0" TEST_SET=jvm-integration
 
 script:
-  - ./scripts/run-tests-ci.sh
+  - zip -r
+#  - ./scripts/run-tests-ci.sh
 
 after_success:
   - scripts/deploy/deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,7 @@ env:
     - PANTS_SHA="release_1.1.0" TEST_SET=jvm-integration
 
 script:
-  - echo '123'
-#  - ./scripts/run-tests-ci.sh
+  - ./scripts/run-tests-ci.sh
 
 after_success:
   - scripts/deploy/deploy.sh
-  - find tmp

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -68,12 +68,12 @@ if __name__ == "__main__":
                  '-username {username} ' \
                  '-password \'{password}\' ' \
                  '-plugin {plugin_id} ' \
-                 '-file {FINAL_ZIP}' \
+                 '-file {zip}' \
       .format(channel=CHANNEL,
               username=os.environ['USERNAME'],
               password=os.environ['PASSWORD'],
               plugin_id=PLUGIN_ID,
-              plugin_jar=PLUGIN_JAR)
+              zip=FINAL_ZIP)
 
     logger.info('Uploading...')
 

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -9,7 +9,6 @@ PLUGIN_XML = 'resources/META-INF/plugin.xml'
 PLUGIN_ID = 7412
 PLUGIN_JAR = 'dist/intellij-pants-plugin.jar'
 PACKAGING_DIR = 'intellij-pants-plugin/lib'
-FINAL_ZIP = 'pants.zip'
 CHANNEL = 'BleedingEdge'
 REPO = 'https://plugins.jetbrains.com/plugin/7412'
 
@@ -34,6 +33,7 @@ if __name__ == "__main__":
   subprocess.check_output('git checkout {}'.format(PLUGIN_XML), shell=True)
 
   sha = get_head_sha()
+  zip_name = 'pants_{}.zip'.format(sha)
   logger.info('Append git sha {} to plugin version'.format(sha))
 
   tree = ET.parse(PLUGIN_XML)
@@ -57,7 +57,7 @@ if __name__ == "__main__":
 
       logger.info("Packaging into a zip")
       packaging_cmd = 'mkdir -p {package}; cp {jar} {package}; zip -r {zip} {package}' \
-        .format(package=PACKAGING_DIR, jar=PLUGIN_JAR, zip=FINAL_ZIP)
+        .format(package=PACKAGING_DIR, jar=PLUGIN_JAR, zip=zip_name)
       subprocess.check_output(packaging_cmd, shell=True, stderr=devnull)
 
     finally:
@@ -75,7 +75,7 @@ if __name__ == "__main__":
               username=os.environ['USERNAME'],
               password=os.environ['PASSWORD'],
               plugin_id=PLUGIN_ID,
-              zip=FINAL_ZIP)
+              zip=zip_name)
 
     logger.info('Uploading...')
 

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -58,12 +58,11 @@ if __name__ == "__main__":
       logger.info("Packaging into a zip")
       # Move the jar under pants/lib, but because there is already `pants` under build root,
       # we have to create a temp dir, then build the zip there.
-      packaging_cmd = 'mkdir -p tmp &&' \
-                      'mkdir -p tmp/pants/lib && ' \
+      packaging_cmd = 'mkdir -p tmp/pants/lib && ' \
                       'cp {jar} tmp/pants/lib && ' \
-                      'pushd tmp && ' \
+                      'cd tmp && ' \
                       'zip -r {zip} pants/ &&' \
-                      'popd &&' \
+                      'cd .. &&' \
                       'cp tmp/{zip} {zip} &&' \
                       'rm -rf tmp' \
         .format(jar=PLUGIN_JAR, zip=zip_name)

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -8,6 +8,8 @@ import xml.etree.ElementTree as ET
 PLUGIN_XML = 'resources/META-INF/plugin.xml'
 PLUGIN_ID = 7412
 PLUGIN_JAR = 'dist/intellij-pants-plugin.jar'
+PACKAGING_DIR = 'intellij-pants-plugin/lib'
+FINAL_ZIP = 'pants.zip'
 CHANNEL = 'BleedingEdge'
 REPO = 'https://plugins.jetbrains.com/plugin/7412'
 
@@ -52,6 +54,10 @@ if __name__ == "__main__":
                   './pants binary scripts/sdk:intellij-pants-plugin-publish'
       logger.info(build_cmd)
       subprocess.check_output(build_cmd, shell=True, stderr=devnull)
+
+      logger.info("Packaging into a zip")
+      packaging_cmd = 'mkdir -p {package}; cp {jar} {package}; zip -r {zip} {package}' \
+        .format(package=PACKAGING_DIR, jar=PLUGIN_JAR, zip=FINAL_ZIP)
     finally:
       # Reset `PLUGIN_XML` since it has been modified.
       subprocess.check_output('git checkout {}'.format(PLUGIN_XML), shell=True, stderr=devnull)
@@ -62,7 +68,7 @@ if __name__ == "__main__":
                  '-username {username} ' \
                  '-password \'{password}\' ' \
                  '-plugin {plugin_id} ' \
-                 '-file {plugin_jar}' \
+                 '-file {FINAL_ZIP}' \
       .format(channel=CHANNEL,
               username=os.environ['USERNAME'],
               password=os.environ['PASSWORD'],

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -58,6 +58,8 @@ if __name__ == "__main__":
       logger.info("Packaging into a zip")
       packaging_cmd = 'mkdir -p {package}; cp {jar} {package}; zip -r {zip} {package}' \
         .format(package=PACKAGING_DIR, jar=PLUGIN_JAR, zip=FINAL_ZIP)
+      subprocess.check_output(packaging_cmd, shell=True, stderr=devnull)
+
     finally:
       # Reset `PLUGIN_XML` since it has been modified.
       subprocess.check_output('git checkout {}'.format(PLUGIN_XML), shell=True, stderr=devnull)

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -33,7 +33,6 @@ if __name__ == "__main__":
   subprocess.check_output('git checkout {}'.format(PLUGIN_XML), shell=True)
 
   sha = get_head_sha()
-  zip_name = 'pants_{}.zip'.format(sha)
   logger.info('Append git sha {} to plugin version'.format(sha))
 
   tree = ET.parse(PLUGIN_XML)
@@ -47,6 +46,8 @@ if __name__ == "__main__":
 
   version.text = "{}.{}".format(version.text, sha)
   tree.write(PLUGIN_XML)
+
+  zip_name = 'pants_{}.zip'.format(version.text)
 
   with open(os.devnull, 'w') as devnull:
     try:

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# if [ "$TRAVIS_BRANCH" == "master" ]; then
+if [ "$TRAVIS_BRANCH" == "master" ]; then
   source scripts/prepare-ci-environment.sh
   ./scripts/deploy/deploy.py
-# fi
+fi

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -2,4 +2,6 @@
 if [ "$TRAVIS_BRANCH" == "master" ]; then
   source scripts/prepare-ci-environment.sh
   ./scripts/deploy/deploy.py
+else
+  echo "Not on master. Skip deployment."
 fi

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ "$TRAVIS_BRANCH" == "master" ]; then
+# if [ "$TRAVIS_BRANCH" == "master" ]; then
   source scripts/prepare-ci-environment.sh
   ./scripts/deploy/deploy.py
-fi
+# fi


### PR DESCRIPTION
Previously after the plugin binary is built, the deploy script will directly upload the jar `intellij-pants-plugin.jar`, but it does not conform to the standard plugin distribution format. 

This change moves the jar into `pants/lib/intellij-pants-plugin.jar` then produces and upload a zip in this structure.