### PR TITLE
Prepare the 1.8.0 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,25 +112,25 @@ test sources, resources, test resources, generated sources, etc).
 * Run plugin configuration 'Pants' to verify your setup. It should launch a separate IntelliJ app.
 
 ### Release process:
-* Create a new release branch from the latest master. E.g. `git checkout -b 1.7.0`
+* Create a new release branch from the latest master. E.g. `git checkout -b 1.8.0`
 * In plugin.xml:
-  * Update `<version>`. E.g. `1.7.0`
+  * Update `<version>`. E.g. `1.8.0`
   * Make sure of since/until build number for target IDEA versions.
 * Do a dry run on publishing, and make sure it has no error and produces a pants_xxx.zip
   ```
   $ TRAVIS_BRANCH=master ./scripts/deploy/deploy.sh --skip-publish
-  INFO:__main__:Append current git sha, c891da3a7dc4bca40938717696310ba612fcba07, to plugin version
-  INFO:__main__:Releasing 1.7.0.c891da3a7dc4bca40938717696310ba612fcba07 to BleedingEdge channel
+  INFO:__main__:Append current git sha, a35c3c816bbc4453ccc9142e86c3b463d43b7f76, to plugin version
+  INFO:__main__:Releasing 1.8.0.a35c3c816bbc4453ccc9142e86c3b463d43b7f76 to BleedingEdge channel
   INFO:__main__:rm -rf dist;./pants binary scripts/sdk:intellij-pants-plugin-publish
   INFO:__main__:Packaging into a zip
-  INFO:__main__:mkdir -p tmp/pants/lib && cp dist/intellij-pants-plugin-publish.jar tmp/pants/lib && cd tmp && zip -r pants_1.7.0.c891da3a7dc4bca40938717696310ba612fcba07.zip pants/ &&cd .. &&cp tmp/pants_1.7.0.c891da3a7dc4bca40938717696310ba612fcba07.zip pants_1.7.0.c891da3a7dc4bca40938717696310ba612fcba07.zip &&rm -rf tmp
-  INFO:__main__:pants_1.7.0.c891da3a7dc4bca40938717696310ba612fcba07.zip built successfully
+  INFO:__main__:mkdir -p tmp/pants/lib && cp dist/intellij-pants-plugin-publish.jar tmp/pants/lib && cd tmp && zip -r pants_1.8.0.a35c3c816bbc4453ccc9142e86c3b463d43b7f76.zip pants/ &&cd .. &&cp tmp/pants_1.8.0.a35c3c816bbc4453ccc9142e86c3b463d43b7f76.zip pants_1.8.0.a35c3c816bbc4453ccc9142e86c3b463d43b7f76.zip &&rm -rf tmp
+  INFO:__main__:pants_1.8.0.a35c3c816bbc4453ccc9142e86c3b463d43b7f76.zip built successfully
   INFO:__main__:Publishing skipped.
   ```
 * Open an PR. In description, add the change notes which can be obtained by inspecting the commit since last release.
 * Submit review with green Travis CI.
-* Once merged, create git tag with release number in master. E.g. `git tag release_1.7.0`
-* Push the tag. E.g. `git push upstream release_1.7.0`. Fill out the release notes on github.
+* Once merged, create git tag with release number in master. E.g. `git tag release_1.8.0`
+* Push the tag. E.g. `git push upstream release_1.8.0`. Fill out the release notes on github.
 * Once the build for the tagged commit passed travis ci, the plugin will be published to the stable channel in [the plugin repo](https://plugins.jetbrains.com/plugin/7412)
 
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
       </ul>
       ]]>
   </change-notes>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <vendor>Twitter, Inc.</vendor>
 
   <idea-version since-build="173.0" until-build="173.*"/>


### PR DESCRIPTION
# Notable Changes
- Compatibility with IntelliJ 2017.3. #319 
- Add .idea, .pants.d to git ignore. #307 
- Improve exception messages used within import dialog. #314, #321 
- Update release doc. #306
- Add a lint action to the plugin context menus and dropdown menu. #312 
- Fix a bug which would occur when displaying two projects at once. #320 
- Attach annotations for plugin selected JDK. #308 