### PR TITLE
fix "Unrecognized command line flags on global scope: --async"

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -50,7 +50,7 @@ public class PantsConstants {
   public static final String PANTS_CLI_OPTION_NO_COLORS = "--no-colors";
   public static final String PANTS_CLI_OPTION_JVM_DISTRIBUTIONS_PATHS = "--jvm-distributions-paths";
   public static final String PANTS_CLI_OPTION_NO_TEST_JUNIT_TIMEOUTS = "--no-test-junit-timeouts";
-  public static final String PANTS_CLI_OPTION_ASYNC_CLEAN_ALL = "--async";
+  public static final String PANTS_CLI_OPTION_ASYNC_CLEAN_ALL = "--clean-all-async";
   public static final String PANTS_CLI_OPTION_PYTEST = "--test-pytest-options";
   public static final String PANTS_CLI_OPTION_JUNIT_TEST = "--test-junit-test";
 

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -37,7 +37,7 @@ fi
 
 # we will use Community ids to download plugins.
 export SCALA_PLUGIN_ID="org.intellij.scala"
-export SCALA_PLUGIN_MD5="5834e8b534e8a25a423f48c4b5365ebe"
+export SCALA_PLUGIN_MD5="5009e830aa1f24d2eddd88c2e0889d56"
 
 export INTELLIJ_PLUGINS_HOME="$CWD/.cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins"
 export INTELLIJ_HOME="$CWD/.cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist"

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Sets;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemBeforeRunTaskProvider;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
@@ -83,6 +84,10 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
       "testprojects/src/java/org/pantsbuild/testproject/annotation/main:main"
     ));
     assertEquals(expectedTargets, targetAddresses);
+
+    PantsMakeBeforeRun runner = (PantsMakeBeforeRun) ExternalSystemBeforeRunTaskProvider.getProvider(myProject, PantsMakeBeforeRun.ID);
+    PantsExecuteTaskResult result = rebuildAction.execute(runner, myProject, targetAddresses);
+    assertTrue(result.output.get(), result.succeeded);
   }
 
   public void testCompileAllTargetsInModuleAction() throws Throwable {

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsCompileActionsTest.java
@@ -24,6 +24,7 @@ import com.twitter.intellij.pants.compiler.actions.PantsCompileCurrentTargetActi
 import com.twitter.intellij.pants.compiler.actions.PantsCompileTargetAction;
 import com.twitter.intellij.pants.compiler.actions.PantsRebuildAction;
 import com.twitter.intellij.pants.compiler.actions.PantsLintTargetAction;
+import com.twitter.intellij.pants.compiler.actions.PantsTaskActionBase;
 import com.twitter.intellij.pants.execution.PantsExecuteTaskResult;
 import com.twitter.intellij.pants.execution.PantsMakeBeforeRun;
 import com.twitter.intellij.pants.model.PantsOptions;
@@ -43,6 +44,12 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
 
   private final DataContext PANTS_PROJECT_DATA = s -> s.equals("project") ? myProject : null;
 
+  protected void assertActionSucceeds(PantsTaskActionBase action, Set<String> targetAddresses) throws Exception {
+    PantsMakeBeforeRun runner = (PantsMakeBeforeRun) ExternalSystemBeforeRunTaskProvider.getProvider(myProject, PantsMakeBeforeRun.ID);
+    PantsExecuteTaskResult result = action.execute(runner, myProject, targetAddresses);
+    assertPantsCompileExecutesAndSucceeds(result);
+  }
+
   public void testCompileAllAction() throws Throwable {
     doImport("testprojects/src/java/org/pantsbuild/testproject/annotation");
     PantsCompileAllTargetsAction compileAllTargetsAction = new PantsCompileAllTargetsAction();
@@ -57,6 +64,7 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
       "testprojects/src/java/org/pantsbuild/testproject/annotation/main:main"
     ));
     assertEquals(expectedTargets, targetAddresses);
+    assertActionSucceeds(compileAllTargetsAction, targetAddresses);
   }
 
   public void testCompileTargetAction() throws Throwable {
@@ -68,6 +76,7 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
       .collect(Collectors.toSet());
     Set<String> expectedTarget = Sets.newHashSet("testprojects/src/java/org/pantsbuild/testproject/annotation/main:main");
     assertEquals(expectedTarget, targetAddresses);
+    assertActionSucceeds(compileTargetAction, Sets.newHashSet());
   }
 
   public void testRebuildAction() throws Throwable {
@@ -84,10 +93,7 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
       "testprojects/src/java/org/pantsbuild/testproject/annotation/main:main"
     ));
     assertEquals(expectedTargets, targetAddresses);
-
-    PantsMakeBeforeRun runner = (PantsMakeBeforeRun) ExternalSystemBeforeRunTaskProvider.getProvider(myProject, PantsMakeBeforeRun.ID);
-    PantsExecuteTaskResult result = rebuildAction.execute(runner, myProject, targetAddresses);
-    assertTrue(result.output.get(), result.succeeded);
+    assertActionSucceeds(rebuildAction, targetAddresses);
   }
 
   public void testCompileAllTargetsInModuleAction() throws Throwable {
@@ -134,6 +140,7 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
     assertEquals(expectedTargets, mockedTargetAddresses);
     assertTrue(compileAllTargetsInModuleAction.module.isPresent());
     assertEquals(testscopeModule, compileAllTargetsInModuleAction.module.get());
+    assertActionSucceeds(compileAllTargetsInModuleAction, expectedTargets);
   }
 
   public void testCompileTargetsInSelectedEditor() throws Throwable {
@@ -169,6 +176,7 @@ public class OSSPantsCompileActionsTest extends OSSPantsIntegrationTest {
         .getTargets(getPantsActionEvent(), myProject)
         .collect(Collectors.toSet());
       assertEquals(Sets.newHashSet(target), currentTargets);
+      assertActionSucceeds(compileCurrentTargetAction, currentTargets);
     }
   }
 


### PR DESCRIPTION
The "Rebuild" action was calling `clean-all`, but it added the `--async` parameter without a thought to the ordering of the command line. This fixes that error by using `--clean-all-async` and adds tests to stop similar regressions (`testRebuildAction` now fails if `--async` is used).