### PR TITLE
[Trivial] Cleanup and refactoring

### DIFF
--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -95,20 +95,7 @@ public class TargetAddressInfo {
            getGlobs().hasFileExtension("py");
   }
 
-  public boolean isAnnotationProcessor() {
-    return StringUtil.equals("annotation_processor", getInternalPantsTargetType());
-  }
-
   public boolean isJarLibrary() {
     return StringUtil.equals("jar_library", getInternalPantsTargetType());
-  }
-
-  public String getCanonicalId() {
-    if (getId() != null) {
-      return getId();
-    }
-    else {
-      return PantsUtil.getCanonicalTargetId(targetAddress);
-    }
   }
 }

--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -4,8 +4,6 @@
 package com.twitter.intellij.pants.model;
 
 import com.intellij.openapi.util.text.StringUtil;
-import com.twitter.intellij.pants.util.PantsUtil;
-import com.twitter.intellij.pants.model.Globs;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/common/com/twitter/intellij/pants/util/PantsOutputMessage.java
+++ b/common/com/twitter/intellij/pants/util/PantsOutputMessage.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.util.Objects;
 
 public class PantsOutputMessage {
   private final int myStart;
@@ -71,9 +72,9 @@ public class PantsOutputMessage {
   }
 
   /**
-   * @param line of an output
+   * @param line                 the output
    * @param onlyCompilerMessages will look only for compiler specific message e.g. with a log level
-   * @param checkFileExistence will check if the parsed {@code myFilePath} exists
+   * @param checkFileExistence   will check if the parsed {@code myFilePath} exists
    */
   @Nullable
   public static PantsOutputMessage parseMessage(@NotNull String line, boolean onlyCompilerMessages, boolean checkFileExistence) {
@@ -82,7 +83,8 @@ public class PantsOutputMessage {
     final boolean isWarning = isWarning(line);
     if (isError || isWarning || line.contains("[debug]")) {
       i = line.indexOf(']') + 1;
-    } else if (onlyCompilerMessages) {
+    }
+    else if (onlyCompilerMessages) {
       return null;
     }
     while (i < line.length() && (Character.isSpaceChar(line.charAt(i)) || line.charAt(i) == '\t')) {
@@ -134,7 +136,7 @@ public class PantsOutputMessage {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    PantsOutputMessage message = (PantsOutputMessage)o;
+    PantsOutputMessage message = (PantsOutputMessage) o;
 
     if (myEnd != message.myEnd) return false;
     if (myLineNumber != message.myLineNumber) return false;
@@ -147,11 +149,12 @@ public class PantsOutputMessage {
 
   @Override
   public int hashCode() {
-    int result = myStart;
-    result = 31 * result + myEnd;
-    result = 31 * result + myLineNumber;
-    result = 31 * result + (myFilePath != null ? myFilePath.hashCode() : 0);
-    result = 31 * result + (myLevel != null ? myLevel.hashCode() : 0);
-    return result;
+    return Objects.hash(
+      myStart,
+      myEnd,
+      myLineNumber,
+      myFilePath,
+      myLevel
+    );
   }
 }

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -100,7 +100,7 @@ public class PantsUtil {
   public static final ScheduledExecutorService scheduledThreadPool = Executors.newSingleThreadScheduledExecutor(
     new ThreadFactory() {
       @Override
-      public Thread newThread(Runnable r) {
+      public Thread newThread(@NotNull Runnable r) {
         return new Thread(r, "Pants-Plugin-Pool");
       }
     });

--- a/src/com/twitter/intellij/pants/components/impl/PantsMetrics.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsMetrics.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbServiceImpl;
 import com.intellij.openapi.project.Project;
 import com.twitter.intellij.pants.util.PantsUtil;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.FileWriter;
@@ -117,7 +118,7 @@ public class PantsMetrics {
     indexThreadPool = Executors.newSingleThreadScheduledExecutor(
       new ThreadFactory() {
         @Override
-        public Thread newThread(Runnable r) {
+        public Thread newThread(@NotNull Runnable r) {
           return new Thread(r, "Pants-Plugin-Metrics-Pool");
         }
       });

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.TestOnly;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -205,11 +206,11 @@ public class PantsCompileOptionsExecutor {
       commandLine.addParameter("--export-libraries-javadocs");
     }
 
-    commandLine.addParameters(getAllTargetAddresses());
-    System.out.println(getAllTargetAddresses());
+    commandLine.addParameters(getTargetSpecs());
+    System.out.println(getTargetSpecs());
     if (getOptions().isWithDependees()) {
       statusConsumer.consume("Looking for dependents...");
-      commandLine.addParameters(loadDependees(getAllTargetAddresses()));
+      commandLine.addParameters(loadDependees(getTargetSpecs()));
     }
 
     commandLine.addParameter("--export-output-file=" + outputFile.getPath());
@@ -235,9 +236,9 @@ public class PantsCompileOptionsExecutor {
   }
 
   @NotNull
-  private List<String> getAllTargetAddresses() {
+  private List<String> getTargetSpecs() {
     // If project is opened via pants cli, the targets are in specs.
-    return getOptions().getTargetSpecs();
+    return Collections.unmodifiableList(getOptions().getTargetSpecs());
   }
 
   /**

--- a/src/com/twitter/intellij/pants/service/project/model/ContentRoot.java
+++ b/src/com/twitter/intellij/pants/service/project/model/ContentRoot.java
@@ -8,11 +8,11 @@ import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+// FIXME: Change `source_root` argument to `content_root` once it is corrected in Pants.
 public class ContentRoot implements Comparable<ContentRoot> {
   private String source_root;
   private String package_prefix;
 
-  // FIXME: Change `source_root` argument to `content_root` once it is corrected in Pants.
   public ContentRoot(@NotNull String source_root, @NotNull String package_prefix) {
     this.source_root = source_root;
     this.package_prefix = package_prefix;

--- a/src/com/twitter/intellij/pants/service/project/model/ContentRoot.java
+++ b/src/com/twitter/intellij/pants/service/project/model/ContentRoot.java
@@ -8,11 +8,12 @@ import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class SourceRoot implements Comparable<SourceRoot> {
+public class ContentRoot implements Comparable<ContentRoot> {
   private String source_root;
   private String package_prefix;
 
-  public SourceRoot(@NotNull String source_root, @NotNull String package_prefix) {
+  // FIXME: Change `source_root` argument to `content_root` once it is corrected in Pants.
+  public ContentRoot(@NotNull String source_root, @NotNull String package_prefix) {
     this.source_root = source_root;
     this.package_prefix = package_prefix;
   }
@@ -42,7 +43,7 @@ public class SourceRoot implements Comparable<SourceRoot> {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    SourceRoot root = (SourceRoot)o;
+    ContentRoot root = (ContentRoot)o;
 
     if (!package_prefix.equals(root.package_prefix)) return false;
     if (!source_root.equals(root.source_root)) return false;
@@ -61,14 +62,14 @@ public class SourceRoot implements Comparable<SourceRoot> {
   @Override
   public String toString() {
     return String.format(
-      "SourceRoot{'source_root='%s', package_prefix='%s'}",
+      "ContentRoot{'source_root='%s', package_prefix='%s'}",
       source_root,
       package_prefix
     );
   }
 
   @Override
-  public int compareTo(@NotNull SourceRoot o) {
+  public int compareTo(@NotNull ContentRoot o) {
     return StringUtil.naturalCompare(getRawSourceRoot(), o.getRawSourceRoot());
   }
 }

--- a/src/com/twitter/intellij/pants/service/project/model/ContentRoot.java
+++ b/src/com/twitter/intellij/pants/service/project/model/ContentRoot.java
@@ -8,8 +8,8 @@ import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-// FIXME: Change `source_root` argument to `content_root` once it is corrected in Pants.
 public class ContentRoot implements Comparable<ContentRoot> {
+  // FIXME: Change `source_root` argument to `content_root` once it is corrected in Pants.
   private String source_root;
   private String package_prefix;
 

--- a/src/com/twitter/intellij/pants/service/project/model/ProjectInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/ProjectInfo.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -66,7 +67,7 @@ public class ProjectInfo {
   }
 
   public Map<String, LibraryInfo> getLibraries() {
-    return libraries;
+    return Collections.unmodifiableMap(libraries);
   }
 
   public void setLibraries(Map<String, LibraryInfo> libraries) {
@@ -78,7 +79,7 @@ public class ProjectInfo {
   }
 
   public Map<String, TargetInfo> getTargets() {
-    return targets;
+    return Collections.unmodifiableMap(targets);
   }
 
   public void setTargets(Map<String, TargetInfo> targets) {

--- a/src/com/twitter/intellij/pants/service/project/model/PythonInterpreterInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/PythonInterpreterInfo.java
@@ -5,6 +5,8 @@ package com.twitter.intellij.pants.service.project.model;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 public class PythonInterpreterInfo {
   @NotNull
   private String binary;
@@ -42,8 +44,9 @@ public class PythonInterpreterInfo {
 
   @Override
   public int hashCode() {
-    int result = binary.hashCode();
-    result = 31 * result + chroot.hashCode();
-    return result;
+    return Objects.hash(
+      binary,
+      chroot
+    );
   }
 }

--- a/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
@@ -39,7 +39,7 @@ public class TargetInfo {
   /**
    * List of source roots.
    */
-  protected Set<SourceRoot> roots = Collections.emptySet();
+  protected Set<ContentRoot> roots = Collections.emptySet();
 
   public TargetInfo(TargetAddressInfo... addressInfos) {
     setAddressInfos(ContainerUtil.newHashSet(addressInfos));
@@ -50,7 +50,7 @@ public class TargetInfo {
     Set<String> targets,
     Set<String> libraries,
     Set<String> excludes,
-    Set<SourceRoot> roots
+    Set<ContentRoot> roots
   ) {
     setAddressInfos(addressInfos);
     setLibraries(libraries);
@@ -95,12 +95,12 @@ public class TargetInfo {
   }
 
   @NotNull
-  public Set<SourceRoot> getRoots() {
+  public Set<ContentRoot> getRoots() {
     return roots;
   }
 
-  public void setRoots(Set<SourceRoot> roots) {
-    this.roots = new TreeSet<SourceRoot>(roots);
+  public void setRoots(Set<ContentRoot> roots) {
+    this.roots = new TreeSet<ContentRoot>(roots);
   }
 
   public boolean isEmpty() {

--- a/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
@@ -104,7 +104,7 @@ public class TargetInfo {
   }
 
   public boolean isEmpty() {
-    return libraries.isEmpty() && targets.isEmpty() && roots.isEmpty();
+    return libraries.isEmpty() && targets.isEmpty() && roots.isEmpty() && addressInfos.isEmpty();
   }
 
   @Nullable

--- a/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
@@ -152,13 +152,6 @@ public class TargetInfo {
     return PantsSourceType.SOURCE;
   }
 
-  /**
-   * @return true if not an actual target
-   */
-  public boolean isDummy() {
-    return addressInfos.isEmpty();
-  }
-
   public boolean isJarLibrary() {
     return getAddressInfos().stream().allMatch(TargetAddressInfo::isJarLibrary);
   }

--- a/src/com/twitter/intellij/pants/service/project/model/TargetInfoDeserializer.java
+++ b/src/com/twitter/intellij/pants/service/project/model/TargetInfoDeserializer.java
@@ -24,12 +24,12 @@ public class TargetInfoDeserializer implements JsonDeserializer<TargetInfo> {
     final List<String> targets = getStringListField(object, "targets");
     final List<String> libraries = getStringListField(object, "libraries");
     final List<String> excludes = getStringListField(object, "excludes");
-    final List<SourceRoot> sourceRoots = getFieldAsList(
+    final List<ContentRoot> contentRoots = getFieldAsList(
       object.getAsJsonArray("roots"),
-      new Function<JsonElement, SourceRoot>() {
+      new Function<JsonElement, ContentRoot>() {
         @Override
-        public SourceRoot fun(JsonElement element) {
-          return context.deserialize(element, SourceRoot.class);
+        public ContentRoot fun(JsonElement element) {
+          return context.deserialize(element, ContentRoot.class);
         }
       }
     );
@@ -39,7 +39,7 @@ public class TargetInfoDeserializer implements JsonDeserializer<TargetInfo> {
       new HashSet<String>(targets),
       new HashSet<String>(libraries),
       new HashSet<String>(excludes),
-      new HashSet<SourceRoot>(sourceRoots)
+      new HashSet<ContentRoot>(contentRoots)
     );
   }
 

--- a/src/com/twitter/intellij/pants/service/project/modifier/PantsSourceRootCompressor.java
+++ b/src/com/twitter/intellij/pants/service/project/modifier/PantsSourceRootCompressor.java
@@ -7,7 +7,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.twitter.intellij.pants.service.PantsCompileOptionsExecutor;
 import com.twitter.intellij.pants.service.project.PantsProjectInfoModifierExtension;
 import com.twitter.intellij.pants.service.project.model.ProjectInfo;
-import com.twitter.intellij.pants.service.project.model.SourceRoot;
+import com.twitter.intellij.pants.service.project.model.ContentRoot;
 import com.twitter.intellij.pants.service.project.model.TargetInfo;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
@@ -26,16 +26,16 @@ public class PantsSourceRootCompressor implements PantsProjectInfoModifierExtens
   }
 
   @NotNull
-  private Set<SourceRoot> compressRootsIfPossible(@NotNull Set<SourceRoot> roots) {
-    final Set<String> packageRoots = roots.stream().map(SourceRoot::getPackageRoot).collect(Collectors.toSet());
+  private Set<ContentRoot> compressRootsIfPossible(@NotNull Set<ContentRoot> roots) {
+    final Set<String> packageRoots = roots.stream().map(ContentRoot::getPackageRoot).collect(Collectors.toSet());
     if (packageRoots.size() != 1) {
       return roots;
     }
     final String packageRoot = packageRoots.iterator().next();
-    final Set<File> sourceRoots = roots.stream().map(SourceRoot::getRawSourceRoot).map(File::new).collect(Collectors.toSet());
+    final Set<File> sourceRoots = roots.stream().map(ContentRoot::getRawSourceRoot).map(File::new).collect(Collectors.toSet());
 
     if (folderContainsOnlyRoots(new File(packageRoot), sourceRoots)) {
-      return Collections.singleton(new SourceRoot(packageRoot, ""));
+      return Collections.singleton(new ContentRoot(packageRoot, ""));
     }
     return roots;
   }

--- a/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
+++ b/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
@@ -15,8 +15,8 @@ import com.intellij.util.containers.ContainerUtilRt;
 import com.twitter.intellij.pants.model.PantsSourceType;
 import com.twitter.intellij.pants.service.PantsCompileOptionsExecutor;
 import com.twitter.intellij.pants.service.project.PantsResolverExtension;
+import com.twitter.intellij.pants.service.project.model.ContentRoot;
 import com.twitter.intellij.pants.service.project.model.ProjectInfo;
-import com.twitter.intellij.pants.service.project.model.SourceRoot;
 import com.twitter.intellij.pants.service.project.model.TargetInfo;
 import com.twitter.intellij.pants.service.project.model.graph.BuildGraph;
 import com.twitter.intellij.pants.util.PantsConstants;
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 public class PantsSourceRootsExtension implements PantsResolverExtension {
 
-  private static String getSourceRootRegardingTargetType(@NotNull TargetInfo targetInfo, @NotNull SourceRoot root) {
+  private static String getSourceRootRegardingTargetType(@NotNull TargetInfo targetInfo, @NotNull ContentRoot root) {
     return doNotSupportPackagePrefixes(targetInfo) ? root.getPackageRoot() : root.getRawSourceRoot();
   }
 
@@ -70,7 +70,7 @@ public class PantsSourceRootsExtension implements PantsResolverExtension {
   }
 
   private void createContentRoots(@NotNull DataNode<ModuleData> moduleDataNode, @NotNull final TargetInfo targetInfo) {
-    final Set<SourceRoot> roots = targetInfo.getRoots();
+    final Set<ContentRoot> roots = targetInfo.getRoots();
     if (roots.isEmpty()) {
       return;
     }
@@ -79,7 +79,7 @@ public class PantsSourceRootsExtension implements PantsResolverExtension {
       final ContentRootData contentRoot = new ContentRootData(PantsConstants.SYSTEM_ID, baseRoot);
       moduleDataNode.createChild(ProjectKeys.CONTENT_ROOT, contentRoot);
 
-      for (SourceRoot sourceRoot : roots) {
+      for (ContentRoot sourceRoot : roots) {
         final String sourceRootPathToAdd = getSourceRootRegardingTargetType(targetInfo, sourceRoot);
         if (FileUtil.isAncestor(baseRoot, sourceRootPathToAdd, false)) {
           try {
@@ -99,7 +99,7 @@ public class PantsSourceRootsExtension implements PantsResolverExtension {
   }
 
   @NotNull
-  private List<String> findBaseRoots(@NotNull final TargetInfo targetInfo, Set<SourceRoot> roots) {
+  private List<String> findBaseRoots(@NotNull final TargetInfo targetInfo, Set<ContentRoot> roots) {
     Set<String> allRoots = roots.stream()
       .map(root -> getSourceRootRegardingTargetType(targetInfo, root))
       .collect(Collectors.toSet());

--- a/src/com/twitter/intellij/pants/service/python/PythonInfoModifier.java
+++ b/src/com/twitter/intellij/pants/service/python/PythonInfoModifier.java
@@ -29,14 +29,14 @@ public class PythonInfoModifier implements PantsProjectInfoModifierExtension {
   ) {
     TargetInfo sources = null;
     TargetInfo tests = null;
-    final Set<String> allPythonTargets = ContainerUtilRt.newHashSet();
+    final Set<String> pythonTargetNames = ContainerUtilRt.newHashSet();
     for (Map.Entry<String, TargetInfo> entry : projectInfo.getTargets().entrySet()) {
       final String targetName = entry.getKey();
       final TargetInfo targetInfo = entry.getValue();
       if (!targetInfo.isPythonTarget()) {
         continue;
       }
-      allPythonTargets.add(targetName);
+      pythonTargetNames.add(targetName);
       if (targetInfo.isTest()) {
         tests = tests == null ? targetInfo : tests.union(targetInfo);
       } else {
@@ -46,19 +46,19 @@ public class PythonInfoModifier implements PantsProjectInfoModifierExtension {
     if (sources == null) {
       return;
     }
-    projectInfo.removeTargets(allPythonTargets);
-    if (!allPythonTargets.isEmpty() && log.isDebugEnabled()) {
-      log.debug(String.format("Combining %d python targets", allPythonTargets.size()));
+    projectInfo.removeTargets(pythonTargetNames);
+    if (!pythonTargetNames.isEmpty() && log.isDebugEnabled()) {
+      log.debug(String.format("Combining %d python targets", pythonTargetNames.size()));
     }
 
-    sources.getTargets().removeAll(allPythonTargets);
-    projectInfo.getTargets().put("python:src", sources);
+    sources.getTargets().removeAll(pythonTargetNames);
+    projectInfo.addTarget("python:src", sources);
     if (tests != null) {
       // make sure src and test don't have common roots
       sources.getRoots().removeAll(tests.getRoots());
-      tests.getTargets().removeAll(allPythonTargets);
+      tests.getTargets().removeAll(pythonTargetNames);
       tests.getTargets().add("python:src");
-      projectInfo.getTargets().put("python:tests", tests);
+      projectInfo.addTarget("python:tests", tests);
     }
   }
 }

--- a/src/com/twitter/intellij/pants/service/python/PythonInfoModifier.java
+++ b/src/com/twitter/intellij/pants/service/python/PythonInfoModifier.java
@@ -27,8 +27,8 @@ public class PythonInfoModifier implements PantsProjectInfoModifierExtension {
     @NotNull PantsCompileOptionsExecutor executor,
     @NotNull Logger log
   ) {
-    TargetInfo sources = null;
-    TargetInfo tests = null;
+    TargetInfo sources = new TargetInfo();
+    TargetInfo tests = new TargetInfo();
     final Set<String> pythonTargetNames = ContainerUtilRt.newHashSet();
     for (Map.Entry<String, TargetInfo> entry : projectInfo.getTargets().entrySet()) {
       final String targetName = entry.getKey();
@@ -38,12 +38,12 @@ public class PythonInfoModifier implements PantsProjectInfoModifierExtension {
       }
       pythonTargetNames.add(targetName);
       if (targetInfo.isTest()) {
-        tests = tests == null ? targetInfo : tests.union(targetInfo);
+        tests = tests.union(targetInfo);
       } else {
-        sources = sources == null ? targetInfo : sources.union(targetInfo);
+        sources = sources.union(targetInfo);
       }
     }
-    if (sources == null) {
+    if (sources.isEmpty()) {
       return;
     }
     projectInfo.removeTargets(pythonTargetNames);
@@ -53,7 +53,7 @@ public class PythonInfoModifier implements PantsProjectInfoModifierExtension {
 
     sources.getTargets().removeAll(pythonTargetNames);
     projectInfo.addTarget("python:src", sources);
-    if (tests != null) {
+    if (!tests.isEmpty()) {
       // make sure src and test don't have common roots
       sources.getRoots().removeAll(tests.getRoots());
       tests.getTargets().removeAll(pythonTargetNames);

--- a/src/com/twitter/intellij/pants/settings/PantsSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsSettings.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.components.StoragePathMacros;
+import com.intellij.openapi.components.StorageScheme;
 import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettings;
 import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListener;
 import com.intellij.openapi.project.Project;
@@ -21,7 +22,13 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 import java.util.Set;
 
-@State(name = "PantsSettings", storages = {@Storage(file = StoragePathMacros.WORKSPACE_FILE)})
+@State(
+  name = "PantsSettings",
+  storages = {
+    @Storage(file = StoragePathMacros.PROJECT_FILE),
+    @Storage(file = StoragePathMacros.PROJECT_CONFIG_DIR + "/pants.xml", scheme = StorageScheme.DIRECTORY_BASED)
+  }
+)
 public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings, PantsProjectSettings, PantsSettingsListener>
   implements PersistentStateComponent<PantsSettings.MyState> {
 
@@ -50,8 +57,8 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
     }
     PantsSettings other = (PantsSettings) obj;
     return Objects.equals(myUseIdeaProjectJdk, other.myUseIdeaProjectJdk)
-           && Objects.equals(myUsePantsMakeBeforeRun, other.myUsePantsMakeBeforeRun)
-           && Objects.equals(myResolverVersion, other.myResolverVersion);
+      && Objects.equals(myUsePantsMakeBeforeRun, other.myUsePantsMakeBeforeRun)
+      && Objects.equals(myResolverVersion, other.myResolverVersion);
   }
 
   public static PantsSettings copy(PantsSettings pantsSettings) {

--- a/src/com/twitter/intellij/pants/settings/PantsSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsSettings.java
@@ -57,8 +57,8 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
     }
     PantsSettings other = (PantsSettings) obj;
     return Objects.equals(myUseIdeaProjectJdk, other.myUseIdeaProjectJdk)
-      && Objects.equals(myUsePantsMakeBeforeRun, other.myUsePantsMakeBeforeRun)
-      && Objects.equals(myResolverVersion, other.myResolverVersion);
+           && Objects.equals(myUsePantsMakeBeforeRun, other.myUsePantsMakeBeforeRun)
+           && Objects.equals(myResolverVersion, other.myResolverVersion);
   }
 
   public static PantsSettings copy(PantsSettings pantsSettings) {

--- a/src/com/twitter/intellij/pants/settings/PantsSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsSettings.java
@@ -8,7 +8,6 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.components.StoragePathMacros;
-import com.intellij.openapi.components.StorageScheme;
 import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettings;
 import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListener;
 import com.intellij.openapi.project.Project;
@@ -22,13 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 import java.util.Set;
 
-@State(
-  name = "PantsSettings",
-  storages = {
-    @Storage(file = StoragePathMacros.PROJECT_FILE),
-    @Storage(file = StoragePathMacros.PROJECT_CONFIG_DIR + "/pants.xml", scheme = StorageScheme.DIRECTORY_BASED)
-  }
-)
+@State(name = "PantsSettings", storages = {@Storage(file = StoragePathMacros.WORKSPACE_FILE)})
 public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings, PantsProjectSettings, PantsSettingsListener>
   implements PersistentStateComponent<PantsSettings.MyState> {
 
@@ -57,8 +50,8 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
     }
     PantsSettings other = (PantsSettings) obj;
     return Objects.equals(myUseIdeaProjectJdk, other.myUseIdeaProjectJdk)
-      && Objects.equals(myUsePantsMakeBeforeRun, other.myUsePantsMakeBeforeRun)
-      && Objects.equals(myResolverVersion, other.myResolverVersion);
+           && Objects.equals(myUsePantsMakeBeforeRun, other.myUsePantsMakeBeforeRun)
+           && Objects.equals(myResolverVersion, other.myResolverVersion);
   }
 
   public static PantsSettings copy(PantsSettings pantsSettings) {

--- a/tests/com/twitter/intellij/pants/metrics/MetricsUnitTest.java
+++ b/tests/com/twitter/intellij/pants/metrics/MetricsUnitTest.java
@@ -38,7 +38,7 @@ public class MetricsUnitTest extends TestCase {
       illegalCalls();
       fail(String.format("%s should have been thrown.", IllegalStateException.class));
     }
-    catch (IllegalStateException e) {
+    catch (IllegalStateException ignored) {
 
     }
   }

--- a/tests/com/twitter/intellij/pants/model/PantsOptionsTest.java
+++ b/tests/com/twitter/intellij/pants/model/PantsOptionsTest.java
@@ -55,7 +55,7 @@ public class PantsOptionsTest extends TestCase {
       PantsOptions.getPantsOptions("some_invalid_pants_path");
       fail(String.format("%s should have been thrown.", PantsException.class));
     }
-    catch (PantsException e) {
+    catch (PantsException ignored) {
 
     }
   }

--- a/tests/com/twitter/intellij/pants/service/project/PantsResolverTestBase.java
+++ b/tests/com/twitter/intellij/pants/service/project/PantsResolverTestBase.java
@@ -18,9 +18,9 @@ import com.intellij.util.containers.ContainerUtil;
 import com.twitter.intellij.pants.model.PantsSourceType;
 import com.twitter.intellij.pants.model.TargetAddressInfo;
 import com.twitter.intellij.pants.service.PantsCompileOptionsExecutor;
+import com.twitter.intellij.pants.service.project.model.ContentRoot;
 import com.twitter.intellij.pants.service.project.model.LibraryInfo;
 import com.twitter.intellij.pants.service.project.model.ProjectInfo;
-import com.twitter.intellij.pants.service.project.model.SourceRoot;
 import com.twitter.intellij.pants.service.project.model.TargetInfo;
 import com.twitter.intellij.pants.testFramework.PantsCodeInsightFixtureTestCase;
 import com.twitter.intellij.pants.util.PantsConstants;
@@ -227,7 +227,7 @@ abstract class PantsResolverTestBase extends PantsCodeInsightFixtureTestCase {
     private Set<String> libraries = new HashSet<String>();
     private Set<String> excludes = new HashSet<String>();
     private Set<String> targets = new HashSet<String>();
-    private Set<SourceRoot> roots = new HashSet<SourceRoot>();
+    private Set<ContentRoot> roots = new HashSet<ContentRoot>();
 
     @Override
     public TargetInfo build() {
@@ -243,7 +243,7 @@ abstract class PantsResolverTestBase extends PantsCodeInsightFixtureTestCase {
 
     public TargetInfoBuilder withRoot(@Nls String rootRelativePath, @NotNull String packagePrefix) {
       final File root = new File(new File(""), rootRelativePath);
-      roots.add(new SourceRoot(root.getAbsolutePath(), packagePrefix));
+      roots.add(new ContentRoot(root.getAbsolutePath(), packagePrefix));
       return this;
     }
 


### PR DESCRIPTION
* Rename class `SourceRoot` to `ContentRoot` because what it really meant
* Rename method `getAllTargetAddresses` to `getTargetSpecs` for the same reason
* Correct annotation on nullity
* Use `Objects.hash` instead of sketchy implementation