### PR TITLE
Add assertions for accidental bug fix from #312

### DIFF
--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -37,7 +37,7 @@ fi
 
 # we will use Community ids to download plugins.
 export SCALA_PLUGIN_ID="org.intellij.scala"
-export SCALA_PLUGIN_MD5="e2b247e6c5edf2a6d7e2472769ec2bb7" # 2017.2.11
+export SCALA_PLUGIN_MD5="474ec053a0fbf6a9772b380c1efaf03e" # 2017.2.11
 
 export INTELLIJ_PLUGINS_HOME="$CWD/.cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins"
 export INTELLIJ_HOME="$CWD/.cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist"

--- a/src/com/twitter/intellij/pants/compiler/actions/PantsCompileAllTargetsInModuleAction.java
+++ b/src/com/twitter/intellij/pants/compiler/actions/PantsCompileAllTargetsInModuleAction.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
  */
 public class PantsCompileAllTargetsInModuleAction extends PantsCompileActionBase {
 
-  private final Optional<Module> module;
+  public final Optional<Module> module;
 
   public PantsCompileAllTargetsInModuleAction(Optional<Module> module) {
     super("Compile all targets in module");

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
@@ -93,12 +93,10 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
     assertFalse(action.module.isPresent());
 
     VirtualFile vf = PantsUtil.findFileRelativeToBuildRoot(myProject, "testprojects/src/java/org/pantsbuild/testproject/junit/mixed/tests/org/pantsbuild/tmp/tests/AllTests.java").get();
-    Module mockModule = PantsUtil.getModuleForFile(vf, myProject).get();
-    assertEquals(mockModule, mixedModule);
+    assertEquals(mixedModule, PantsUtil.getModuleForFile(vf, myProject).get());
     Set<String> expectedTargetsMixed = Sets.newHashSet(
       "testprojects/src/java/org/pantsbuild/testproject/junit/mixed/tests/org/pantsbuild/tmp/tests:tests");
-    Set<String> mixedModuleAddresses = PantsUtil.getNonGenTargetAddresses(mixedModule).stream().collect(Collectors.toSet());
-    assertEquals(mixedModuleAddresses, expectedTargetsMixed);
+    assertEquals(expectedTargetsMixed, PantsUtil.getNonGenTargetAddresses(mixedModule).stream().collect(Collectors.toSet()));
     DataContext dcMock = new DataContext() {
         @Override
         public Object getData(String dataId) {
@@ -115,7 +113,7 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
 
     PantsCompileAllTargetsInModuleAction compileAllTargetsInModuleAction = new PantsCompileAllTargetsInModuleAction(Optional.of(testscopeModule));
     assertTrue(compileAllTargetsInModuleAction.module.isPresent());
-    assertEquals(compileAllTargetsInModuleAction.module.get(), testscopeModule);
+    assertEquals(testscopeModule, compileAllTargetsInModuleAction.module.get());
 
     Set<String> targetAddresses = compileAllTargetsInModuleAction.getTargets(getPantsActionEvent(), myProject).collect(Collectors.toSet());
     Set<String> expectedTargets = Sets.newHashSet(
@@ -125,12 +123,12 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
       "testprojects/src/java/org/pantsbuild/testproject/junit/testscope:bin");
     assertEquals(expectedTargets, targetAddresses);
     assertTrue(compileAllTargetsInModuleAction.module.isPresent());
-    assertEquals(compileAllTargetsInModuleAction.module.get(), testscopeModule);
+    assertEquals(testscopeModule, compileAllTargetsInModuleAction.module.get());
 
     Set<String> mockedTargetAddresses = compileAllTargetsInModuleAction.getTargets(evMock, myProject).collect(Collectors.toSet());
     assertEquals(expectedTargets, mockedTargetAddresses);
     assertTrue(compileAllTargetsInModuleAction.module.isPresent());
-    assertEquals(compileAllTargetsInModuleAction.module.get(), testscopeModule);
+    assertEquals(testscopeModule, compileAllTargetsInModuleAction.module.get());
   }
 
   public void testCompileTargetsInSelectedEditor() throws Throwable {

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
@@ -6,6 +6,7 @@ package com.twitter.intellij.pants.integration;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.Module;
@@ -86,19 +87,50 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
 
   public void testCompileAllTargetsInModuleAction() throws Throwable {
     doImport("testprojects/src/java/org/pantsbuild/testproject/junit");
-    Module module = getModule("testprojects_src_java_org_pantsbuild_testproject_junit_testscope_common_sources");
-    PantsCompileAllTargetsInModuleAction compileAllTargetsInModuleAction =
-      new PantsCompileAllTargetsInModuleAction(Optional.of(module));
-    Set<String> targetAddresses = compileAllTargetsInModuleAction
-      .getTargets(getPantsActionEvent(), myProject)
-      .collect(Collectors.toSet());
-    Set<String> expectedTargets = new HashSet<>(Arrays.asList(
+    Module testscopeModule = getModule("testprojects_src_java_org_pantsbuild_testproject_junit_testscope_common_sources");
+    Module mixedModule = getModule("testprojects_src_java_org_pantsbuild_testproject_junit_mixed_tests_org_pantsbuild_tmp_tests_tests");
+    PantsCompileAllTargetsInModuleAction action = new PantsCompileAllTargetsInModuleAction(Optional.empty());
+    assertFalse(action.module.isPresent());
+
+    VirtualFile vf = PantsUtil.findFileRelativeToBuildRoot(myProject, "testprojects/src/java/org/pantsbuild/testproject/junit/mixed/tests/org/pantsbuild/tmp/tests/AllTests.java").get();
+    Module mockModule = PantsUtil.getModuleForFile(vf, myProject).get();
+    assertEquals(mockModule, mixedModule);
+    Set<String> expectedTargetsMixed = Sets.newHashSet(
+      "testprojects/src/java/org/pantsbuild/testproject/junit/mixed/tests/org/pantsbuild/tmp/tests:tests");
+    Set<String> mixedModuleAddresses = PantsUtil.getNonGenTargetAddresses(mixedModule).stream().collect(Collectors.toSet());
+    assertEquals(mixedModuleAddresses, expectedTargetsMixed);
+    DataContext dcMock = new DataContext() {
+        @Override
+        public Object getData(String dataId) {
+          if (dataId.equals(CommonDataKeys.VIRTUAL_FILE.getName())) {
+            return vf;
+          }
+          return null;
+        }
+    };
+    AnActionEvent evMock = AnActionEvent.createFromDataContext("", null, dcMock);
+    Set<String> mockAddresses = action.getTargets(evMock, myProject).collect(Collectors.toSet());
+    assertEquals(expectedTargetsMixed, mockAddresses);
+    assertFalse(action.module.isPresent());
+
+    PantsCompileAllTargetsInModuleAction compileAllTargetsInModuleAction = new PantsCompileAllTargetsInModuleAction(Optional.of(testscopeModule));
+    assertTrue(compileAllTargetsInModuleAction.module.isPresent());
+    assertEquals(compileAllTargetsInModuleAction.module.get(), testscopeModule);
+
+    Set<String> targetAddresses = compileAllTargetsInModuleAction.getTargets(getPantsActionEvent(), myProject).collect(Collectors.toSet());
+    Set<String> expectedTargets = Sets.newHashSet(
       "testprojects/src/java/org/pantsbuild/testproject/junit/testscope:tests",
       "testprojects/src/java/org/pantsbuild/testproject/junit/testscope:check",
       "testprojects/src/java/org/pantsbuild/testproject/junit/testscope:lib",
-      "testprojects/src/java/org/pantsbuild/testproject/junit/testscope:bin"
-    ));
+      "testprojects/src/java/org/pantsbuild/testproject/junit/testscope:bin");
     assertEquals(expectedTargets, targetAddresses);
+    assertTrue(compileAllTargetsInModuleAction.module.isPresent());
+    assertEquals(compileAllTargetsInModuleAction.module.get(), testscopeModule);
+
+    Set<String> mockedTargetAddresses = compileAllTargetsInModuleAction.getTargets(evMock, myProject).collect(Collectors.toSet());
+    assertEquals(expectedTargets, mockedTargetAddresses);
+    assertTrue(compileAllTargetsInModuleAction.module.isPresent());
+    assertEquals(compileAllTargetsInModuleAction.module.get(), testscopeModule);
   }
 
   public void testCompileTargetsInSelectedEditor() throws Throwable {
@@ -137,6 +169,8 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
     }
   }
 
+  // TODO(cosmicexplorer): should check the output of the lint task and ensure it catches errors
+  // according to the lint specification
   public void testLintTargetAction() throws Throwable {
     // check whether we have expected targets
     doImport("testprojects/src/java/org/pantsbuild/testproject/annotation");


### PR DESCRIPTION
In #312, a change was made to [`CompileAllTargetsInModuleAction.java`](https://github.com/pantsbuild/intellij-pants-plugin/pull/312/files#diff-41cc874d589fdbd635d9ca9f78149ef9) which stopped a bug that affected usage.

To reproduce the error, take a version of the plugin from any commit before b2a024a52a9287d74944400dc4f27a7a613989ba. Open a pants project A, then open a pants project B in a separate window. Click `Build->Compile Module '...'` with a source file from A open in the editor, which should work correctly. Switch to the window for project B, open a source file from B in the editor, then click `Build->Compile Module '...'`. The name of the module will be correct, but the `./pants compile ...` command will build the module from project A (which can be seen in the pants console -- the targets for project A are selected).

#312 accidentally fixed this (see link to diff at the top of this comment) by not mutating the private `module` field in `CompileAllTargetsInModuleAction`, but I didn't realize this modified any behavior until the bug above came to my attention. This adds multiple assertions to `OSSPantsCompileActionsTest#testCompileAllTargetsInModuleAction` to avoid a regression.