### PR TITLE
Fix deploy process for test lib publishing

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -108,7 +108,7 @@
                      groupName="Pants" enabledByDefault="true"
                      implementationClass="com.twitter.intellij.pants.inspection.PythonPluginInspection"/>
 
-    <compileServer.plugin classpath="pants-jps-plugin.jar;pants-common.jar"/>
+    <compileServer.plugin classpath="intellij-pants-plugin-publish.jar"/>
     <buildProcess.parametersProvider implementation="com.twitter.intellij.pants.compiler.PantsBuildProcessParametersProvider"/>
 
     <projectConfigurable instance="com.twitter.intellij.pants.config.PantsProjectCompilerConfigurable"

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -7,7 +7,7 @@ import xml.etree.ElementTree as ET
 
 PLUGIN_XML = 'resources/META-INF/plugin.xml'
 PLUGIN_ID = 7412
-PLUGIN_JAR = 'dist/intellij-pants-plugin.jar'
+PLUGIN_JAR = 'dist/intellij-pants-plugin-publish.jar'
 CHANNEL = 'BleedingEdge'
 REPO = 'https://plugins.jetbrains.com/plugin/7412'
 

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -68,6 +68,7 @@ if __name__ == "__main__":
         .format(jar=PLUGIN_JAR, zip=zip_name)
       logger.info(packaging_cmd)
       subprocess.check_output(packaging_cmd, shell=True, stderr=devnull)
+      logger.info('{} built successfully'.format(zip_name))
 
     finally:
       # Reset `PLUGIN_XML` since it has been modified.

--- a/scripts/sdk/BUILD
+++ b/scripts/sdk/BUILD
@@ -55,7 +55,7 @@ jvm_binary(
 
 jvm_binary(
   name='intellij-pants-plugin-publish',
-  basename='intellij-pants-plugin',
+  basename='intellij-pants-plugin-publish',
   dependencies=[
     'common',
     'jps-plugin',


### PR DESCRIPTION
Earlier published jar has basename='intellij-pants-plugin` so it will overwrite of the test library with the same basename. This change makes it consistent with the target name.