### PR TITLE
Exclude trilead-ssh2 from plugin dist

### DIFF
--- a/scripts/sdk/BUILD
+++ b/scripts/sdk/BUILD
@@ -254,6 +254,7 @@ jvm_binary(
     exclude('com.intellij.sdk.community', 'studio-profiler-grpc'),
     exclude('com.intellij.sdk.community', 'swingx-core'),
     exclude('com.intellij.sdk.community', 'trang-core'),
+    exclude('com.intellij.sdk.community', 'trilead-ssh2'),
     exclude('com.intellij.sdk.community', 'trove4j'),
     exclude('com.intellij.sdk.community', 'util'),
     exclude('com.intellij.sdk.community', 'velocity'),


### PR DESCRIPTION
Generated by `scripts/get_3rdparty_jars.py`