### PR TITLE
Remove stale code on retrieving Pants exported classpath

### DIFF
--- a/src/com/twitter/intellij/pants/execution/PantsClasspathRunConfigurationExtension.java
+++ b/src/com/twitter/intellij/pants/execution/PantsClasspathRunConfigurationExtension.java
@@ -27,7 +27,6 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,13 +64,6 @@ public class PantsClasspathRunConfigurationExtension extends RunConfigurationExt
     params.setUseDynamicClasspath(true);
 
     final PathsList classpath = params.getClassPath();
-
-    for (Map.Entry<String, String> excludedPathEntry : findAllExcludedJars(classpath.getPathList(), findExcludes(module)).entrySet()) {
-      final String excludedPath = excludedPathEntry.getKey();
-      final String address = excludedPathEntry.getValue();
-      LOG.info(address + " excluded " + excludedPath);
-      classpath.remove(excludedPath);
-    }
 
     VirtualFile manifestJar = PantsUtil.findProjectManifestJar(configuration.getProject())
       .orElseThrow(() -> new ExecutionException("Pants supports manifest jar, but it is not found."));
@@ -146,26 +138,6 @@ public class PantsClasspathRunConfigurationExtension extends RunConfigurationExt
     runtimeEnumerator.forEachModule(processor);
   }
 
-  @NotNull
-  private Map<String, String> findAllExcludedJars(@NotNull List<String> classpathEntries, @NotNull Map<String, String> excludes) {
-    if (excludes.isEmpty()) {
-      return Collections.emptyMap();
-    }
-    final Map<String, String> result = new HashMap<String, String>();
-    for (String classpathEntry : classpathEntries) {
-      for (Map.Entry<String, String> excludeEntry : excludes.entrySet()) {
-        final String exclude = excludeEntry.getKey();
-        final String address = excludeEntry.getValue();
-        // exclude looks like com.foo:bar
-        // let's remove all jars with /com.foo/bar/ in the path
-        // because Pants uses Ivy
-        if (StringUtil.contains(classpathEntry, File.separator + exclude.replace(':', File.separatorChar) + File.separator)) {
-          result.put(classpathEntry, address);
-        }
-      }
-    }
-    return result;
-  }
 
   @Nullable
   private <T extends RunConfigurationBase> Module findPantsModule(T configuration) {

--- a/tests/com/twitter/intellij/pants/extension/PantsExternalMetricsListenerExtensionTest.java
+++ b/tests/com/twitter/intellij/pants/extension/PantsExternalMetricsListenerExtensionTest.java
@@ -81,7 +81,7 @@ public class PantsExternalMetricsListenerExtensionTest extends OSSPantsIntegrati
     assertEquals(PantsExternalMetricsListener.TestRunnerType.JUNIT_RUNNER, listener.lastRun);
   }
 
-  public void testScalaRunnerMetrics() {
+  public void testScalaRunnerMetrics() throws Exception {
     class TestMetricsListener extends EmptyMetricsTestListener {
       private PantsExternalMetricsListener.TestRunnerType lastRun;
 

--- a/tests/com/twitter/intellij/pants/highlighting/PantsUnresolvedJavaReferenceQuickFixProviderTest.java
+++ b/tests/com/twitter/intellij/pants/highlighting/PantsUnresolvedJavaReferenceQuickFixProviderTest.java
@@ -53,9 +53,5 @@ public class PantsUnresolvedJavaReferenceQuickFixProviderTest extends PantsHighl
     assertPantsCompileExecutesAndSucceeds(
       pantsCompileModule("testprojects_src_java_org_pantsbuild_testproject_missingdepswhitelist2_missingdepswhitelist2"));
 
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.testproject.missingdepswhitelist2.MissingDepsWhitelist2",
-      "testprojects_src_java_org_pantsbuild_testproject_missingdepswhitelist2_missingdepswhitelist2"
-    );
   }
 }

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsExamplesMultiTargetsIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsExamplesMultiTargetsIntegrationTest.java
@@ -26,10 +26,6 @@ public class OSSPantsExamplesMultiTargetsIntegrationTest extends OSSPantsIntegra
 
     assertPantsCompileExecutesAndSucceeds(pantsCompileModule("examples_src_java_org_pantsbuild_example_hello_main_main"));
 
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.hello.greet.Greeting", "examples_src_java_org_pantsbuild_example_hello_greet_greet"
-    );
-
     doImport("examples/src/scala/org/pantsbuild/example/hello/BUILD", "hello");
     assertProjectName("pants.examples.src.scala.org.pantsbuild.example.hello:hello");
 
@@ -45,9 +41,5 @@ public class OSSPantsExamplesMultiTargetsIntegrationTest extends OSSPantsIntegra
       addAll(initialModules, additionalModules));
 
     assertPantsCompileExecutesAndSucceeds(pantsCompileProject());
-
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.hello.welcome.WelcomeEverybody", "examples_src_scala_org_pantsbuild_example_hello_welcome_welcome"
-    );
   }
 }

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
@@ -31,16 +31,6 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
     );
 
     assertPantsCompileExecutesAndSucceeds(pantsCompileModule("examples_src_java_org_pantsbuild_example_annotation_main_main"));
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.annotation.main.Main", "examples_src_java_org_pantsbuild_example_annotation_main_main"
-    );
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.annotation.example.Example", "examples_src_java_org_pantsbuild_example_annotation_example_example"
-    );
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.annotation.processor.ExampleProcessor",
-      "examples_src_java_org_pantsbuild_example_annotation_processor_processor"
-    );
   }
 
   public void testAntl3() throws Throwable {
@@ -53,9 +43,6 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
     assertGenModules(1);
 
     assertPantsCompileExecutesAndSucceeds(pantsCompileModule("examples_src_java_org_pantsbuild_example_antlr3_antlr3"));
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.antlr3.ExampleAntlr3", "examples_src_java_org_pantsbuild_example_antlr3_antlr3"
-    );
   }
 
   public void testAntl4() throws Throwable {
@@ -68,9 +55,6 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
     assertGenModules(1);
 
     assertPantsCompileExecutesAndSucceeds(pantsCompileModule("examples_src_java_org_pantsbuild_example_antlr4_antlr4"));
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.antlr4.ExampleAntlr4", "examples_src_java_org_pantsbuild_example_antlr4_antlr4"
-    );
   }
 
   public void testHello() throws Throwable {
@@ -93,12 +77,6 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
     );
 
     assertPantsCompileExecutesAndSucceeds(pantsCompileModule("examples_src_java_org_pantsbuild_example_hello_main_main"));
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.hello.greet.Greeting", "examples_src_java_org_pantsbuild_example_hello_greet_greet"
-    );
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.hello.main.HelloMain", "examples_src_java_org_pantsbuild_example_hello_main_main-bin"
-    );
   }
 
   public void testJaxb() throws Throwable {
@@ -113,9 +91,6 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
     assertGenModules(1);
 
     assertPantsCompileExecutesAndSucceeds(pantsCompileModule("examples_src_java_org_pantsbuild_example_jaxb_main_main"));
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.jaxb.main.ExampleJaxb", "examples_src_java_org_pantsbuild_example_jaxb_main_main"
-    );
   }
 
   public void testProtobuf() throws Throwable {
@@ -128,9 +103,6 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
     assertGenModules(1);
 
     assertPantsCompileExecutesAndSucceeds(pantsCompileModule("examples_src_java_org_pantsbuild_example_protobuf_distance_distance"));
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.protobuf.distance.ExampleProtobuf", "examples_src_java_org_pantsbuild_example_protobuf_distance_distance"
-    );
   }
 
   public void testExcludes1() throws Throwable {
@@ -142,9 +114,6 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
 
     assertPantsCompileExecutesAndSucceeds(
       pantsCompileModule("intellij-integration_src_java_org_pantsbuild_testproject_excludes1_excludes1")
-    );
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.testproject.excludes1.Foo", "intellij-integration_src_java_org_pantsbuild_testproject_excludes1_excludes1"
     );
   }
 
@@ -158,9 +127,6 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
 
     assertPantsCompileExecutesAndSucceeds(
       pantsCompileModule("intellij-integration_src_java_org_pantsbuild_testproject_excludes2_excludes2")
-    );
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.testproject.excludes2.foo.Foo", "intellij-integration_src_java_org_pantsbuild_testproject_excludes2_excludes2"
     );
   }
 

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsScalaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsScalaExamplesIntegrationTest.java
@@ -29,9 +29,6 @@ public class OSSPantsScalaExamplesIntegrationTest extends OSSPantsIntegrationTes
     );
     assertPantsCompileExecutesAndSucceeds(pantsCompileModule("examples_src_scala_org_pantsbuild_example_hello_exe_exe"));
 
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.hello.welcome.WelcomeEverybody", "examples_src_scala_org_pantsbuild_example_hello_welcome_welcome"
-    );
     assertGotoFileContains("README");
     //Assert if README file under a sub directory is indexed.
     assertGotoFileContains("README_DOCS");
@@ -45,9 +42,6 @@ public class OSSPantsScalaExamplesIntegrationTest extends OSSPantsIntegrationTes
 
     assertFirstSourcePartyModules(moduleName);
     assertPantsCompileExecutesAndSucceeds(pantsCompileProject());
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.scala_with_java_sources.GreetEverybody", moduleName
-    );
   }
 
   public void testExcludes1() throws Throwable {
@@ -67,10 +61,6 @@ public class OSSPantsScalaExamplesIntegrationTest extends OSSPantsIntegrationTes
     assertPantsCompileExecutesAndSucceeds(pantsCompileModule("intellij-integration_src_scala_org_pantsbuild_testproject_excludes1_excludes1"));
 
     findClassAndAssert("org.pantsbuild.testproject.excludes1.nested.foo.Foo");
-
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.testproject.excludes1.nested.foo.Foo", "intellij-integration_src_scala_org_pantsbuild_testproject_excludes1_nested_foo_foo"
-    );
   }
 
   public void testError1() throws Throwable {
@@ -102,9 +92,5 @@ public class OSSPantsScalaExamplesIntegrationTest extends OSSPantsIntegrationTes
 
     findClassAndAssert("org.pantsbuild.example.hello.welcome.WelSpec");
     assertScalaLibrary("examples_tests_scala_org_pantsbuild_example_hello_welcome_welcome");
-
-    assertClassFileInModuleOutput(
-      "org.pantsbuild.example.hello.welcome.WelSpec", "examples_tests_scala_org_pantsbuild_example_hello_welcome_welcome"
-    );
   }
 }


### PR DESCRIPTION
This change removes the stale code on retrieving Pants exported classpath before initiating intellij scala/junit runner. Exporting classpaths via a manifest jar was added to Pants pre 1.0, so it should be safe to assume all Pants users have this functionality.

Other refactoring:
Move `assertManifestJarExists()` into `assertPantsCompileExecutesAndSucceeds()` and `assertPantsCompileNoop()`