### PR TITLE
Bug fix on GUI import

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -5,10 +5,8 @@ package com.twitter.intellij.pants.util;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.intellij.execution.CommonProgramRunConfigurationParameters;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessOutput;
@@ -71,7 +69,6 @@ import org.jetbrains.jps.model.java.JpsJavaSdkType;
 import org.jetbrains.jps.model.library.JpsLibrary;
 import org.jetbrains.jps.model.library.impl.sdk.JpsSdkImpl;
 import org.jetbrains.jps.model.library.sdk.JpsSdkReference;
-import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration;
 
 import java.io.File;
 import java.io.IOException;
@@ -172,7 +169,7 @@ public class PantsUtil {
    */
   public static boolean isPantsProjectFile(VirtualFile file) {
     if (file.isDirectory()) {
-      return findPantsExecutable(file) != null;
+      return findPantsExecutable(file).isPresent();
     }
     return isBUILDFileName(file.getName());
   }

--- a/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
+++ b/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
@@ -1,0 +1,17 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.util;
+
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+
+public class PantsUtilTest extends OSSPantsIntegrationTest {
+
+  public void testIsPantsProject() {
+    // Current project path should be under a Pants repo.
+    assertTrue(PantsUtil.isPantsProjectFile(LocalFileSystem.getInstance().findFileByPath(getProjectPath())));
+    // File system root should not.
+    assertFalse(PantsUtil.isPantsProjectFile(LocalFileSystem.getInstance().findFileByPath("/")));
+  }
+}

--- a/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
+++ b/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
@@ -8,7 +8,7 @@ import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
 
 public class PantsUtilTest extends OSSPantsIntegrationTest {
 
-  public void testIsPantsProject() {
+  public void testIsPantsProjectFile() {
     // Current project path should be under a Pants repo.
     assertTrue(PantsUtil.isPantsProjectFile(LocalFileSystem.getInstance().findFileByPath(getProjectPath())));
     // File system root should not.


### PR DESCRIPTION
* Fix a bug in finding pants executable
* Move error handling to the appropriate method that throws configuration exceptions, so IntelliJ will display a nice GUI for any import issue instead of treating it as an exception.