### PR TITLE
Use 2016.3.4 for CI

### DIFF
--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -26,13 +26,13 @@ if [[ $IJ_ULTIMATE == "true" ]]; then
   export FULL_IJ_BUILD_NUMBER="IU-${IJ_BUILD_NUMBER}"
   export EXPECTED_IJ_MD5="440561a9019f05187b73453fc3856403"
   export PYTHON_PLUGIN_ID="Pythonid"
-  export PYTHON_PLUGIN_MD5="b736164c472cb60c216eed9aacdc0ec3"
+  export PYTHON_PLUGIN_MD5="1f34f9075de5ee393f7280e3ee8bfe59"
 else
   export IJ_BUILD="IC-${IJ_VERSION}"
   export FULL_IJ_BUILD_NUMBER="IC-${IJ_BUILD_NUMBER}"
   export EXPECTED_IJ_MD5="bc890f97797f7b5b4bbe233e04aad22f"
   export PYTHON_PLUGIN_ID="PythonCore"
-  export PYTHON_PLUGIN_MD5="f61f0f1cb4980755b31de376ad3ed74a"
+  export PYTHON_PLUGIN_MD5="31301817b75b089d10dba64e17b68fbd"
 fi
 
 # we will use Community ids to download plugins.

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -10,8 +10,8 @@ fi
 # Python plugin for Community and Ultimate Edition
 
 export CWD=$(pwd)
-export IJ_VERSION="2016.3.3"
-export IJ_BUILD_NUMBER="163.11103.6"
+export IJ_VERSION="2016.3.4"
+export IJ_BUILD_NUMBER="163.12024.16"
 
 get_md5(){
   if [[ $OSTYPE == *"darwin"* ]]; then
@@ -24,13 +24,13 @@ get_md5(){
 if [[ $IJ_ULTIMATE == "true" ]]; then
   export IJ_BUILD="IU-${IJ_VERSION}"
   export FULL_IJ_BUILD_NUMBER="IU-${IJ_BUILD_NUMBER}"
-  export EXPECTED_IJ_MD5="b94b85827464cc1441d36febfcac62c0"
+  export EXPECTED_IJ_MD5="440561a9019f05187b73453fc3856403"
   export PYTHON_PLUGIN_ID="Pythonid"
   export PYTHON_PLUGIN_MD5="b736164c472cb60c216eed9aacdc0ec3"
 else
   export IJ_BUILD="IC-${IJ_VERSION}"
   export FULL_IJ_BUILD_NUMBER="IC-${IJ_BUILD_NUMBER}"
-  export EXPECTED_IJ_MD5="eee28ebe453fd555032a5727f16ab384"
+  export EXPECTED_IJ_MD5="bc890f97797f7b5b4bbe233e04aad22f"
   export PYTHON_PLUGIN_ID="PythonCore"
   export PYTHON_PLUGIN_MD5="f61f0f1cb4980755b31de376ad3ed74a"
 fi


### PR DESCRIPTION
Jetbrains took down 2016.3.3, so switch to 2016.3.4 instead.