### PR TITLE
Add compile current target action

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -68,6 +68,10 @@
               class="com.twitter.intellij.pants.compiler.actions.PantsCompileAllTargetsAction"
               text="Compile all targets in project">
       </action>
+      <action id="com.twitter.intellij.pants.compiler.actions.PantsCompileCurrentTargetAction"
+              class="com.twitter.intellij.pants.compiler.actions.PantsCompileCurrentTargetAction"
+              text="Compile target(s) in the selected editor">
+      </action>
     </group>
 
     <group id="Pants.Compile" text="Pants Compile" description="Pants compilation options" icon="PantsIcons.Icon"

--- a/src/com/twitter/intellij/pants/compiler/actions/PantsCompileCurrentTargetAction.java
+++ b/src/com/twitter/intellij/pants/compiler/actions/PantsCompileCurrentTargetAction.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * PantsCompileAllTargetsAction is a UI action that, when in a project, compiles all targets in the project
+ * PantsCompileAllTargetsAction is a UI action that, when in a project, compiles target(s) related to the file under edit.
  */
 public class PantsCompileCurrentTargetAction extends PantsCompileActionBase {
 

--- a/src/com/twitter/intellij/pants/compiler/actions/PantsCompileCurrentTargetAction.java
+++ b/src/com/twitter/intellij/pants/compiler/actions/PantsCompileCurrentTargetAction.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * PantsCompileAllTargetsAction is a UI action that, when in a project, compiles target(s) related to the file under edit.
+ * PantsCompileCurrentTargetAction is a UI action that compiles target(s) related to the file under edit.
  */
 public class PantsCompileCurrentTargetAction extends PantsCompileActionBase {
 

--- a/src/com/twitter/intellij/pants/compiler/actions/PantsCompileCurrentTargetAction.java
+++ b/src/com/twitter/intellij/pants/compiler/actions/PantsCompileCurrentTargetAction.java
@@ -1,0 +1,50 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.compiler.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.twitter.intellij.pants.util.PantsUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * PantsCompileAllTargetsAction is a UI action that, when in a project, compiles all targets in the project
+ */
+public class PantsCompileCurrentTargetAction extends PantsCompileActionBase {
+
+  protected PantsCompileCurrentTargetAction(String name) {
+    super(name);
+  }
+
+  public PantsCompileCurrentTargetAction() {
+    this("Compile target(s) in the selected editor");
+  }
+
+  /**
+   * Find the target(s) that are only associated with the file opened in the selected editor.
+   */
+  @NotNull
+  @Override
+  public Stream<String> getTargets(@NotNull AnActionEvent e, @NotNull Project project) {
+    VirtualFile[] files = FileEditorManager.getInstance(project).getSelectedFiles();
+    Set<Module> relatedModules =
+      Arrays.stream(files)
+        .map(x -> ProjectRootManager.getInstance(project).getFileIndex().getModuleForFile(x))
+        .collect(Collectors.toSet());
+
+    return relatedModules.stream()
+      .map(PantsUtil::getNonGenTargetAddresses)
+      .flatMap(Collection::stream);
+  }
+}

--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -199,6 +199,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
     // If project has not changed since last Compile, return immediately.
     if (!FileChangeTracker.shouldRecompileThenReset(currentProject, targetAddressesToCompile)) {
       PantsExternalMetricsListenerManager.getInstance().logIsPantsNoopCompile(true);
+      showPantsMakeTaskMessage("Already up to date.\n", ConsoleViewContentType.SYSTEM_OUTPUT, currentProject);
       return Pair.create(true, Optional.of(PantsConstants.NOOP_COMPILE));
     }
 

--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -199,7 +199,8 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
     // If project has not changed since last Compile, return immediately.
     if (!FileChangeTracker.shouldRecompileThenReset(currentProject, targetAddressesToCompile)) {
       PantsExternalMetricsListenerManager.getInstance().logIsPantsNoopCompile(true);
-      showPantsMakeTaskMessage("Already up to date.\n", ConsoleViewContentType.SYSTEM_OUTPUT, currentProject);
+      Notification start = new Notification(PantsConstants.PANTS, "Pants Compile", "Already up to date.\n", NotificationType.INFORMATION);
+      Notifications.Bus.notify(start);
       return Pair.create(true, Optional.of(PantsConstants.NOOP_COMPILE));
     }
 

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
@@ -90,7 +90,7 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
     doImport("examples/tests/scala/org/pantsbuild/example");
 
     ArrayList<Pair<String, String>> testClassAndTarget = Lists.newArrayList(
-      // Pair of class reference and the target it belong to
+      // Pair of class reference and its containing target
       Pair.create("org.pantsbuild.example.hello.welcome.WelSpec", "examples/tests/scala/org/pantsbuild/example/hello/welcome:welcome"),
       Pair.create("org.pantsbuild.example.specs2.HelloWorldSpec", "examples/tests/scala/org/pantsbuild/example/specs2:specs2")
     );

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
@@ -88,11 +88,16 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
 
   public void testCompileTargetsInSelectedEditor() throws Throwable {
     doImport("examples/tests/scala/org/pantsbuild/example");
-
     ArrayList<Pair<String, String>> testClassAndTarget = Lists.newArrayList(
       // Pair of class reference and its containing target
-      Pair.create("org.pantsbuild.example.hello.welcome.WelSpec", "examples/tests/scala/org/pantsbuild/example/hello/welcome:welcome"),
-      Pair.create("org.pantsbuild.example.specs2.HelloWorldSpec", "examples/tests/scala/org/pantsbuild/example/specs2:specs2")
+      Pair.create(
+        "org.pantsbuild.example.hello.welcome.WelSpec",
+        "examples/tests/scala/org/pantsbuild/example/hello/welcome:welcome"
+      ),
+      Pair.create(
+        "org.pantsbuild.example.hello.welcome.WelcomeEverybody",
+        "examples/src/scala/org/pantsbuild/example/hello/welcome:welcome"
+      )
     );
 
     for (Pair<String, String> classAndTarget : testClassAndTarget) {

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
@@ -3,15 +3,24 @@
 
 package com.twitter.intellij.pants.integration;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.search.GlobalSearchScope;
 import com.twitter.intellij.pants.compiler.actions.PantsCompileAllTargetsAction;
 import com.twitter.intellij.pants.compiler.actions.PantsCompileAllTargetsInModuleAction;
+import com.twitter.intellij.pants.compiler.actions.PantsCompileCurrentTargetAction;
 import com.twitter.intellij.pants.compiler.actions.PantsCompileTargetAction;
 import com.twitter.intellij.pants.compiler.actions.PantsRebuildAction;
 import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -75,6 +84,31 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
     ));
     assertEquals(expectedTargets, targetAddresses);
     assertFalse(compileAllTargetsInModuleAction.doCleanAll());
+  }
+
+  public void testCompileTargetsInSelectedEditor() throws Throwable {
+    doImport("examples/tests/scala/org/pantsbuild/example");
+
+    ArrayList<Pair<String, String>> testClassAndTarget = Lists.newArrayList(
+      // Pair of class reference and the target it belong to
+      Pair.create("org.pantsbuild.example.hello.welcome.WelSpec", "examples/tests/scala/org/pantsbuild/example/hello/welcome:welcome"),
+      Pair.create("org.pantsbuild.example.specs2.HelloWorldSpec", "examples/tests/scala/org/pantsbuild/example/specs2:specs2")
+    );
+
+    for (Pair<String, String> classAndTarget : testClassAndTarget) {
+      String clazzName = classAndTarget.getFirst();
+      String target = classAndTarget.getSecond();
+
+      PsiClass clazz = JavaPsiFacade.getInstance(myProject)
+        .findClass(clazzName, GlobalSearchScope.projectScope(myProject));
+
+      assertNotNull(String.format("%s does not exist, but should.", clazz), clazz);
+
+      FileEditorManager.getInstance(myProject).openFile(clazz.getContainingFile().getVirtualFile(), true);
+      PantsCompileCurrentTargetAction compileCurrentTargetAction = new PantsCompileCurrentTargetAction();
+      Set<String> currentTargets = compileCurrentTargetAction.getTargets(getPantsActionEvent(), myProject).collect(Collectors.toSet());
+      assertEquals(Sets.newHashSet(target), currentTargets);
+    }
   }
 
   private AnActionEvent getPantsActionEvent() {

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
@@ -101,6 +101,7 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
     );
 
     for (Pair<String, String> classAndTarget : testClassAndTarget) {
+      // Preparation
       String clazzName = classAndTarget.getFirst();
       String target = classAndTarget.getSecond();
 
@@ -109,8 +110,11 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
 
       assertNotNull(String.format("%s does not exist, but should.", clazz), clazz);
 
+      // Open the file and have the editor focus on it
       FileEditorManager.getInstance(myProject).openFile(clazz.getContainingFile().getVirtualFile(), true);
       PantsCompileCurrentTargetAction compileCurrentTargetAction = new PantsCompileCurrentTargetAction();
+
+      // Execute body
       Set<String> currentTargets = compileCurrentTargetAction.getTargets(getPantsActionEvent(), myProject).collect(Collectors.toSet());
       assertEquals(Sets.newHashSet(target), currentTargets);
     }


### PR DESCRIPTION
This change adds a quick way to trigger Pants compile for the target under edit. User can choose to tie the action in their keymap.