### PR TITLE
Disable quick fix for missing dependencies

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -25,7 +25,7 @@
   </extensions>
   <extensions defaultExtensionNs="com.intellij">
     <externalProjectDataService implementation="com.twitter.intellij.pants.service.scala.PantsScalaDataService" order="last"/>
-    <highlightVisitor implementation="com.twitter.intellij.pants.highlight.PantScalaHighlightVisitor"/>
+    <highlightVisitor implementation="com.twitter.intellij.pants.highlight.PantsScalaHighlightVisitor"/>
   </extensions>
   <!--End of scala plugin related extensions-->
 

--- a/src/com/twitter/intellij/pants/highlight/PantScalaHighlightVisitor.java
+++ b/src/com/twitter/intellij/pants/highlight/PantScalaHighlightVisitor.java
@@ -62,7 +62,6 @@ public class PantScalaHighlightVisitor implements HighlightVisitor {
       final IntentionAction action = actionDescriptor.getAction();
       if (action instanceof CreateTypeDefinitionQuickFix) {
         final String className = textRange.substring(containingFile.getText());
-
         final List<PantsQuickFix> missingDependencyFixes =
           PantsUnresolvedReferenceFixFinder.findMissingDependencies(className, containingFile);
         for (PantsQuickFix fix : missingDependencyFixes) {

--- a/src/com/twitter/intellij/pants/highlight/PantScalaHighlightVisitor.java
+++ b/src/com/twitter/intellij/pants/highlight/PantScalaHighlightVisitor.java
@@ -7,6 +7,7 @@ import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.codeInsight.daemon.impl.HighlightVisitor;
 import com.intellij.codeInsight.daemon.impl.analysis.HighlightInfoHolder;
 import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.TextRange;
@@ -56,14 +57,18 @@ public class PantScalaHighlightVisitor implements HighlightVisitor {
       final IntentionAction action = actionDescriptor.getAction();
       if (action instanceof CreateTypeDefinitionQuickFix) {
         final String className = textRange.substring(containingFile.getText());
-        final List<PantsQuickFix> missingDependencyFixes =
-          PantsUnresolvedReferenceFixFinder.findMissingDependencies(className, containingFile);
-        for (PantsQuickFix fix : missingDependencyFixes) {
-          info.registerFix(fix, null, fix.getName(), textRange, null);
-        }
-        if (!missingDependencyFixes.isEmpty()) {
-          // we should add only one fix per info
-          return;
+        // FIXME: Re-enable quick fix for missing dependencies once it is functional again.
+        // https://github.com/pantsbuild/intellij-pants-plugin/issues/280
+        if (ApplicationManager.getApplication().isUnitTestMode()) {
+          final List<PantsQuickFix> missingDependencyFixes =
+            PantsUnresolvedReferenceFixFinder.findMissingDependencies(className, containingFile);
+          for (PantsQuickFix fix : missingDependencyFixes) {
+            info.registerFix(fix, null, fix.getName(), textRange, null);
+          }
+          if (!missingDependencyFixes.isEmpty()) {
+            // we should add only one fix per info
+            return;
+          }
         }
       }
     }

--- a/src/com/twitter/intellij/pants/highlight/PantsScalaHighlightVisitor.java
+++ b/src/com/twitter/intellij/pants/highlight/PantsScalaHighlightVisitor.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * A hack to extend fixes in Scala code. @fkorotkov asked JetBrains to add an extension point as we have for Java
  */
-public class PantScalaHighlightVisitor implements HighlightVisitor {
+public class PantsScalaHighlightVisitor implements HighlightVisitor {
   private HighlightInfoHolder myHolder;
 
   @Override
@@ -95,7 +95,7 @@ public class PantScalaHighlightVisitor implements HighlightVisitor {
   @NotNull
   @Override
   public HighlightVisitor clone() {
-    return new PantScalaHighlightVisitor();
+    return new PantsScalaHighlightVisitor();
   }
 
   @Override

--- a/src/com/twitter/intellij/pants/quickfix/PantsUnresolvedJavaReferenceQuickFixProvider.java
+++ b/src/com/twitter/intellij/pants/quickfix/PantsUnresolvedJavaReferenceQuickFixProvider.java
@@ -5,6 +5,7 @@ package com.twitter.intellij.pants.quickfix;
 
 import com.intellij.codeInsight.daemon.QuickFixActionRegistrar;
 import com.intellij.codeInsight.quickfix.UnresolvedReferenceQuickFixProvider;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.psi.PsiJavaCodeReferenceElement;
 import com.intellij.psi.PsiReference;
 import org.jetbrains.annotations.NotNull;
@@ -18,6 +19,11 @@ public class PantsUnresolvedJavaReferenceQuickFixProvider extends UnresolvedRefe
 
   @Override
   public void registerFixes(@NotNull PsiReference reference, @NotNull QuickFixActionRegistrar registrar) {
+    // FIXME: Re-enable quick fix for missing dependencies once it is functional again.
+    // https://github.com/pantsbuild/intellij-pants-plugin/issues/280
+    if (!ApplicationManager.getApplication().isUnitTestMode()) {
+      return;
+    }
     for (PantsQuickFix quickFix : PantsUnresolvedReferenceFixFinder.findMissingDependencies(reference)) {
       registrar.register(quickFix);
     }


### PR DESCRIPTION
In #280, due to Pants' adopting default target, the plugin is not able to parse the BUILD file correctly in order to suggest dependency fixes. The existing fix will confuse user because it will end up being a noop, hence disabling the whole feature.