### PR TITLE
Adopt unique module path to avoid module creation lockup

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -46,10 +46,12 @@ import com.twitter.intellij.pants.service.PantsCompileOptionsExecutor;
 import com.twitter.intellij.pants.settings.PantsExecutionSettings;
 import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -147,7 +149,14 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     final ProjectData projectData = new ProjectData(
       PantsConstants.SYSTEM_ID,
       executor.getProjectName(),
-      executor.getBuildRoot().getPath() + "/.idea/pants-projects/" + executor.getProjectRelativePath(),
+      Paths.get(
+        executor.getBuildRoot().getPath(),
+        ".idea",
+        "pants-projects",
+        DigestUtils.sha1Hex(Long.toString(System.currentTimeMillis())),
+        executor.getProjectRelativePath()
+      )
+        .toString(),
       executor.getProjectPath()
     );
     final DataNode<ProjectData> projectDataNode = new DataNode<>(ProjectKeys.PROJECT, projectData, null);

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -155,8 +155,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
         "pants-projects",
         DigestUtils.sha1Hex(Long.toString(System.currentTimeMillis())),
         executor.getProjectRelativePath()
-      )
-        .toString(),
+      ).toString(),
       executor.getProjectPath()
     );
     final DataNode<ProjectData> projectDataNode = new DataNode<>(ProjectKeys.PROJECT, projectData, null);

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -153,6 +153,9 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
         executor.getBuildRoot().getPath(),
         ".idea",
         "pants-projects",
+        // Use a timestamp hash to avoid module creation dead lock
+        // when overlapping targets were imported into multiple projects
+        // from the same Pants repo.
         DigestUtils.sha1Hex(Long.toString(System.currentTimeMillis())),
         executor.getProjectRelativePath()
       ).toString(),


### PR DESCRIPTION
### Problem

The stacktrace shows my suspicion before on module create lock between projects: if target X is in both project A and B, then both projects will create module X whose module definition file isn't unique at this point, causing a dead lock.

```
	at com.twitter.intellij.pants.components.impl.PantsProjectComponentImpl$$Lambda$1909/170935657.run(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:1010)
	at com.twitter.intellij.pants.components.impl.PantsProjectComponentImpl.applyProjectSdk(PantsProjectComponentImpl.java:216)
	at com.twitter.intellij.pants.components.impl.PantsProjectComponentImpl.access$1300(PantsProjectComponentImpl.java:48)
	at com.twitter.intellij.pants.components.impl.PantsProjectComponentImpl$1$1.moduleAdded(PantsProjectComponentImpl.java:158)
	at sun.reflect.GeneratedMethodAccessor69.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.util.messages.impl.MessageBusConnectionImpl.deliverMessage(MessageBusConnectionImpl.java:117)
	at com.intellij.util.messages.impl.MessageBusImpl.doPumpMessages(MessageBusImpl.java:426)
	at com.intellij.util.messages.impl.MessageBusImpl.pumpWaitingBuses(MessageBusImpl.java:387)
	at com.intellij.util.messages.impl.MessageBusImpl.pumpMessages(MessageBusImpl.java:376)
	at com.intellij.util.messages.impl.MessageBusImpl.pumpMessages(MessageBusImpl.java:364)
	at com.intellij.util.messages.impl.MessageBusImpl.sendMessage(MessageBusImpl.java:357)
	at com.intellij.util.messages.impl.MessageBusImpl.access$200(MessageBusImpl.java:43)
	at com.intellij.util.messages.impl.MessageBusImpl$2.invoke(MessageBusImpl.java:208)
	at com.sun.proxy.$Proxy135.moduleAdded(Unknown Source)
	at com.intellij.openapi.module.impl.ModuleManagerImpl.fireModuleAdded(ModuleManagerImpl.java:386)
	at com.intellij.openapi.module.impl.ModuleManagerImpl.lambda$commitModel$5(ModuleManagerImpl.java:1012)
	at com.intellij.openapi.module.impl.ModuleManagerImpl$$Lambda$1905/1492672951.run(Unknown Source)
	at com.intellij.openapi.roots.impl.ProjectRootManagerImpl.makeRootsChange(ProjectRootManagerImpl.java:330)
	at com.intellij.openapi.module.impl.ModuleManagerImpl.commitModel(ModuleManagerImpl.java:966)
	at com.intellij.openapi.module.impl.ModuleManagerImpl.access$1500(ModuleManagerImpl.java:64)
	at com.intellij.openapi.module.impl.ModuleManagerImpl$ModuleModelImpl.commitWithRunnable(ModuleManagerImpl.java:874)
	at com.intellij.openapi.module.impl.ModuleManagerImpl$ModuleModelImpl.access$1200(ModuleManagerImpl.java:640)
	at com.intellij.openapi.module.impl.ModuleManagerImpl.commitModelWithRunnable(ModuleManagerImpl.java:631)
	at com.intellij.openapi.roots.impl.ModifiableModelCommitter.multiCommit(ModifiableModelCommitter.java:50)
	at com.intellij.openapi.roots.impl.ModifiableModelCommitter.multiCommit(ModifiableModelCommitter.java:39)
```

### Solution

Assign a unique parent directory for modules at each import. The implementation uses a hash from the timestamp.

### Result

Verified multiple imports of the same target do not cause a lockup.