### PR TITLE
Skip looking for JDK when there is one set already

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -81,7 +81,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -739,22 +738,7 @@ public class PantsUtil {
   }
 
   public static Set<String> filterGenTargets(@NotNull Collection<String> addresses) {
-    return new HashSet<String>(
-      ContainerUtil.filter(
-        addresses,
-        new Condition<String>() {
-          @Override
-          public boolean value(String targetAddress) {
-            return !isGenTarget(targetAddress);
-          }
-        }
-      )
-    );
-  }
-
-
-  public static boolean supportExportDefaultJavaSdk(@NotNull final String pantsExecutable) {
-    return versionCompare(SimpleExportResult.getExportResult(pantsExecutable).getVersion(), "1.0.7") >= 0;
+    return addresses.stream().filter(s -> !isGenTarget(s)).collect(Collectors.toSet());
   }
 
   @Nullable

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -31,6 +31,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.JavaSdk;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
 import com.intellij.openapi.roots.ContentEntry;
@@ -758,6 +759,15 @@ public class PantsUtil {
 
   @Nullable
   public static Optional<Sdk> getDefaultJavaSdk(@NotNull final String pantsExecutable) {
+    // If a JDK belongs to this particular `pantsExecutable`, then its name will contain the path to Pants.
+    Optional<Sdk> sdkForPants = Arrays.stream(ProjectJdkTable.getInstance().getAllJdks())
+      .filter(sdk -> sdk.getName().contains(pantsExecutable) && sdk.getSdkType() instanceof JavaSdk)
+      .findFirst();
+
+    if (sdkForPants.isPresent()) {
+      return sdkForPants;
+    }
+
     final SimpleExportResult exportResult = SimpleExportResult.getExportResult(pantsExecutable);
     if (versionCompare(exportResult.getVersion(), "1.0.7") < 0) {
       return Optional.empty();

--- a/pants.ini
+++ b/pants.ini
@@ -5,7 +5,7 @@ local_artifact_cache = %(buildroot)s/.cache
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [GLOBAL]
-pants_version: 1.3.0.dev9
+pants_version: 1.2.0
 print_exception_stacktrace: True
 pants_ignore: +[
     'out/',

--- a/pants.ini
+++ b/pants.ini
@@ -5,7 +5,7 @@ local_artifact_cache = %(buildroot)s/.cache
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [GLOBAL]
-pants_version: 1.2.0
+pants_version: 1.3.0.dev9
 print_exception_stacktrace: True
 pants_ignore: +[
     'out/',

--- a/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportProvider.java
+++ b/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportProvider.java
@@ -48,7 +48,7 @@ public class PantsProjectImportProvider extends AbstractExternalProjectImportPro
     /**
      * Newer export version project sdk can be automatically discovered and configured.
      */
-    AtomicBoolean isSdkConfigured = new AtomicBoolean(false);
+    AtomicBoolean isSdkConfigured = new AtomicBoolean(true);
     String message = PantsBundle.message("pants.default.sdk.config.progress");
     ProgressManager.getInstance().run(new Task.Modal(context.getProject(), message, !CAN_BE_CANCELLED) {
       @Override

--- a/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportProvider.java
+++ b/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportProvider.java
@@ -53,11 +53,6 @@ public class PantsProjectImportProvider extends AbstractExternalProjectImportPro
     ProgressManager.getInstance().run(new Task.Modal(context.getProject(), message, !CAN_BE_CANCELLED) {
       @Override
       public void run(@NotNull ProgressIndicator indicator) {
-        Optional<VirtualFile> pantsExecutable = PantsUtil.findPantsExecutable(context.getProjectFileDirectory());
-        if (pantsExecutable.isPresent()) {
-          isSdkConfigured.set(PantsUtil.supportExportDefaultJavaSdk(pantsExecutable.get().getPath()));
-        }
-
         if (isSdkConfigured.get()) {
           isSdkConfigured.set(isJvmProject(context.getProjectFileDirectory()));
         }

--- a/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
+++ b/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
@@ -3,6 +3,8 @@
 
 package com.twitter.intellij.pants.util;
 
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
@@ -22,9 +24,16 @@ public class PantsUtilTest extends OSSPantsIntegrationTest {
   public void testFindJdk() {
     Optional<File> executable = PantsUtil.findPantsExecutable(getProjectFolder());
     assertTrue(executable.isPresent());
-    Optional<Sdk> sdk_a = PantsUtil.getDefaultJavaSdk(executable.get().getPath());
-    Optional<Sdk> sdk_b = PantsUtil.getDefaultJavaSdk(executable.get().getPath());
-    // Make sure they are identical
-    assertTrue(sdk_a.get() == sdk_b.get());
+    Optional<Sdk> sdkA = PantsUtil.getDefaultJavaSdk(executable.get().getPath());
+    assertTrue(sdkA.isPresent());
+    ApplicationManager.getApplication().runWriteAction(new Runnable() {
+      @Override
+      public void run() {
+        ProjectJdkTable.getInstance().addJdk(sdkA.get());
+      }
+    });
+    Optional<Sdk> sdkB = PantsUtil.getDefaultJavaSdk(executable.get().getPath());
+    //Make sure they are identical.
+    assertTrue(sdkA.get() == sdkB.get());
   }
 }

--- a/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
+++ b/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
@@ -33,7 +33,7 @@ public class PantsUtilTest extends OSSPantsIntegrationTest {
       }
     });
     Optional<Sdk> sdkB = PantsUtil.getDefaultJavaSdk(executable.get().getPath());
-    //Make sure they are identical.
+    // Make sure they are identical, meaning that no new JDK was created on the 2nd find.
     assertTrue(sdkA.get() == sdkB.get());
   }
 }

--- a/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
+++ b/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
@@ -3,8 +3,12 @@
 
 package com.twitter.intellij.pants.util;
 
+import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+
+import java.io.File;
+import java.util.Optional;
 
 public class PantsUtilTest extends OSSPantsIntegrationTest {
 
@@ -13,5 +17,14 @@ public class PantsUtilTest extends OSSPantsIntegrationTest {
     assertTrue(PantsUtil.isPantsProjectFile(LocalFileSystem.getInstance().findFileByPath(getProjectPath())));
     // File system root should not.
     assertFalse(PantsUtil.isPantsProjectFile(LocalFileSystem.getInstance().findFileByPath("/")));
+  }
+
+  public void testFindJdk() {
+    Optional<File> executable = PantsUtil.findPantsExecutable(getProjectFolder());
+    assertTrue(executable.isPresent());
+    Optional<Sdk> sdk_a = PantsUtil.getDefaultJavaSdk(executable.get().getPath());
+    Optional<Sdk> sdk_b = PantsUtil.getDefaultJavaSdk(executable.get().getPath());
+    // Make sure they are identical
+    assertTrue(sdk_a.get() == sdk_b.get());
   }
 }


### PR DESCRIPTION
Other change:
Remove Pants export version >= 1.0.7 because it's always true.