### PR TITLE
Fix redundant refresh notifications

### DIFF
--- a/src/com/twitter/intellij/pants/file/FileChangeTracker.java
+++ b/src/com/twitter/intellij/pants/file/FileChangeTracker.java
@@ -130,7 +130,7 @@ public class FileChangeTracker {
    * https://github.com/JetBrains/intellij-community/blob/b5d046018b9a82fccd86bc9c1f1da2e28068440a/plugins/maven/src/main/java/org/jetbrains/idea/maven/utils/MavenImportNotifier.java#L92-L108
    */
   private static void notifyProjectRefreshIfNecessary(@NotNull VirtualFile file, final Project project) {
-    // Check if there is still standing refresh notification, do not proceed to issue another notification.
+    // If there is standing refresh notification, do not proceed to issue another notification.
     if (hasExistingRefreshNotification(project)) {
       return;
     }

--- a/src/com/twitter/intellij/pants/file/FileChangeTracker.java
+++ b/src/com/twitter/intellij/pants/file/FileChangeTracker.java
@@ -324,6 +324,7 @@ public class FileChangeTracker {
 
       @Override
       public void fileDeleted(@NotNull VirtualFileEvent event) {
+        FileChangeTracker.markDirty(event.getFile(), this);
       }
 
       @Override

--- a/tests/com/twitter/intellij/pants/integration/OSSRefreshPromptIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSRefreshPromptIntegrationTest.java
@@ -150,7 +150,10 @@ public class OSSRefreshPromptIntegrationTest extends OSSPantsIntegrationTest {
         // Verify the notification is triggered.
 
         ArrayList<Notification> notifications = EventLog.getLogModel(myProject).getNotifications();
-        assertEquals(1, notifications.size());
+        assertEquals(
+          String.format("Project should only have 1 refresh notification, but has %s", notifications.size()),
+          1, notifications.size()
+        );
       }
     });
   }

--- a/tests/com/twitter/intellij/pants/integration/OSSRefreshPromptIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSRefreshPromptIntegrationTest.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.psi.search.FilenameIndex;
@@ -27,8 +28,17 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class OSSRefreshPromptIntegrationTest extends OSSPantsIntegrationTest {
+
+
+  private static List<Notification> findAllExistingRefreshNotification(Project project) {
+    ArrayList<Notification> notifications = EventLog.getLogModel(project).getNotifications();
+    return notifications.stream().filter(s -> s.getContent().contains(FileChangeTracker.REFRESH_PANTS_PROJECT_DISPLAY))
+      .collect(Collectors.toList());
+  }
 
   /**
    * Modifying a BUILD file in project should not trigger refresh prompt.
@@ -38,18 +48,21 @@ public class OSSRefreshPromptIntegrationTest extends OSSPantsIntegrationTest {
       @Override
       public void run() {
         doImport("examples/tests/java/org/pantsbuild/example/useproto");
+
         // Find a BUILD file in project.
         FileEditorManager.getInstance(myProject).openFile(firstMatchingVirtualFileInProject("BUILD"), true);
         Editor editor = FileEditorManager.getInstance(myProject).getSelectedTextEditor();
+
         // Add a newline to the BUILD file.
         editor.getDocument().setText(editor.getDocument().getText() + "\n");
+
         // Save the BUILD file. Then the refresh notification should be triggered.
         FileDocumentManager.getInstance().saveAllDocuments();
+
         // Verify the notification is triggered.
-        ArrayList<Notification> notifications = EventLog.getLogModel(myProject).getNotifications();
-        int notificationSize = notifications.size();
-        assertTrue(notificationSize > 0);
-        Notification notification = notifications.get(notificationSize - 1);
+        List<Notification> refreshNotifications = findAllExistingRefreshNotification(myProject);
+        assertEquals(1, refreshNotifications.size());
+        Notification notification = refreshNotifications.get(0);
         assertEquals(PantsBundle.message("pants.project.build.files.changed"), notification.getTitle());
 
         /*
@@ -100,6 +113,44 @@ public class OSSRefreshPromptIntegrationTest extends OSSPantsIntegrationTest {
         // Verify the notification is triggered.
         ArrayList<Notification> notifications = EventLog.getLogModel(myProject).getNotifications();
         assertEquals("There should not be any notifications, but there is", 0, notifications.size());
+      }
+    });
+  }
+
+  public void testNotificationQuantity() throws Throwable {
+    ApplicationManager.getApplication().runWriteAction(new Runnable() {
+      @Override
+      public void run() {
+        doImport("examples/tests/java/org/pantsbuild/example/useproto");
+        // Find a BUILD file in project.
+        FileEditorManager.getInstance(myProject).openFile(firstMatchingVirtualFileInProject("BUILD"), true);
+        Editor editor = FileEditorManager.getInstance(myProject).getSelectedTextEditor();
+
+        // Save the file multiple times and make sure there is only one active refresh notification
+        for (int i = 0; i < 2; i++) {
+          saveFileAndAssertRefreshNotification(editor);
+        }
+
+        // Expire the existing one
+        EventLog.getLogModel(myProject).getNotifications().forEach(Notification::expire);
+        // Make sure there is no active one left
+        assertEquals(0, EventLog.getLogModel(myProject).getNotifications().size());
+        saveFileAndAssertRefreshNotification(editor);
+      }
+
+      /**
+       * Change the text file in an editor and make sure there is only one refresh notification.
+       * @param editor an editor containing an opened file.
+       */
+      private void saveFileAndAssertRefreshNotification(Editor editor) {
+        // Add a newline to the BUILD file.
+        editor.getDocument().setText(editor.getDocument().getText() + "\n");
+        // Save the BUILD file. Then the refresh notification should be triggered.
+        FileDocumentManager.getInstance().saveAllDocuments();
+        // Verify the notification is triggered.
+
+        ArrayList<Notification> notifications = EventLog.getLogModel(myProject).getNotifications();
+        assertEquals(1, notifications.size());
       }
     });
   }


### PR DESCRIPTION
## Problem (#270)
Pants refresh notification is triggered on every build file edit, causing hundreds of them showing up after a git operation.

## Solution
The behavior has changed so that user will only be notified when there was no existing refresh notification.