### PR TITLE
Langugage level fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - IJ_ULTIMATE=false PANTS_TEST_JUNIT_TEST_SHARD=0/2
     - IJ_ULTIMATE=false PANTS_TEST_JUNIT_TEST_SHARD=1/2
     - IJ_ULTIMATE=true
-    - PANTS_SHA="release_1.3.0dev5" TEST_SET=jvm-integration
+    - PANTS_SHA="release_1.3.0.dev5" TEST_SET=jvm-integration
     - PANTS_SHA="release_1.2.1rc0" TEST_SET=jvm-integration
     - PANTS_SHA="release_1.2.0" TEST_SET=jvm-integration
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - IJ_ULTIMATE=false PANTS_TEST_JUNIT_TEST_SHARD=1/2
     - IJ_ULTIMATE=true
     - PANTS_SHA="release_1.3.0.dev5" TEST_SET=jvm-integration
-    - PANTS_SHA="release_1.2.1rc0" TEST_SET=jvm-integration
+    - PANTS_SHA="release_1.2.1" TEST_SET=jvm-integration
     - PANTS_SHA="release_1.2.0" TEST_SET=jvm-integration
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ env:
     - IJ_ULTIMATE=false PANTS_TEST_JUNIT_TEST_SHARD=0/2
     - IJ_ULTIMATE=false PANTS_TEST_JUNIT_TEST_SHARD=1/2
     - IJ_ULTIMATE=true
-    - PANTS_SHA="release_1.3.0dev1" TEST_SET=jvm-integration
+    - PANTS_SHA="release_1.3.0dev5" TEST_SET=jvm-integration
+    - PANTS_SHA="release_1.2.1rc0" TEST_SET=jvm-integration
     - PANTS_SHA="release_1.2.0" TEST_SET=jvm-integration
-    - PANTS_SHA="release_1.1.0" TEST_SET=jvm-integration
 
 script:
   - ./scripts/run-tests-ci.sh

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -780,6 +780,7 @@ public class PantsUtil {
     if (!jdkHome.isPresent()) {
       return Optional.empty();
     }
+
     Sdk jdk = JavaSdk.getInstance().createJdk(jdkName, jdkHome.get());
     return Optional.of(jdk);
   }

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -768,7 +768,7 @@ public class PantsUtil {
     String jdkName = "1.x_from_pants";
     for (String version : ContainerUtil.newArrayList("6", "7", "8", "9")) {
       if (defaultPlatform.contains(version)) {
-        jdkName = String.format("1.%s_from_pants", version);
+        jdkName = String.format("1.%s_from_%s", version, pantsExecutable);
         break;
       }
     }

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -763,7 +763,15 @@ public class PantsUtil {
     }
 
     final String defaultPlatform = exportResult.getJvmPlatforms().getDefaultPlatform();
-    final String jdkName = String.format("JDK from pants %s", defaultPlatform);
+
+    // if defaultPlatform is java8, then jdkName should be 1.8_from_pants
+    String jdkName = "1.x_from_pants";
+    for (String version : ContainerUtil.newArrayList("6", "7", "8", "9")) {
+      if (defaultPlatform.contains(version)) {
+        jdkName = String.format("1.%s_from_pants", version);
+        break;
+      }
+    }
 
     boolean strict = PantsOptions.getPantsOptions(pantsExecutable)
       .get(PantsConstants.PANTS_OPTION_TEST_JUNIT_STRICT_JVM_VERSION)
@@ -772,7 +780,8 @@ public class PantsUtil {
     if (!jdkHome.isPresent()) {
       return Optional.empty();
     }
-    return Optional.of(JavaSdk.getInstance().createJdk(jdkName, jdkHome.get()));
+    Sdk jdk = JavaSdk.getInstance().createJdk(jdkName, jdkHome.get());
+    return Optional.of(jdk);
   }
 
   /**

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -781,8 +781,7 @@ public class PantsUtil {
       return Optional.empty();
     }
 
-    Sdk jdk = JavaSdk.getInstance().createJdk(jdkName, jdkHome.get());
-    return Optional.of(jdk);
+    return Optional.of(JavaSdk.getInstance().createJdk(jdkName, jdkHome.get()));
   }
 
   /**

--- a/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
@@ -8,7 +8,9 @@ import com.intellij.execution.RunManager;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.impl.RunManagerImpl;
 import com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl;
+import com.intellij.openapi.roots.LanguageLevelProjectExtension;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.pom.java.LanguageLevel;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -79,5 +81,17 @@ abstract public class OSSPantsIntegrationTest extends PantsIntegrationTestCase {
    */
   protected void assertEmptyBeforeRunTask(RunConfiguration configuration) {
     assertEmpty(getBeforeRunTask(configuration));
+  }
+
+  /**
+   * Assert Project has the right JDK (JVM project only).
+   */
+  protected void assertProjectJdk() {
+    LanguageLevel projectLanguageLevel = LanguageLevelProjectExtension.getInstance(myProject).getLanguageLevel();
+    LanguageLevel expectedLanguageLevel = LanguageLevel.JDK_1_8;
+    assertTrue(
+      String.format("Project Language Level should be %s, but is %s", expectedLanguageLevel, projectLanguageLevel),
+      projectLanguageLevel.equals(LanguageLevel.JDK_1_8)
+    );
   }
 }

--- a/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
@@ -9,8 +9,10 @@ import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.impl.RunManagerImpl;
 import com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl;
 import com.intellij.openapi.roots.LanguageLevelProjectExtension;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.pom.java.LanguageLevel;
+import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -84,14 +86,19 @@ abstract public class OSSPantsIntegrationTest extends PantsIntegrationTestCase {
   }
 
   /**
-   * Assert Project has the right JDK (JVM project only).
+   * Assert Project has the right JDK and language level (JVM project only).
    */
-  protected void assertProjectJdk() {
+  protected void assertProjectJdkAndLanguageLevel() {
     LanguageLevel projectLanguageLevel = LanguageLevelProjectExtension.getInstance(myProject).getLanguageLevel();
     LanguageLevel expectedLanguageLevel = LanguageLevel.JDK_1_8;
     assertTrue(
       String.format("Project Language Level should be %s, but is %s", expectedLanguageLevel, projectLanguageLevel),
       projectLanguageLevel.equals(LanguageLevel.JDK_1_8)
+    );
+
+    assertEquals(
+      ProjectRootManager.getInstance(myProject).getProjectSdk().getHomePath(),
+      PantsUtil.getDefaultJavaSdk(getParentPath()).get().getHomePath()
     );
   }
 }

--- a/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
@@ -89,16 +89,16 @@ abstract public class OSSPantsIntegrationTest extends PantsIntegrationTestCase {
    * Assert Project has the right JDK and language level (JVM project only).
    */
   protected void assertProjectJdkAndLanguageLevel() {
+    assertEquals(
+      ProjectRootManager.getInstance(myProject).getProjectSdk().getHomePath(),
+      PantsUtil.getDefaultJavaSdk(getParentPath()).get().getHomePath()
+    );
+
     LanguageLevel projectLanguageLevel = LanguageLevelProjectExtension.getInstance(myProject).getLanguageLevel();
     LanguageLevel expectedLanguageLevel = LanguageLevel.JDK_1_8;
     assertTrue(
       String.format("Project Language Level should be %s, but is %s", expectedLanguageLevel, projectLanguageLevel),
       projectLanguageLevel.equals(LanguageLevel.JDK_1_8)
-    );
-
-    assertEquals(
-      ProjectRootManager.getInstance(myProject).getProjectSdk().getHomePath(),
-      PantsUtil.getDefaultJavaSdk(getParentPath()).get().getHomePath()
     );
   }
 }

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -132,9 +132,6 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
   protected void setUpInWriteAction() throws Exception {
     super.setUpInWriteAction();
 
-    //final Sdk sdk = JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk();
-    //ProjectRootManager.getInstance(myProject).setProjectSdk(sdk);
-
     cleanProjectRoot();
 
     myProjectRoot = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(getProjectFolder());

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -38,8 +38,7 @@ import com.intellij.openapi.externalSystem.test.ExternalSystemImportingTestCase;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.ui.Messages;
@@ -133,8 +132,8 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
   protected void setUpInWriteAction() throws Exception {
     super.setUpInWriteAction();
 
-    final Sdk sdk = JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk();
-    ProjectRootManager.getInstance(myProject).setProjectSdk(sdk);
+    //final Sdk sdk = JavaAwareProjectJdkTableImpl.getInstanceEx().getInternalJdk();
+    //ProjectRootManager.getInstance(myProject).setProjectSdk(sdk);
 
     cleanProjectRoot();
 
@@ -346,6 +345,16 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
     System.out.println("Import: " + projectFolderPathToImport);
     myRelativeProjectPath = projectFolderPathToImport;
     myProjectSettings.setTargetSpecs(PantsUtil.convertToTargetSpecs(projectFolderPathToImport, Arrays.asList(targetNames)));
+    ApplicationManager.getApplication().runWriteAction(new Runnable() {
+      @Override
+      public void run() {
+        PantsUtil.getDefaultJavaSdk(getProjectPath())
+          .ifPresent(sdk -> {
+            ProjectJdkTable.getInstance().addJdk(sdk);
+            ProjectRootManager.getInstance(myProject).setProjectSdk(sdk);
+          });
+      }
+    });
     importProject();
     PantsMetrics.markIndexEnd();
   }

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
@@ -38,7 +38,8 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
       "org.pantsbuild.example.annotation.example.Example", "examples_src_java_org_pantsbuild_example_annotation_example_example"
     );
     assertClassFileInModuleOutput(
-      "org.pantsbuild.example.annotation.processor.ExampleProcessor", "examples_src_java_org_pantsbuild_example_annotation_processor_processor"
+      "org.pantsbuild.example.annotation.processor.ExampleProcessor",
+      "examples_src_java_org_pantsbuild_example_annotation_processor_processor"
     );
   }
 
@@ -74,6 +75,7 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
 
   public void testHello() throws Throwable {
     doImport("examples/src/java/org/pantsbuild/example/hello");
+    assertProjectJdk();
 
     String[] initialModules = {
       "examples_src_resources_org_pantsbuild_example_hello_hello",
@@ -195,7 +197,7 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
   }
 
   private String[] getModulesNamesFromPantsDependencies(String targetName) throws ProjectBuildException {
-    Optional<VirtualFile>  pantsExe = PantsUtil.findPantsExecutable(myProject);
+    Optional<VirtualFile> pantsExe = PantsUtil.findPantsExecutable(myProject);
     assertTrue(pantsExe.isPresent());
     final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(pantsExe.get().getPath());
     commandLine.addParameters(PantsConstants.PANTS_CLI_OPTION_NO_COLORS);

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
@@ -75,7 +75,7 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
 
   public void testHello() throws Throwable {
     doImport("examples/src/java/org/pantsbuild/example/hello");
-    assertProjectJdk();
+    assertProjectJdkAndLanguageLevel();
 
     String[] initialModules = {
       "examples_src_resources_org_pantsbuild_example_hello_hello",


### PR DESCRIPTION
## Problem
For a fresh IJ environment, the JDK pants plugin selected cannot be automatically recognized in terms of language level.

## Solution
* Adjust the jdkNames to be `1.8_xxxx` so intellij can automatically pick up the language level
* Remove hardcoded project sdk in test framework and use the jdk created via pants instead, in order to verify the fix works.

## Other change
* Remove pants 1.1.0 from `.travis.yml` since it was old and still uses java6 as default.
* Add 1.2.1
