### PR TITLE
Restrict BUILD file change popup to Pants project

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -196,8 +196,8 @@ public class PantsUtil {
    *
    * @param file - a BUILD file
    */
-  public static boolean isFileUnderPantsProject(VirtualFile file) {
-    return findPantsExecutable(file).isPresent() && isBUILDFileName(file.getName());
+  public static boolean isFileUnderPantsRepo(VirtualFile file) {
+    return findPantsExecutable(file).isPresent();
   }
 
   public static boolean isScalaTestRunConfiguration(RunConfiguration rc) {

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -178,6 +178,8 @@ public class PantsUtil {
 
   /**
    * Checks if it's a BUILD file or folder under a Pants project
+   * Does not consider if the file is a BUILD file under a Pants project, only
+   * that the file is a directory under a pants project.
    *
    * @param file - a BUILD file or a directory
    */
@@ -186,6 +188,16 @@ public class PantsUtil {
       return findPantsExecutable(file).isPresent();
     }
     return isBUILDFileName(file.getName());
+  }
+
+  /**
+   * Almost exactly like isPantsProjectFile, but checks that the BUILD
+   * file is under a Pants project.
+   *
+   * @param file - a BUILD file
+   */
+  public static boolean isFileUnderPantsProject(VirtualFile file) {
+    return findPantsExecutable(file).isPresent() && isBUILDFileName(file.getName());
   }
 
   public static boolean isScalaTestRunConfiguration(RunConfiguration rc) {

--- a/src/com/twitter/intellij/pants/file/FileChangeTracker.java
+++ b/src/com/twitter/intellij/pants/file/FileChangeTracker.java
@@ -145,7 +145,7 @@ public class FileChangeTracker {
       }
     };
 
-    if (PantsUtil.isBUILDFileName(file.getName())) {
+    if (PantsUtil.isFileUnderPantsProject(file) && PantsUtil.isBUILDFileName(file.getName())) {
       Notification myNotification = new Notification(
         PantsConstants.PANTS,
         PantsBundle.message("pants.project.build.files.changed"),

--- a/src/com/twitter/intellij/pants/file/FileChangeTracker.java
+++ b/src/com/twitter/intellij/pants/file/FileChangeTracker.java
@@ -145,7 +145,7 @@ public class FileChangeTracker {
       }
     };
 
-    if (PantsUtil.isFileUnderPantsProject(file) && PantsUtil.isBUILDFileName(file.getName())) {
+    if (PantsUtil.isFileUnderPantsRepo(file) && PantsUtil.isBUILDFileName(file.getName())) {
       Notification myNotification = new Notification(
         PantsConstants.PANTS,
         PantsBundle.message("pants.project.build.files.changed"),


### PR DESCRIPTION
Before this change, when you update a Gradle project build file, a pop up would occur suggesting you refresh the Pants project, even though the changes weren't being made to a Pants project. This change fixes that. 

Verified manually. 