### PR TITLE
Release 1.6.1 with automation

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
       </ul>
       ]]>
   </change-notes>
-  <version>1.6.0</version>
+  <version>1.6.1</version>
   <vendor>Twitter, Inc.</vendor>
 
   <!--if you are changing since-build don't forget to change it in .travis.yml file as well-->

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -46,9 +46,9 @@ if __name__ == "__main__":
     exit(1)
 
   if args.tag:
-    channel = CHANNEL_BLEEDING_EDGE
-  else:
     channel = CHANNEL_STABLE
+  else:
+    channel = CHANNEL_BLEEDING_EDGE
 
     sha = get_head_sha()
     logger.info('Append git sha {} to plugin version'.format(sha))

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -32,9 +32,13 @@ def get_head_sha():
 if __name__ == "__main__":
 
   parser = argparse.ArgumentParser()
-  parser.add_argument('--tag', type=str, default='')
+  parser.add_argument('--tag', type=str, default='',
+                      help='If tag exists, this script will release to {} channel, otherwise {} channel.'
+                      .format(CHANNEL_STABLE, CHANNEL_BLEEDING_EDGE))
   args = parser.parse_args()
 
+  # Make sure the $PLUGIN_XML is not modified after multiple runs,
+  # since the workflow below may do so.
   subprocess.check_output('git checkout {}'.format(PLUGIN_XML), shell=True)
 
   tree = ET.parse(PLUGIN_XML)
@@ -51,7 +55,7 @@ if __name__ == "__main__":
     channel = CHANNEL_BLEEDING_EDGE
 
     sha = get_head_sha()
-    logger.info('Append git sha {} to plugin version'.format(sha))
+    logger.info('Append current git sha, {}, to plugin version'.format(sha))
     version.text = "{}.{}".format(version.text, sha)
 
     tree.write(PLUGIN_XML)

--- a/scripts/deploy/deploy.py
+++ b/scripts/deploy/deploy.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import logging
 import os
 import subprocess
@@ -8,7 +9,8 @@ import xml.etree.ElementTree as ET
 PLUGIN_XML = 'resources/META-INF/plugin.xml'
 PLUGIN_ID = 7412
 PLUGIN_JAR = 'dist/intellij-pants-plugin-publish.jar'
-CHANNEL = 'BleedingEdge'
+CHANNEL_BLEEDING_EDGE = 'BleedingEdge'
+CHANNEL_STABLE = 'Stable'
 REPO = 'https://plugins.jetbrains.com/plugin/7412'
 
 logger = logging.getLogger(__name__)
@@ -29,22 +31,32 @@ def get_head_sha():
 
 if __name__ == "__main__":
 
-  subprocess.check_output('git checkout {}'.format(PLUGIN_XML), shell=True)
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--tag', type=str, default='')
+  args = parser.parse_args()
 
-  sha = get_head_sha()
-  logger.info('Append git sha {} to plugin version'.format(sha))
+  subprocess.check_output('git checkout {}'.format(PLUGIN_XML), shell=True)
 
   tree = ET.parse(PLUGIN_XML)
   root = tree.getroot()
-
-  # Find the `version` tag then append the head sha to it.
   version = root.find('version')
+
   if version is None:
     logger.error("version tag not found in {}".format(PLUGIN_XML))
     exit(1)
 
-  version.text = "{}.{}".format(version.text, sha)
-  tree.write(PLUGIN_XML)
+  if args.tag:
+    channel = CHANNEL_BLEEDING_EDGE
+  else:
+    channel = CHANNEL_STABLE
+
+    sha = get_head_sha()
+    logger.info('Append git sha {} to plugin version'.format(sha))
+    version.text = "{}.{}".format(version.text, sha)
+
+    tree.write(PLUGIN_XML)
+
+  logger.info('Releasing {} to {} channel'.format(version.text, channel))
 
   zip_name = 'pants_{}.zip'.format(version.text)
 
@@ -81,7 +93,7 @@ if __name__ == "__main__":
                  '-password \'{password}\' ' \
                  '-plugin {plugin_id} ' \
                  '-file {zip}' \
-      .format(channel=CHANNEL,
+      .format(channel=channel,
               username=os.environ['USERNAME'],
               password=os.environ['PASSWORD'],
               plugin_id=PLUGIN_ID,

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ "$TRAVIS_BRANCH" == "master" ]; then
+if [ "$TRAVIS_BRANCH" == "master" ] || [ ! -z "$TRAVIS_TAG" ]; then
   source scripts/prepare-ci-environment.sh
   ./scripts/deploy/deploy.py --tag="$TRAVIS_TAG"
 else

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ "$TRAVIS_BRANCH" == "master" ]; then
   source scripts/prepare-ci-environment.sh
-  ./scripts/deploy/deploy.py
+  ./scripts/deploy/deploy.py --tag="$TRAVIS_TAG"
 else
   echo "Not on master. Skip deployment."
 fi

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Trigger deploy process if travis ci build is on master or on a tag.
 if [ "$TRAVIS_BRANCH" == "master" ] || [ ! -z "$TRAVIS_TAG" ]; then
   source scripts/prepare-ci-environment.sh
   ./scripts/deploy/deploy.py --tag="$TRAVIS_TAG"


### PR DESCRIPTION
## Problem

Earlier the manual release into Stable channel missed certain classfiles, because not having Scala SDK set correctly in the intellij project of this repo caused compilation to miss all the scala files and passed only with warnings. 

## Solution 

Add 'stable' channel into the release automation script as well, so from now on there should be no need to manually build and upload jars to Jetbrains plugin repo anymore.

## Result
Example run can be seen at https://travis-ci.org/wisechengyi/intellij-pants-plugin/jobs/230219448
```
INFO:__main__:Releasing 1.6.1 to Stable channel
INFO:__main__:rm -rf dist;./pants binary scripts/sdk:intellij-pants-plugin-publish
INFO:__main__:Packaging into a zip
INFO:__main__:mkdir -p tmp/pants/lib && cp dist/intellij-pants-plugin-publish.jar tmp/pants/lib && cd tmp && zip -r pants_1.6.1.zip pants/ &&cd .. &&cp tmp/pants_1.6.1.zip pants_1.6.1.zip &&rm -rf tmp
INFO:__main__:pants_1.6.1.zip built successfully
...
```

## Notable changes from 1.6.0
* Detect cyclic dependency on target itself #288 