### PR TITLE
Limit the scope of modules to obtain target addresses from before invoking Pants

### DIFF
--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -329,8 +329,13 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
 
   @NotNull
   private Set<String> getTargetAddressesToCompile(RunConfiguration configuration) {
-    /* JUnit, Application, Scala runs */
-    if (configuration instanceof RunProfileWithCompileBeforeLaunchOption) {
+    /* Scala run configurations */
+    if (configuration instanceof AbstractTestRunConfiguration) {
+      Module module = ((AbstractTestRunConfiguration) configuration).getModule();
+      return getTargetAddressesToCompile(new Module[]{module});
+    }
+    /* JUnit, Application run configurations */
+    else if (configuration instanceof RunProfileWithCompileBeforeLaunchOption) {
       RunProfileWithCompileBeforeLaunchOption config = (RunProfileWithCompileBeforeLaunchOption) configuration;
       Module[] targetModules = config.getModules();
       return getTargetAddressesToCompile(targetModules);

--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -328,7 +328,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
   }
 
   @NotNull
-  private Set<String> getTargetAddressesToCompile(RunConfiguration configuration) {
+  protected Set<String> getTargetAddressesToCompile(RunConfiguration configuration) {
     /* Scala run configurations */
     if (configuration instanceof AbstractTestRunConfiguration) {
       Module module = ((AbstractTestRunConfiguration) configuration).getModule();

--- a/tests/com/twitter/intellij/pants/execution/IntelliJRunnerAddressInvocationTest.java
+++ b/tests/com/twitter/intellij/pants/execution/IntelliJRunnerAddressInvocationTest.java
@@ -1,0 +1,73 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.execution;
+
+import com.google.common.collect.Sets;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.externalSystem.util.ExternalSystemConstants;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleTypeId;
+import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+import com.twitter.intellij.pants.util.PantsConstants;
+import com.twitter.intellij.pants.util.PantsUtil;
+import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestConfigurationType;
+import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestRunConfiguration;
+import org.jetbrains.plugins.scala.testingSupport.test.scalatest.ScalaTestRunConfigurationFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class IntelliJRunnerAddressInvocationTest extends OSSPantsIntegrationTest {
+
+
+  private Module createModuleWithSerializedAddresses(String path, Set addresses) {
+    Module module = ModuleManager.getInstance(myProject).newModule(path, ModuleTypeId.JAVA_MODULE);
+    // Make it a Pants module
+    module.setOption(ExternalSystemConstants.EXTERNAL_SYSTEM_ID_KEY, PantsConstants.SYSTEM_ID.getId());
+    module.setOption(PantsConstants.PANTS_TARGET_ADDRESSES_KEY, PantsUtil.dehydrateTargetAddresses(addresses)
+    );
+    return module;
+  }
+
+
+  public void testAddressInvoked() throws Throwable {
+
+    ApplicationManager.getApplication().runWriteAction(new Runnable() {
+      @Override
+      public void run() {
+        HashSet<String> address_1 = Sets.newHashSet("x:x");
+        HashSet<String> address_2 = Sets.newHashSet("y:y");
+        HashSet<String> address_3 = Sets.newHashSet("z:z");
+        Module module1 = createModuleWithSerializedAddresses("a", address_1);
+        Module module2 = createModuleWithSerializedAddresses("b", address_2);
+        Module module3 = createModuleWithSerializedAddresses("c", address_3);
+
+        // Make module1 depend on module2 and module3
+        ModifiableRootModel model = ModuleRootManager.getInstance(module1).getModifiableModel();
+        model.addModuleOrderEntry(module2);
+        model.addModuleOrderEntry(module3);
+        model.commit();
+
+        assertTrue(ModuleManager.getInstance(myProject).isModuleDependent(module1, module2));
+        assertTrue(ModuleManager.getInstance(myProject).isModuleDependent(module1, module3));
+
+
+        ScalaTestRunConfiguration configuration =
+          new ScalaTestRunConfiguration(
+            myProject,
+            new ScalaTestRunConfigurationFactory(new ScalaTestConfigurationType()),
+            "dummy"
+          );
+        configuration.setModule(module1);
+        PantsMakeBeforeRun run = new PantsMakeBeforeRun(myProject);
+        Set<String> addressesToCompile = run.getTargetAddressesToCompile(configuration);
+
+        assertEquals(address_1, addressesToCompile);
+      }
+    });
+  }
+}

--- a/tests/com/twitter/intellij/pants/execution/IntelliJRunnerAddressInvocationTest.java
+++ b/tests/com/twitter/intellij/pants/execution/IntelliJRunnerAddressInvocationTest.java
@@ -42,12 +42,12 @@ public class IntelliJRunnerAddressInvocationTest extends OSSPantsIntegrationTest
     ApplicationManager.getApplication().runWriteAction(new Runnable() {
       @Override
       public void run() {
-        HashSet<String> address_1 = Sets.newHashSet("x:x");
-        HashSet<String> address_2 = Sets.newHashSet("y:y");
-        HashSet<String> address_3 = Sets.newHashSet("z:z");
-        Module module1 = createModuleWithSerializedAddresses("a", address_1);
-        Module module2 = createModuleWithSerializedAddresses("b", address_2);
-        Module module3 = createModuleWithSerializedAddresses("c", address_3);
+        HashSet<String> address1 = Sets.newHashSet("x:x");
+        HashSet<String> address2 = Sets.newHashSet("y:y");
+        HashSet<String> address3 = Sets.newHashSet("z:z");
+        Module module1 = createModuleWithSerializedAddresses("a", address1);
+        Module module2 = createModuleWithSerializedAddresses("b", address2);
+        Module module3 = createModuleWithSerializedAddresses("c", address3);
 
         // Make module1 depend on module2 and module3
         ModifiableRootModel model = ModuleRootManager.getInstance(module1).getModifiableModel();
@@ -58,7 +58,7 @@ public class IntelliJRunnerAddressInvocationTest extends OSSPantsIntegrationTest
         assertTrue(ModuleManager.getInstance(myProject).isModuleDependent(module1, module2));
         assertTrue(ModuleManager.getInstance(myProject).isModuleDependent(module1, module3));
 
-
+        // Make Scala run configuration for that module.
         ScalaTestRunConfiguration configuration =
           new ScalaTestRunConfiguration(
             myProject,
@@ -66,10 +66,11 @@ public class IntelliJRunnerAddressInvocationTest extends OSSPantsIntegrationTest
             "dummy"
           );
         configuration.setModule(module1);
+
+        // Make sure there is only one and the only address that gets passed to Pants.
         PantsMakeBeforeRun run = new PantsMakeBeforeRun(myProject);
         Set<String> addressesToCompile = run.getTargetAddressesToCompile(configuration);
-
-        assertEquals(address_1, addressesToCompile);
+        assertEquals(address1, addressesToCompile);
       }
     });
   }
@@ -79,12 +80,12 @@ public class IntelliJRunnerAddressInvocationTest extends OSSPantsIntegrationTest
     ApplicationManager.getApplication().runWriteAction(new Runnable() {
       @Override
       public void run() {
-        HashSet<String> address_1 = Sets.newHashSet("x:x");
-        HashSet<String> address_2 = Sets.newHashSet("y:y");
-        HashSet<String> address_3 = Sets.newHashSet("z:z");
-        Module module1 = createModuleWithSerializedAddresses("a", address_1);
-        Module module2 = createModuleWithSerializedAddresses("b", address_2);
-        Module module3 = createModuleWithSerializedAddresses("c", address_3);
+        HashSet<String> address1 = Sets.newHashSet("x:x");
+        HashSet<String> address2 = Sets.newHashSet("y:y");
+        HashSet<String> address3 = Sets.newHashSet("z:z");
+        Module module1 = createModuleWithSerializedAddresses("a", address1);
+        Module module2 = createModuleWithSerializedAddresses("b", address2);
+        Module module3 = createModuleWithSerializedAddresses("c", address3);
 
         // Make module1 depend on module2 and module3
         ModifiableRootModel model = ModuleRootManager.getInstance(module1).getModifiableModel();
@@ -95,14 +96,15 @@ public class IntelliJRunnerAddressInvocationTest extends OSSPantsIntegrationTest
         assertTrue(ModuleManager.getInstance(myProject).isModuleDependent(module1, module2));
         assertTrue(ModuleManager.getInstance(myProject).isModuleDependent(module1, module3));
 
-
+        // Make JUnit configuration for that module.
         final ConfigurationFactory factory = JUnitConfigurationType.getInstance().getConfigurationFactories()[0];
         final JUnitConfiguration configuration = new JUnitConfiguration("dummy", myProject, factory);
         configuration.setModule(module1);
+
+        // Make sure there is only one and the only address that gets passed to Pants.
         PantsMakeBeforeRun run = new PantsMakeBeforeRun(myProject);
         Set<String> addressesToCompile = run.getTargetAddressesToCompile(configuration);
-
-        assertEquals(address_1, addressesToCompile);
+        assertEquals(address1, addressesToCompile);
       }
     });
   }


### PR DESCRIPTION
## Problem
Currently the plugin will call configuration.getModules() in order to determine the target address associated with them, but `getModules()` behave differently in JUnitConfiguration and ScalaTestConfiguration:
* JUnitConfiguration returns a singleton list of module that the configuration belongs to
* ScalaTestConfiguration returns the transitive set of modules, causing 
1) More than one address getting invoked 
2) jar exclusion issues since not all its transitive modules are 1:1:1 conforming, which could introduce additional jars that meant to be excluded when invoking with just the single target.

## Solution
Make sure with Scala run configuration, we only get the module directly related to the test file instead of all its transitive modules.

## Result
As reflected in the test.