### PR TITLE
Remove unnecessary project wide file sync to reduce system load

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -163,6 +163,10 @@ public class PantsUtil {
     return StringUtil.equalsIgnoreCase(PantsConstants.BUILD, FileUtil.getNameWithoutExtension(name));
   }
 
+  public static boolean isThriftFileName(@NotNull String name) {
+    return FileUtilRt.getExtension(name).equals("thrift");
+  }
+
   /**
    * Checks if it's a BUILD file or folder under a Pants project
    *

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -167,10 +167,6 @@ public class PantsUtil {
     return StringUtil.equalsIgnoreCase(PantsConstants.BUILD, FileUtil.getNameWithoutExtension(name));
   }
 
-  public static boolean isThriftFileName(@NotNull String name) {
-    return FileUtilRt.getExtension(name).equals("thrift");
-  }
-
   /**
    * Checks if it's a BUILD file or folder under a Pants project
    *
@@ -652,7 +648,7 @@ public class PantsUtil {
 
   @NotNull
   public static String fileNameWithoutExtension(@NotNull String name) {
-    int index = name.lastIndexOf('.' );
+    int index = name.lastIndexOf('.');
     if (index < 0) return name;
     return name.substring(0, index);
   }

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -886,14 +886,14 @@ public class PantsUtil {
       ApplicationManager.getApplication().runWriteAction(() -> {
         FileDocumentManager.getInstance().saveAllDocuments();
         SaveAndSyncHandler.getInstance().refreshOpenFiles();
-        VirtualFileManager.getInstance().refreshWithoutFileWatcher(false); /** synchronous */
+        //VirtualFileManager.getInstance().refreshWithoutFileWatcher(false); /** synchronous */
       });
     }
     else {
       ApplicationManager.getApplication().invokeLater(() -> {
         FileDocumentManager.getInstance().saveAllDocuments();
         SaveAndSyncHandler.getInstance().refreshOpenFiles();
-        VirtualFileManager.getInstance().refreshWithoutFileWatcher(true); /** asynchronous */
+        //VirtualFileManager.getInstance().refreshWithoutFileWatcher(true); /** asynchronous */
       });
     }
   }

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -10,7 +10,10 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessOutput;
+import com.intellij.ide.FrameStateManager;
+import com.intellij.ide.GeneralSettings;
 import com.intellij.ide.SaveAndSyncHandler;
+import com.intellij.ide.SaveAndSyncHandlerImpl;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.ide.util.PropertiesComponent;
@@ -29,6 +32,7 @@ import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.JavaSdk;
 import com.intellij.openapi.projectRoots.Sdk;
@@ -648,7 +652,7 @@ public class PantsUtil {
 
   @NotNull
   public static String fileNameWithoutExtension(@NotNull String name) {
-    int index = name.lastIndexOf('.');
+    int index = name.lastIndexOf('.' );
     if (index < 0) return name;
     return name.substring(0, index);
   }
@@ -889,15 +893,23 @@ public class PantsUtil {
     if (ApplicationManager.getApplication().isUnitTestMode() && ApplicationManager.getApplication().isWriteAccessAllowed()) {
       ApplicationManager.getApplication().runWriteAction(() -> {
         FileDocumentManager.getInstance().saveAllDocuments();
-        SaveAndSyncHandler.getInstance().refreshOpenFiles();
-        //VirtualFileManager.getInstance().refreshWithoutFileWatcher(false); /** synchronous */
+        /**
+         * This is the same as `SaveAndSyncHandler.getInstance().refreshOpenFiles();` below, except using the same thing here
+         * does not work, because in headless mode `SaveAndSyncHandler` is implemented by an empty class
+         * {@link com.intellij.ide.SaveAndSyncHandlerStub}
+         */
+        new SaveAndSyncHandlerImpl(
+          GeneralSettings.getInstance(),
+          ProgressManager.getInstance(),
+          FrameStateManager.getInstance(),
+          FileDocumentManager.getInstance()
+        ).refreshOpenFiles();
       });
     }
     else {
       ApplicationManager.getApplication().invokeLater(() -> {
         FileDocumentManager.getInstance().saveAllDocuments();
         SaveAndSyncHandler.getInstance().refreshOpenFiles();
-        //VirtualFileManager.getInstance().refreshWithoutFileWatcher(true); /** asynchronous */
       });
     }
   }

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -894,7 +894,7 @@ public class PantsUtil {
       ApplicationManager.getApplication().runWriteAction(() -> {
         FileDocumentManager.getInstance().saveAllDocuments();
         /**
-         * This is the same as `SaveAndSyncHandler.getInstance().refreshOpenFiles();` below, except using the same thing here
+         * This is the same as `SaveAndSyncHandler.getInstance().refreshOpenFiles();` in the else statement, except using the same thing here
          * does not work, because in headless mode `SaveAndSyncHandler` is implemented by an empty class
          * {@link com.intellij.ide.SaveAndSyncHandlerStub}
          */

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -3,7 +3,6 @@
 
 package com.twitter.intellij.pants.components.impl;
 
-import com.intellij.compiler.server.BuildManagerListener;
 import com.intellij.execution.RunManagerAdapter;
 import com.intellij.execution.RunManagerEx;
 import com.intellij.execution.RunnerAndConfigurationSettings;
@@ -18,7 +17,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.util.messages.MessageBusConnection;
 import com.twitter.intellij.pants.PantsBundle;
 import com.twitter.intellij.pants.components.PantsProjectComponent;
 import com.twitter.intellij.pants.execution.PantsMakeBeforeRun;
@@ -36,7 +34,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 public class PantsProjectComponentImpl extends AbstractProjectComponent implements PantsProjectComponent {
   protected PantsProjectComponentImpl(Project project) {
@@ -74,7 +71,6 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
             convertToPantsProject();
           }
 
-          registerExternalBuilderListener();
           subscribeToRunConfigurationAddition();
           registerFileListener();
           final AbstractExternalSystemSettings pantsSettings = ExternalSystemApiUtil.getSettings(myProject, PantsConstants.SYSTEM_ID);
@@ -164,35 +160,6 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
         }
       }
     );
-  }
-
-  /**
-   * This registers the listener when IDEA external builder process calls Pants.
-   */
-  private void registerExternalBuilderListener() {
-    MessageBusConnection connection = myProject.getMessageBus().connect();
-    BuildManagerListener buildManagerListener = new BuildManagerListener() {
-      @Override
-      public void beforeBuildProcessStarted(Project project, UUID sessionId) {
-
-      }
-
-      @Override
-      public void buildStarted(Project project, UUID sessionId, boolean isAutomake) {
-
-      }
-
-      @Override
-      public void buildFinished(Project project, UUID sessionId, boolean isAutomake) {
-        /**
-         * Sync files as generated sources may have changed after external compile,
-         * specifically when {@link com.twitter.intellij.pants.jps.incremental.PantsTargetBuilder} finishes,
-         * except this code is run within IDEA core, thus having access to file sync calls.
-         */
-        PantsUtil.synchronizeFiles();
-      }
-    };
-    connection.subscribe(BuildManagerListener.TOPIC, buildManagerListener);
   }
 
   private void registerFileListener() {

--- a/src/com/twitter/intellij/pants/file/FileChangeTracker.java
+++ b/src/com/twitter/intellij/pants/file/FileChangeTracker.java
@@ -6,10 +6,6 @@ package com.twitter.intellij.pants.file;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
-import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
@@ -23,11 +19,9 @@ import com.intellij.openapi.vfs.VirtualFileMoveEvent;
 import com.intellij.openapi.vfs.VirtualFilePropertyEvent;
 import com.twitter.intellij.pants.metrics.PantsExternalMetricsListenerManager;
 import com.twitter.intellij.pants.settings.PantsSettings;
-import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.event.HyperlinkEvent;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -111,40 +105,6 @@ public class FileChangeTracker {
     LOG.debug(String.format("Changed: %s. In project: %s", file.getPath(), inProject));
     if (inProject) {
       markDirty(project);
-      notifyProjectRefreshIfNecessary(file, project);
-    }
-  }
-
-  private static void notifyProjectRefreshIfNecessary(@NotNull VirtualFile file, final Project project) {
-    NotificationListener.Adapter refreshAction = new NotificationListener.Adapter() {
-      @Override
-      protected void hyperlinkActivated(@NotNull Notification notification, @NotNull HyperlinkEvent event) {
-        if (event.getDescription().equals("reimport")) {
-          PantsUtil.refreshAllProjects(project);
-        }
-        notification.expire();
-      }
-    };
-
-    if (PantsUtil.isBUILDFileName(file.getName())) {
-      Notification myNotification = new Notification(
-        PantsConstants.PANTS,
-        "BUILD file(s) changed.",
-        "<a href='reimport'>Refresh Pants Project</a> ",
-        NotificationType.INFORMATION,
-        refreshAction
-      );
-      Notifications.Bus.notify(myNotification, project);
-    }
-    else if (PantsUtil.isThriftFileName(file.getName())) {
-      Notification myNotification = new Notification(
-        PantsConstants.PANTS,
-        "Thrift file(s) changed.",
-        "<a href='reimport'>Refresh Pants Project</a> ",
-        NotificationType.INFORMATION,
-        refreshAction
-      );
-      Notifications.Bus.notify(myNotification, project);
     }
   }
 


### PR DESCRIPTION
## Problem

IDE may spend significant resources trying to synchronize everything in the project scope after every Pants invocation that may have changed the generated code. However, it is not necessary because interactively, changes only need to be reflected to user for the opened files, the rest of synchronization can be done at core's discretion.

## Solution
Remove project wide file sync.

## Test Plan
There is [an existing test](https://github.com/pantsbuild/intellij-pants-plugin/blob/5444abaa9043bb7765b0f47103fae55a73da56d5/tests/com/twitter/intellij/pants/integration/OSSFileSyncIntegrationTest.java#L32-L61) that covers this front. 

## Other change
Remove listener to external builder, because it is no longer in use.