### PR TITLE
Release 1.6.0

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
       </ul>
       ]]>
   </change-notes>
-  <version>1.5.3</version>
+  <version>1.6.0</version>
   <vendor>Twitter, Inc.</vendor>
 
   <!--if you are changing since-build don't forget to change it in .travis.yml file as well-->

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -26,13 +26,13 @@ if [[ $IJ_ULTIMATE == "true" ]]; then
   export FULL_IJ_BUILD_NUMBER="IU-${IJ_BUILD_NUMBER}"
   export EXPECTED_IJ_MD5="625623556cdbb93f863dae7dc34ac618"
   export PYTHON_PLUGIN_ID="Pythonid"
-  export PYTHON_PLUGIN_MD5="709ab4542fd0bc915c551d0e0252a31a"
+  export PYTHON_PLUGIN_MD5="fdbe77562f4aafb72638ae0f1360349b"
 else
   export IJ_BUILD="IC-${IJ_VERSION}"
   export FULL_IJ_BUILD_NUMBER="IC-${IJ_BUILD_NUMBER}"
   export EXPECTED_IJ_MD5="b17d25c585c1409eb78d87d4cbe79128"
   export PYTHON_PLUGIN_ID="PythonCore"
-  export PYTHON_PLUGIN_MD5="dc69d6b3f1078ed6aead34af9246d00f"
+  export PYTHON_PLUGIN_MD5="0e35d9c84f668e622dad07540ac89dcb"
 fi
 
 # we will use Community ids to download plugins.


### PR DESCRIPTION
## Major update:
* Gradle plugin is now explicitly declared as a dependency to Pants Support (#237). When accidentally disabled, the error will be more obvious that Pants Support will be unavailable as well.
* Like previous major updates, this one is backward **incompatible** with the previous IntelliJ version 2016.3.x

## Bug fixes
* Fix redundant refresh notifications (#279)
* Disable quick fix for missing dependencies (#281)
* Limit the scope of modules to obtain target addresses from before invoking Pants (#282)

## Usability
* Place target list in a scroll pane for user to select (#275) 
* Remove setting default keyboard shortcut for 'Refresh all external projects' (#277)