### PR TITLE
Make scala plugin an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ env:
     - PANTS_SHA="release_1.2.0" TEST_SET=jvm-integration
 
 script:
+  # Test a single Java target without scala plugin
+  - ENABLE_SCALA_PLUGIN=true ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest#testHello
   - ./scripts/run-tests-ci.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
 
 script:
   # Test a single Java target without scala plugin
-  - ENABLE_SCALA_PLUGIN=true ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest#testHello
+  - ENABLE_SCALA_PLUGIN=false ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest#testHello
   - ./scripts/run-tests-ci.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
 
 script:
   # Test a single Java target without scala plugin
-  - ENABLE_SCALA_PLUGIN=false ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest#testHello
+  - ENABLE_SCALA_PLUGIN=false ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest
   - ./scripts/run-tests-ci.sh
 
 after_success:

--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -70,6 +70,6 @@ public class PantsConstants {
   public static final String PANTS_TASK_EXPORT_CLASSPATH = "export-classpath";
   public static final String PANTS_TASK_LINT = "lint";
 
-  public static final String SCALA_PLUGIN_ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME =
-    "org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration";
+  public static final String SCALA_PLUGIN_PACKAGE_TEST_SCALATEST =
+    "org.jetbrains.plugins.scala.testingSupport.test.scalatest";
 }

--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -25,6 +25,8 @@ public class PantsConstants {
   public static final String PANTS_INI = "pants.ini";
   public static final String PANTS_PEX = "pants.pex";
   public static final String PANTS_LIBRARY_NAME = PANTS_PEX;
+  public static final String ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME =
+    "org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration";
 
   protected static final String BUILD = "BUILD";
   protected static final String THRIFT_EXT = "thrift";

--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -25,8 +25,6 @@ public class PantsConstants {
   public static final String PANTS_INI = "pants.ini";
   public static final String PANTS_PEX = "pants.pex";
   public static final String PANTS_LIBRARY_NAME = PANTS_PEX;
-  public static final String ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME =
-    "org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration";
 
   protected static final String BUILD = "BUILD";
   protected static final String THRIFT_EXT = "thrift";
@@ -71,4 +69,7 @@ public class PantsConstants {
   public static final String PANTS_TASK_COMPILE = "compile";
   public static final String PANTS_TASK_EXPORT_CLASSPATH = "export-classpath";
   public static final String PANTS_TASK_LINT = "lint";
+
+  public static final String SCALA_PLUGIN_ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME =
+    "org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration";
 }

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessOutput;
@@ -185,6 +186,10 @@ public class PantsUtil {
       return findPantsExecutable(file).isPresent();
     }
     return isBUILDFileName(file.getName());
+  }
+
+  public static boolean isScalaTestRunConfiguration(RunConfiguration rc) {
+    return rc.getClass().getPackage().getName().startsWith(PantsConstants.SCALA_PLUGIN_PACKAGE_TEST_SCALATEST);
   }
 
   public static Optional<String> findPantsVersion(Optional<VirtualFile> workingDir) {

--- a/resources/META-INF/pants-scala.xml
+++ b/resources/META-INF/pants-scala.xml
@@ -1,0 +1,9 @@
+<!-- Copyright 2018 Pants project contributors (see CONTRIBUTORS.md). -->
+<!-- Licensed under the Apache License, Version 2.0 (see LICENSE). -->
+
+<idea-plugin version="2">
+  <extensions defaultExtensionNs="com.intellij">
+    <externalProjectDataService implementation="com.twitter.intellij.pants.service.scala.PantsScalaDataService" order="last"/>
+    <highlightVisitor implementation="com.twitter.intellij.pants.highlight.PantsScalaHighlightVisitor"/>
+  </extensions>
+</idea-plugin>

--- a/resources/META-INF/pants-scala.xml
+++ b/resources/META-INF/pants-scala.xml
@@ -6,4 +6,7 @@
     <externalProjectDataService implementation="com.twitter.intellij.pants.service.scala.PantsScalaDataService" order="last"/>
     <highlightVisitor implementation="com.twitter.intellij.pants.highlight.PantsScalaHighlightVisitor"/>
   </extensions>
+  <extensions defaultExtensionNs="com.intellij.plugins.pants">
+    <projectResolver implementation="com.twitter.intellij.pants.service.scala.ScalaSdkResolver"/>
+  </extensions>
 </idea-plugin>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -17,20 +17,15 @@
 
   <idea-version since-build="181.0" until-build="181.*"/>
 
-  <!--Scala plugin related extensions-->
-  <depends>org.intellij.scala</depends>
   <!--Add gradle as a dep because of Pants runner requires it.-->
   <depends>org.jetbrains.plugins.gradle</depends>
   <extensions defaultExtensionNs="com.intellij.plugins.pants">
     <projectResolver implementation="com.twitter.intellij.pants.service.scala.ScalaSdkResolver"/>
   </extensions>
-  <extensions defaultExtensionNs="com.intellij">
-    <externalProjectDataService implementation="com.twitter.intellij.pants.service.scala.PantsScalaDataService" order="last"/>
-    <highlightVisitor implementation="com.twitter.intellij.pants.highlight.PantsScalaHighlightVisitor"/>
-  </extensions>
+
   <!--End of scala plugin related extensions-->
 
-  <depends>JUnit</depends>
+  <depends optional="true" config-file="pants-scala.xml">org.intellij.scala</depends>
   <depends optional="true" config-file="pants-python.xml">Pythonid</depends>
   <depends optional="true" config-file="pants-python.xml">PythonCore</depends>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -19,11 +19,6 @@
 
   <!--Add gradle as a dep because of Pants runner requires it.-->
   <depends>org.jetbrains.plugins.gradle</depends>
-  <extensions defaultExtensionNs="com.intellij.plugins.pants">
-    <projectResolver implementation="com.twitter.intellij.pants.service.scala.ScalaSdkResolver"/>
-  </extensions>
-
-  <!--End of scala plugin related extensions-->
 
   <depends optional="true" config-file="pants-scala.xml">org.intellij.scala</depends>
   <depends optional="true" config-file="pants-python.xml">Pythonid</depends>

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -49,8 +49,14 @@ append_intellij_jvm_options() {
   scope=$1
   cmd=""
 
+  if [[ ${ENABLE_SCALA_PLUGIN} ]]; then
+    load_plugins="-Didea.load.plugins.id=com.intellij.properties,org.intellij.groovy,org.jetbrains.plugins.gradle,org.intellij.scala,PythonCore,JUnit,com.intellij.plugins.pants"
+  else
+    load_plugins="-Didea.load.plugins.id=com.intellij.properties,org.intellij.groovy,org.jetbrains.plugins.gradle,PythonCore,JUnit,com.intellij.plugins.pants"
+  fi
+
   INTELLIJ_JVM_OPTIONS=(
-    "-Didea.load.plugins.id=com.intellij.properties,org.intellij.groovy,org.jetbrains.plugins.gradle,org.intellij.scala,PythonCore,JUnit,com.intellij.plugins.pants"
+    "-Didea.load.plugins.id=${load_plugins}"
     "-Didea.plugins.path=$INTELLIJ_PLUGINS_HOME"
     "-Didea.home.path=$INTELLIJ_HOME"
     "-Dpants.plugin.base.path=$CWD/.pants.d/compile/jvm/java"

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -49,7 +49,7 @@ append_intellij_jvm_options() {
   scope=$1
   cmd=""
 
-  if [[ ${ENABLE_SCALA_PLUGIN} ]]; then
+  if [[ ${ENABLE_SCALA_PLUGIN:=true} == true ]]; then
     load_plugins="-Didea.load.plugins.id=com.intellij.properties,org.intellij.groovy,org.jetbrains.plugins.gradle,org.intellij.scala,PythonCore,JUnit,com.intellij.plugins.pants"
   else
     load_plugins="-Didea.load.plugins.id=com.intellij.properties,org.intellij.groovy,org.jetbrains.plugins.gradle,PythonCore,JUnit,com.intellij.plugins.pants"

--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -96,8 +96,9 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
     /**
      /**
      * Scala related run/test configuration inherit {@link AbstractTestRunConfiguration}
+     * Use string test on class name due to scala plugin can be optional and it is hard to separate this logic.
      */
-    if (runConfiguration instanceof AbstractTestRunConfiguration) {
+    if (runConfiguration.getClass().getName().equals("org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration")) {
       if (buildRoot.isPresent()) {
         ((AbstractTestRunConfiguration) runConfiguration).setWorkingDirectory(buildRoot.get().getPath());
       }

--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -98,7 +98,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
      * Scala related run/test configuration inherit {@link AbstractTestRunConfiguration}
      * Use string test on class name due to scala plugin can be optional and it is hard to separate this logic.
      */
-    if (runConfiguration.getClass().getName().equals(PantsConstants.ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
+    if (runConfiguration.getClass().getName().equals(PantsConstants.SCALA_PLUGIN_ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
       if (buildRoot.isPresent()) {
         ((AbstractTestRunConfiguration) runConfiguration).setWorkingDirectory(buildRoot.get().getPath());
       }
@@ -365,7 +365,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
   @NotNull
   protected Set<String> getTargetAddressesToCompile(RunConfiguration configuration) {
     /* Scala run configurations */
-    if (configuration.getClass().getName().equals(PantsConstants.ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
+    if (configuration.getClass().getName().equals(PantsConstants.SCALA_PLUGIN_ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
       Module module = ((AbstractTestRunConfiguration) configuration).getModule();
       return getTargetAddressesToCompile(new Module[]{module});
     }

--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -98,7 +98,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
      * Scala related run/test configuration inherit {@link AbstractTestRunConfiguration}
      * Use string test on class name due to scala plugin can be optional and it is hard to separate this logic.
      */
-    if (runConfiguration.getClass().getName().equals("org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration")) {
+    if (runConfiguration.getClass().getName().equals(PantsConstants.ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
       if (buildRoot.isPresent()) {
         ((AbstractTestRunConfiguration) runConfiguration).setWorkingDirectory(buildRoot.get().getPath());
       }
@@ -365,7 +365,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
   @NotNull
   protected Set<String> getTargetAddressesToCompile(RunConfiguration configuration) {
     /* Scala run configurations */
-    if (configuration instanceof AbstractTestRunConfiguration) {
+    if (configuration.getClass().getName().equals(PantsConstants.ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
       Module module = ((AbstractTestRunConfiguration) configuration).getModule();
       return getTargetAddressesToCompile(new Module[]{module});
     }

--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -98,7 +98,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
      * Scala related run/test configuration inherit {@link AbstractTestRunConfiguration}
      * Use string test on class name due to scala plugin can be optional and it is hard to separate this logic.
      */
-    if (runConfiguration.getClass().getName().equals(PantsConstants.SCALA_PLUGIN_ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
+    if (PantsUtil.isScalaTestRunConfiguration(runConfiguration)) {
       if (buildRoot.isPresent()) {
         ((AbstractTestRunConfiguration) runConfiguration).setWorkingDirectory(buildRoot.get().getPath());
       }
@@ -365,7 +365,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
   @NotNull
   protected Set<String> getTargetAddressesToCompile(RunConfiguration configuration) {
     /* Scala run configurations */
-    if (configuration.getClass().getName().equals(PantsConstants.SCALA_PLUGIN_ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
+    if (PantsUtil.isScalaTestRunConfiguration(configuration)) {
       Module module = ((AbstractTestRunConfiguration) configuration).getModule();
       return getTargetAddressesToCompile(new Module[]{module});
     }

--- a/src/com/twitter/intellij/pants/metrics/PantsExternalMetricsListenerManager.java
+++ b/src/com/twitter/intellij/pants/metrics/PantsExternalMetricsListenerManager.java
@@ -7,6 +7,7 @@ import com.intellij.execution.CommonProgramRunConfigurationParameters;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.ExtensionPointName;
+import com.twitter.intellij.pants.util.PantsConstants;
 import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration;
 
 import java.util.Arrays;
@@ -102,8 +103,9 @@ public class PantsExternalMetricsListenerManager implements PantsExternalMetrics
     /**
      /**
      * Scala related run/test configuration inherit {@link AbstractTestRunConfiguration}
+     * Use string test on class name due to scala plugin can be optional and it is hard to separate this logic.
      */
-    if (runConfiguration instanceof AbstractTestRunConfiguration) {
+    if (runConfiguration.getClass().getName().equals(PantsConstants.ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
       Arrays.stream(EP_NAME.getExtensions()).forEach(s -> {
         try {
           s.logTestRunner(TestRunnerType.SCALA_RUNNER);

--- a/src/com/twitter/intellij/pants/metrics/PantsExternalMetricsListenerManager.java
+++ b/src/com/twitter/intellij/pants/metrics/PantsExternalMetricsListenerManager.java
@@ -105,7 +105,7 @@ public class PantsExternalMetricsListenerManager implements PantsExternalMetrics
      * Scala related run/test configuration inherit {@link AbstractTestRunConfiguration}
      * Use string test on class name due to scala plugin can be optional and it is hard to separate this logic.
      */
-    if (runConfiguration.getClass().getName().equals(PantsConstants.ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
+    if (runConfiguration.getClass().getName().equals(PantsConstants.SCALA_PLUGIN_ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
       Arrays.stream(EP_NAME.getExtensions()).forEach(s -> {
         try {
           s.logTestRunner(TestRunnerType.SCALA_RUNNER);

--- a/src/com/twitter/intellij/pants/metrics/PantsExternalMetricsListenerManager.java
+++ b/src/com/twitter/intellij/pants/metrics/PantsExternalMetricsListenerManager.java
@@ -8,6 +8,7 @@ import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.twitter.intellij.pants.util.PantsConstants;
+import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration;
 
 import java.util.Arrays;
@@ -105,7 +106,7 @@ public class PantsExternalMetricsListenerManager implements PantsExternalMetrics
      * Scala related run/test configuration inherit {@link AbstractTestRunConfiguration}
      * Use string test on class name due to scala plugin can be optional and it is hard to separate this logic.
      */
-    if (runConfiguration.getClass().getName().equals(PantsConstants.SCALA_PLUGIN_ABSTRACT_TEST_RUN_CONFIGURATION_CLASS_NAME)) {
+    if (PantsUtil.isScalaTestRunConfiguration(runConfiguration)) {
       Arrays.stream(EP_NAME.getExtensions()).forEach(s -> {
         try {
           s.logTestRunner(TestRunnerType.SCALA_RUNNER);

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -126,7 +126,6 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
 
   protected String[] getRequiredPluginIds() {
     return new String[]{
-      "org.intellij.scala",
       "org.jetbrains.plugins.gradle",
       PantsConstants.PLUGIN_ID
     };

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsScalaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsScalaExamplesIntegrationTest.java
@@ -6,11 +6,21 @@ package com.twitter.intellij.pants.integration;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.SourceFolder;
 import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+import com.twitter.intellij.pants.util.PantsConstants;
 import org.jetbrains.jps.model.java.JavaSourceRootType;
 
 import java.util.List;
 
 public class OSSPantsScalaExamplesIntegrationTest extends OSSPantsIntegrationTest {
+
+  protected String[] getRequiredPluginIds() {
+    return new String[]{
+      "org.intellij.scala",
+      "org.jetbrains.plugins.gradle",
+      PantsConstants.PLUGIN_ID
+    };
+  }
+
   public void testHelloByTargetName() throws Throwable {
     doImport("examples/src/scala/org/pantsbuild/example/hello/BUILD", "hello");
 


### PR DESCRIPTION
This patch allows pants plugin to function without scala plugin. Reason being:
* some folks are only interested in java builds
* whenever there are scala plugin bugs, we will have to be impacted