### PR TITLE
Throw exception on self cyclic dependencies

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/modifier/PantsCyclicDependenciesModifier.java
+++ b/src/com/twitter/intellij/pants/service/project/modifier/PantsCyclicDependenciesModifier.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
+import com.twitter.intellij.pants.PantsException;
 import com.twitter.intellij.pants.service.PantsCompileOptionsExecutor;
 import com.twitter.intellij.pants.service.project.PantsProjectInfoModifierExtension;
 import com.twitter.intellij.pants.service.project.model.ProjectInfo;
@@ -32,6 +33,11 @@ public class PantsCyclicDependenciesModifier implements PantsProjectInfoModifier
       for (String dependencyTargetName : targetInfo.getTargets()) {
         TargetInfo dependencyTargetInfo = projectInfo.getTarget(dependencyTargetName);
         if (dependencyTargetInfo != null && dependencyTargetInfo.dependOn(targetName)) {
+
+          if (targetName.equals(dependencyTargetName)) {
+            throw new PantsException(String.format("Self cyclic dependency found %s", targetName));
+          }
+
           log.info(String.format("Found cyclic dependency between %s and %s", targetName, dependencyTargetName));
 
           final String combinedTargetName = combinedTargetsName(targetName, dependencyTargetName);

--- a/tests/com/twitter/intellij/pants/service/project/PantsResolverTestBase.java
+++ b/tests/com/twitter/intellij/pants/service/project/PantsResolverTestBase.java
@@ -60,14 +60,14 @@ abstract class PantsResolverTestBase extends PantsCodeInsightFixtureTestCase {
   }
 
   @NotNull
-  private DataNode<ProjectData> getProjectNode() {
+  protected DataNode<ProjectData> getProjectNode() {
     if (myProjectNode == null) {
       myProjectNode = createProjectNode();
     }
     return myProjectNode;
   }
 
-  private DataNode<ProjectData> createProjectNode() {
+  protected DataNode<ProjectData> createProjectNode() {
     final PantsResolver dependenciesResolver = new PantsResolver(PantsCompileOptionsExecutor.createMock());
     dependenciesResolver.setProjectInfo(getProjectInfo());
     final ProjectData projectData = new ProjectData(


### PR DESCRIPTION
### Problem

Currently when there is a self cyclic dependency, the plugin will throw the following error which is very confusing.
```
Error:exception during working with external system: java.util.ConcurrentModificationException
        at java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1211)
        at java.util.TreeMap$KeyIterator.next(TreeMap.java:1265)
        at com.twitter.intellij.pants.service.project.modifier.PantsCyclicDependenciesModifier.modify(PantsCyclicDependenciesModifier.java:32)
        at com.twitter.intellij.pants.service.project.PantsResolver.addInfoTo(PantsResolver.java:97)
```

### Solution
Despite there is still work to do on Pants side to enable cycle detection, we can at least check easiest case of self dependency, so the plugin will throw a more meaningful error instead of stacktrace.

### Result

Now it will give a presentable error during import `Error:Self cyclic dependency found <target name>`