### PR TITLE
Event based project view focusing

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -284,7 +284,8 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
                   }
                 }
               }
-              directoryFocusHandle.cancel(false);
+              final boolean mayInterruptIfRunning = true;
+              directoryFocusHandle.cancel(mayInterruptIfRunning);
             }
           });
         }

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -102,6 +102,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
       new ModuleRootAdapter() {
         @Override
         public void rootsChanged(ModuleRootEvent event) {
+          // Initiate view switch only when project modules have been created.
           new ViewSwitchProcessor(ideProject, projectPath).asyncViewSwitch();
         }
       }

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -35,6 +35,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.util.Consumer;
 import com.intellij.util.messages.MessageBusConnection;
@@ -241,10 +242,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
       /**
        * Make sure the project view opened so the view switch will follow.
        */
-      if (ApplicationManager.getApplication().isUnitTestMode()) {
-        return;
-      }
-      final ToolWindow projectWindow = ToolWindowManager.getInstance(myProject).getToolWindow("Project");
+      final ToolWindow projectWindow = ToolWindowManager.getInstance(myProject).getToolWindow(ToolWindowId.PROJECT_VIEW);
       if (projectWindow == null) {
         return;
       }


### PR DESCRIPTION
## Problem
Previously once project import starts, the code will check periodically whether the project is ready in order to zoom into the import directory, causing GUI to be sluggish every second before project is finally loaded.

## Solution
I have found the right event to subscribe, so zooming will only happen after the project is loaded. 

## Other change
Enable test on zooming.
Clarify code on variable meaning.