### PR TITLE
Place target list in a scroll pane for user to select

### DIFF
--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.ui.CheckBoxList;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.ui.GridBag;
 import com.intellij.util.ui.StatusText;
@@ -71,7 +72,7 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
       myEnableIncrementalImportCheckBox,
       myUseIdeaProjectJdkCheckBox,
       new JBLabel(PantsBundle.message("pants.settings.text.targets")),
-      myTargetSpecsBox
+      new JBScrollPane(myTargetSpecsBox)
     );
 
     GridBag lineConstraints = ExternalSystemUiUtil.getFillLineConstraints(indentLevel);


### PR DESCRIPTION
## Problem
If a BUILD file contains a lot of target, the target selection interface will go out of screen, so user is unable to select the ones beyond the screen.

## Solution
This change add the target list into a scroll pane.

### Before
![screen shot 2017-03-02 at 6 19 25 pm](https://cloud.githubusercontent.com/assets/596358/23535717/f85e15d2-ff74-11e6-8e6f-b408cab9b827.png)

### After
![screen shot 2017-03-02 at 6 18 49 pm](https://cloud.githubusercontent.com/assets/596358/23535715/f4d5def4-ff74-11e6-8a2b-cbeb682223cc.png)

