### PR TITLE
Fix JDK not set correctly from idea-plugin import

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -777,6 +777,8 @@ public class PantsUtil {
       }
     }
 
+    // Finally if we need to create a new JDK, it needs to be registered in the `ProjectJdkTable` on the IDE level
+    // before it can be used.
     Sdk jdk = JavaSdk.getInstance().createJdk(jdkName, jdkHome.get());
     ApplicationManager.getApplication().invokeAndWait(new Runnable() {
       @Override

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -776,7 +776,15 @@ public class PantsUtil {
         }
       }
     }
-    return Optional.of(JavaSdk.getInstance().createJdk(jdkName, jdkHome.get()));
+
+    Sdk jdk = JavaSdk.getInstance().createJdk(jdkName, jdkHome.get());
+    ApplicationManager.getApplication().invokeAndWait(new Runnable() {
+      @Override
+      public void run() {
+        ApplicationManager.getApplication().runWriteAction(() -> ProjectJdkTable.getInstance().addJdk(jdk));
+      }
+    });
+    return Optional.of(jdk);
   }
 
   /**

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -3,6 +3,7 @@
 
 package com.twitter.intellij.pants.components.impl;
 
+import com.intellij.ProjectTopics;
 import com.intellij.compiler.server.BuildManagerListener;
 import com.intellij.execution.RunManagerAdapter;
 import com.intellij.execution.RunManagerEx;
@@ -14,10 +15,14 @@ import com.intellij.openapi.externalSystem.ExternalSystemManager;
 import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettings;
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.ModuleListener;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.util.Function;
 import com.intellij.util.messages.MessageBusConnection;
 import com.twitter.intellij.pants.PantsBundle;
 import com.twitter.intellij.pants.components.PantsProjectComponent;
@@ -131,6 +136,35 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
           PantsUtil.refreshAllProjects(myProject);
 
           prepareGuiComponents();
+
+          final MessageBusConnection connection = myProject.getMessageBus().connect(myProject);
+          connection.subscribe(
+            ProjectTopics.MODULES, new ModuleListener() {
+              @Override
+              public void moduleAdded(@NotNull Project project, @NotNull Module module) {
+                ApplicationManager.getApplication().runWriteAction(() -> ProjectRootManager.getInstance(project).setProjectSdk(
+                  PantsUtil.getDefaultJavaSdk(PantsUtil.findPantsExecutable(project).get().getPath()).get()
+                ));
+              }
+
+              @Override
+              public void beforeModuleRemoved(@NotNull Project project, @NotNull Module module) {
+
+              }
+
+              @Override
+              public void moduleRemoved(@NotNull Project project, @NotNull Module module) {
+
+              }
+
+              @Override
+              public void modulesRenamed(
+                @NotNull Project project, @NotNull List<Module> modules, @NotNull Function<Module, String> oldNameProvider
+              ) {
+
+              }
+            }
+          );
         }
 
         /**

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -158,9 +158,7 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
                     return;
                   }
 
-                  ProjectRootManager.getInstance(project).setProjectSdk(
-                    sdk.get()
-                  );
+                  ProjectRootManager.getInstance(project).setProjectSdk(sdk.get());
                 });
               }
 

--- a/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportProvider.java
+++ b/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportProvider.java
@@ -5,7 +5,6 @@ package com.twitter.intellij.pants.service.project.wizard;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.intellij.ide.util.projectWizard.ModuleWizardStep;


### PR DESCRIPTION
## Problem
If project is initiated from `idea-plugin` goal, project SDK is not set correctly because
* JDK creation is not registered in the core.
* The step to convert the seed Pants project to full bloom one does not explicitly set the project SDK.

## Solution
Explicitly set JDK if any on `idea-plugin` import.