### PR TITLE
Move registering indexing listener to an earlier stage

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -60,9 +60,6 @@
         <option name="WHILE_BRACE_FORCE" value="1" />
         <option name="FOR_BRACE_FORCE" value="1" />
         <option name="FIELD_ANNOTATION_WRAP" value="0" />
-        <MarkdownNavigatorCodeStyleSettings>
-          <option name="RIGHT_MARGIN" value="72" />
-        </MarkdownNavigatorCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -60,6 +60,9 @@
         <option name="WHILE_BRACE_FORCE" value="1" />
         <option name="FOR_BRACE_FORCE" value="1" />
         <option name="FIELD_ANNOTATION_WRAP" value="0" />
+        <MarkdownNavigatorCodeStyleSettings>
+          <option name="RIGHT_MARGIN" value="72" />
+        </MarkdownNavigatorCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -57,14 +57,24 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
     PantsMetrics.report();
     FileChangeTracker.unregisterProject(myProject);
     PantsConsoleManager.unregisterConsole(myProject);
-    LivePantsMetrics.unregisterDumbModeListener(myProject);
     super.projectClosed();
+  }
+
+  @Override
+  public void initComponent() {
+    super.initComponent();
+    LivePantsMetrics.registerDumbModeListener(myProject);
+  }
+
+  @Override
+  public void disposeComponent() {
+    super.disposeComponent();
+    LivePantsMetrics.unregisterDumbModeListener(myProject);
   }
 
   @Override
   public void projectOpened() {
     PantsMetrics.initialize();
-    LivePantsMetrics.registerDumbModeListener(myProject);
     PantsConsoleManager.registerConsole(myProject);
     super.projectOpened();
     if (myProject.isDefault()) {


### PR DESCRIPTION
## Problem
Only the indexing duration on the fly is captured, but not for the initial import.

## Solution
Move the listener registration to an earlier, i.e `initComponent` stage.

## Result
Manually tested that indexing data are logged at the initial import as well. There is currently no way to write such test, because the test framework does not mark indexing period, and there is already test covering artificially entering dumb mode at `com.twitter.intellij.pants.extension.PantsExternalMetricsListenerExtensionTest#testDurationIndexing`.