### PR TITLE
Add .idea, .pants.d to git ignore

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -23,9 +23,6 @@ write: False
 [compile.zinc]
 debug_symbols: True
 
-[compile.scalafmt]
-skip: True
-
 [jvm]
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
       </ul>
       ]]>
   </change-notes>
-  <version>1.7.0</version>
+  <version>1.7.0.git_ignore</version>
   <vendor>Twitter, Inc.</vendor>
 
   <!--if you are changing since-build don't forget to change it in .travis.yml file as well-->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
       </ul>
       ]]>
   </change-notes>
-  <version>1.7.0.git_ignore</version>
+  <version>1.7.0</version>
   <vendor>Twitter, Inc.</vendor>
 
   <!--if you are changing since-build don't forget to change it in .travis.yml file as well-->

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -98,7 +98,6 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
             addPantsProjectIgnoredDirs();
           }
 
-
           subscribeToRunConfigurationAddition();
           FileChangeTracker.registerProject(myProject);
           final AbstractExternalSystemSettings pantsSettings = ExternalSystemApiUtil.getSettings(myProject, PantsConstants.SYSTEM_ID);

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vcs.changes.ChangeListManagerImpl;
+import com.intellij.openapi.vcs.changes.IgnoredBeanFactory;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.twitter.intellij.pants.PantsBundle;
@@ -195,8 +196,15 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
 
   private void addPantsProjectIgnoredDirs() {
     PantsUtil.findBuildRoot(myProject).ifPresent(
-      buildRoot -> ChangeListManagerImpl.getInstanceImpl(myProject)
-        .addDirectoryToIgnoreImplicitly(buildRoot.getPath() + File.separator + ".idea")
+      buildRoot -> {
+        ChangeListManagerImpl clm = ChangeListManagerImpl.getInstanceImpl(myProject);
+        String pathToIgnore = buildRoot.getPath() + File.separator + ".idea";
+        // This will add buildroot/.idea to Version Control -> Ignored Files
+        // TODO: make sure it reflects on GUI immediately without a project reload.
+        clm.addFilesToIgnore(IgnoredBeanFactory.ignoreUnderDirectory(pathToIgnore, myProject));
+        clm.scheduleUpdate();
+        clm.ensureUpToDate(false);
+      }
     );
   }
 

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -30,6 +30,7 @@ import com.twitter.intellij.pants.file.FileChangeTracker;
 import com.twitter.intellij.pants.metrics.LivePantsMetrics;
 import com.twitter.intellij.pants.metrics.PantsExternalMetricsListenerManager;
 import com.twitter.intellij.pants.metrics.PantsMetrics;
+import com.twitter.intellij.pants.model.PantsOptions;
 import com.twitter.intellij.pants.service.project.PantsResolver;
 import com.twitter.intellij.pants.settings.PantsProjectSettings;
 import com.twitter.intellij.pants.settings.PantsSettings;
@@ -192,14 +193,22 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
     );
   }
 
+  /**
+   * This will add buildroot/.idea, buildroot/.pants.d to Version Control -> Ignored Files
+   * TODO: make sure it reflects on GUI immediately without a project reload.
+   */
   private void addPantsProjectIgnoredDirs() {
     PantsUtil.findBuildRoot(myProject).ifPresent(
       buildRoot -> {
         ChangeListManagerImpl clm = ChangeListManagerImpl.getInstanceImpl(myProject);
+
         String pathToIgnore = buildRoot.getPath() + File.separator + ".idea";
-        // This will add buildroot/.idea to Version Control -> Ignored Files
-        // TODO: make sure it reflects on GUI immediately without a project reload.
         clm.addDirectoryToIgnoreImplicitly(pathToIgnore);
+
+        PantsOptions.getPantsOptions(myProject).map(optionObj -> optionObj.get(PantsConstants.PANTS_OPTION_PANTS_WORKDIR))
+          .ifPresent(optionString -> optionString.ifPresent(
+            clm::addDirectoryToIgnoreImplicitly
+          ));
       }
     );
   }

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.vcs.changes.ChangeListManagerImpl;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.twitter.intellij.pants.PantsBundle;
@@ -38,6 +39,7 @@ import com.twitter.intellij.pants.util.PantsUtil;
 import icons.PantsIcons;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -89,6 +91,11 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
           if (PantsUtil.isSeedPantsProject(myProject)) {
             convertToPantsProject();
           }
+
+          PantsUtil.findBuildRoot(myProject).ifPresent(
+            buildRoot -> ChangeListManagerImpl.getInstanceImpl(myProject)
+              .addDirectoryToIgnoreImplicitly(buildRoot.getPath() + File.separator + ".idea")
+          );
 
           subscribeToRunConfigurationAddition();
           FileChangeTracker.registerProject(myProject);

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -73,6 +73,10 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
   public void projectOpened() {
     PantsMetrics.initialize();
     PantsConsoleManager.registerConsole(myProject);
+    if (PantsUtil.isPantsProject(myProject)) {
+      addPantsProjectIgnoredDirs();
+    }
+
     super.projectOpened();
     if (myProject.isDefault()) {
       return;
@@ -90,12 +94,9 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
 
           if (PantsUtil.isSeedPantsProject(myProject)) {
             convertToPantsProject();
+            addPantsProjectIgnoredDirs();
           }
 
-          PantsUtil.findBuildRoot(myProject).ifPresent(
-            buildRoot -> ChangeListManagerImpl.getInstanceImpl(myProject)
-              .addDirectoryToIgnoreImplicitly(buildRoot.getPath() + File.separator + ".idea")
-          );
 
           subscribeToRunConfigurationAddition();
           FileChangeTracker.registerProject(myProject);
@@ -189,6 +190,13 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
           });
         }
       }
+    );
+  }
+
+  private void addPantsProjectIgnoredDirs() {
+    PantsUtil.findBuildRoot(myProject).ifPresent(
+      buildRoot -> ChangeListManagerImpl.getInstanceImpl(myProject)
+        .addDirectoryToIgnoreImplicitly(buildRoot.getPath() + File.separator + ".idea")
     );
   }
 

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -21,7 +21,6 @@ import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vcs.changes.ChangeListManagerImpl;
-import com.intellij.openapi.vcs.changes.IgnoredBeanFactory;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.twitter.intellij.pants.PantsBundle;
@@ -200,9 +199,7 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
         String pathToIgnore = buildRoot.getPath() + File.separator + ".idea";
         // This will add buildroot/.idea to Version Control -> Ignored Files
         // TODO: make sure it reflects on GUI immediately without a project reload.
-        clm.addFilesToIgnore(IgnoredBeanFactory.ignoreUnderDirectory(pathToIgnore, myProject));
-        clm.scheduleUpdate();
-        clm.ensureUpToDate(false);
+        clm.addDirectoryToIgnoreImplicitly(pathToIgnore);
       }
     );
   }

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -194,7 +194,9 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
   }
 
   /**
-   * This will add buildroot/.idea, buildroot/.pants.d to Version Control -> Ignored Files
+   * This will add buildroot/.idea, buildroot/.pants.d to Version Control -> Ignored Files.
+   * This is correctly impossible to test because {@link com.intellij.openapi.externalSystem.test.ExternalSystemTestCase}
+   * put project file in a temp dir unrelated to where the repo resides.
    * TODO: make sure it reflects on GUI immediately without a project reload.
    */
   private void addPantsProjectIgnoredDirs() {


### PR DESCRIPTION
### Problem

IntelliJ git plugin will occasionally prompt user to add files under `<buildroot>/.idea`, `<buildroot>/.pants` to git.

### Solution
This change addes `<buildroot>/.idea`, `<buildroot>/.pants` to Version Control -> Ignored Files.
