### PR TITLE
IntelliJ 2018.2 Compatibility

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -60,9 +60,6 @@
         <option name="WHILE_BRACE_FORCE" value="1" />
         <option name="FOR_BRACE_FORCE" value="1" />
         <option name="FIELD_ANNOTATION_WRAP" value="0" />
-        <MarkdownNavigatorCodeStyleSettings>
-          <option name="RIGHT_MARGIN" value="72" />
-        </MarkdownNavigatorCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>

--- a/.idea/libraries/scala_sdk_2_12_4.xml
+++ b/.idea/libraries/scala_sdk_2_12_4.xml
@@ -1,5 +1,12 @@
 <component name="libraryTable">
-  <library name="scala-sdk-2.12.4">
+  <library name="scala-sdk-2.12.4" type="Scala">
+    <properties>
+      <compiler-classpath>
+        <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.12.4.jar" />
+        <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.4.jar" />
+        <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.12.4.jar" />
+      </compiler-classpath>
+    </properties>
     <CLASSES>
       <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.4.jar!/" />
       <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.12.4.jar!/" />

--- a/.idea/libraries/scala_sdk_2_12_4.xml
+++ b/.idea/libraries/scala_sdk_2_12_4.xml
@@ -1,12 +1,5 @@
 <component name="libraryTable">
-  <library name="scala-sdk-2.12.4" type="Scala">
-    <properties>
-      <compiler-classpath>
-        <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.12.4.jar" />
-        <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.4.jar" />
-        <root url="file://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.12.4.jar" />
-      </compiler-classpath>
-    </properties>
+  <library name="scala-sdk-2.12.4">
     <CLASSES>
       <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.4.jar!/" />
       <root url="jar://$USER_HOME$/.ivy2/cache/org.scala-lang/scala-reflect/jars/scala-reflect-2.12.4.jar!/" />

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -15,7 +15,7 @@
   <version>1.9.2</version>
   <vendor>Twitter, Inc.</vendor>
 
-  <idea-version since-build="181.0" until-build="181.*"/>
+  <idea-version since-build="182.0" until-build="182.*"/>
 
   <!--Add gradle as a dep because of Pants runner requires it.-->
   <depends>org.jetbrains.plugins.gradle</depends>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -119,7 +119,6 @@
                      groupName="Pants" enabledByDefault="true"
                      implementationClass="com.twitter.intellij.pants.inspection.PythonPluginInspection"/>
 
-    <!--<compileServer.plugin classpath="intellij-pants-plugin-publish.jar"/>-->
     <buildProcess.parametersProvider implementation="com.twitter.intellij.pants.compiler.PantsBuildProcessParametersProvider"/>
 
     <projectConfigurable groupId="build.tools" groupWeight="110" id="reference.settingsdialog.project.pants"

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
       </ul>
       ]]>
   </change-notes>
-  <version>1.9.3</version>
+  <version>1.10.0</version>
   <vendor>Twitter, Inc.</vendor>
 
   <idea-version since-build="182.0" until-build="182.*"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -119,7 +119,7 @@
                      groupName="Pants" enabledByDefault="true"
                      implementationClass="com.twitter.intellij.pants.inspection.PythonPluginInspection"/>
 
-    <compileServer.plugin classpath="intellij-pants-plugin-publish.jar"/>
+    <!--<compileServer.plugin classpath="intellij-pants-plugin-publish.jar"/>-->
     <buildProcess.parametersProvider implementation="com.twitter.intellij.pants.compiler.PantsBuildProcessParametersProvider"/>
 
     <projectConfigurable groupId="build.tools" groupWeight="110" id="reference.settingsdialog.project.pants"

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -24,20 +24,20 @@ get_md5(){
 if [[ "${IJ_ULTIMATE:-false}" == "true" ]]; then
   export IJ_BUILD="IU-${IJ_VERSION}"
   export FULL_IJ_BUILD_NUMBER="IU-${IJ_BUILD_NUMBER}"
-  export EXPECTED_IJ_MD5="ca21652fdcbe81ed5ea60ae49a9394a5"
+  export EXPECTED_IJ_MD5="e613bbba7d73ba027012fe6d4c73d12b"
   export PYTHON_PLUGIN_ID="Pythonid"
-  export PYTHON_PLUGIN_MD5="578103a4e9fc96acf38c5e082f322f0f"
+  export PYTHON_PLUGIN_MD5="4e1a7a91e921e063492b5025a38833f6"
 else
   export IJ_BUILD="IC-${IJ_VERSION}"
   export FULL_IJ_BUILD_NUMBER="IC-${IJ_BUILD_NUMBER}"
-  export EXPECTED_IJ_MD5="621457c9147f285683b489d0368b60fc"
+  export EXPECTED_IJ_MD5="c05ee8abc50796cbb6bc6b65e6093ea5"
   export PYTHON_PLUGIN_ID="PythonCore"
-  export PYTHON_PLUGIN_MD5="7e6a7e48f7c01484115bfe2116d853dd"
+  export PYTHON_PLUGIN_MD5="7ebff66b548a41eb5a7d7c6e30ac0687"
 fi
 
 # we will use Community ids to download plugins.
 export SCALA_PLUGIN_ID="org.intellij.scala"
-export SCALA_PLUGIN_MD5="b69af0284c698d7ad086476d545c504a"
+export SCALA_PLUGIN_MD5="8d8d212c43b2b98875a4c3ff41c26e51"
 
 export INTELLIJ_PLUGINS_HOME="$CWD/.cache/intellij/$FULL_IJ_BUILD_NUMBER/plugins"
 export INTELLIJ_HOME="$CWD/.cache/intellij/$FULL_IJ_BUILD_NUMBER/idea-dist"

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -59,9 +59,7 @@ append_intellij_jvm_options() {
     "-Didea.load.plugins.id=${load_plugins}"
     "-Didea.plugins.path=$INTELLIJ_PLUGINS_HOME"
     "-Didea.home.path=$INTELLIJ_HOME"
-    "-Didea.external.build.development.plugins.dir=$CWD/.pants.d/compile/jvm/java"
-    "-Dpants.jps.plugin.classpath=$CWD/jps-plugin:$INTELLIJ_HOME/lib/jps-model.jar"
-    #EAP build does not know its own build number, thus failing to tell plugin compatibility.
+    # EAP build does not know its own build number, thus failing to tell plugin compatibility.
     "-Didea.plugins.compatible.build=$IJ_BUILD_NUMBER"
     # "-Dcompiler.process.debug.port=5006"
   )

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -10,8 +10,8 @@ fi
 # Python plugin for Community and Ultimate Edition
 
 export CWD=$(pwd)
-export IJ_VERSION="2018.1.5"
-export IJ_BUILD_NUMBER="181.5281.24"
+export IJ_VERSION="2018.2"
+export IJ_BUILD_NUMBER="182.3684.101"
 
 get_md5(){
   if [[ $OSTYPE == *"darwin"* ]]; then

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -59,7 +59,7 @@ append_intellij_jvm_options() {
     "-Didea.load.plugins.id=${load_plugins}"
     "-Didea.plugins.path=$INTELLIJ_PLUGINS_HOME"
     "-Didea.home.path=$INTELLIJ_HOME"
-    "-Dpants.plugin.base.path=$CWD/.pants.d/compile/jvm/java"
+    "-Didea.external.build.development.plugins.dir=$CWD/.pants.d/compile/jvm/java"
     "-Dpants.jps.plugin.classpath=$CWD/jps-plugin:$INTELLIJ_HOME/lib/jps-model.jar"
     #EAP build does not know its own build number, thus failing to tell plugin compatibility.
     "-Didea.plugins.compatible.build=$IJ_BUILD_NUMBER"

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -9,7 +9,7 @@ verify_md5(){
   if [ $ACTUAL_MD5 != $EXPECTED_MD5 ];
   then
     echo "$1 md5 incorrect. Expected: $EXPECTED_MD5. Actual: $ACTUAL_MD5" >&2
-    exit 1
+#    exit 1
   fi
 }
 

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -9,7 +9,7 @@ verify_md5(){
   if [ $ACTUAL_MD5 != $EXPECTED_MD5 ];
   then
     echo "$1 md5 incorrect. Expected: $EXPECTED_MD5. Actual: $ACTUAL_MD5" >&2
-#    exit 1
+    exit 1
   fi
 }
 

--- a/src/com/twitter/intellij/pants/compiler/PantsBuildProcessParametersProvider.java
+++ b/src/com/twitter/intellij/pants/compiler/PantsBuildProcessParametersProvider.java
@@ -4,35 +4,58 @@
 package com.twitter.intellij.pants.compiler;
 
 import com.intellij.compiler.server.BuildProcessParametersProvider;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.IdeaPluginDescriptorImpl;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.externalSystem.model.ExternalSystemException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.containers.ContainerUtil;
 import com.twitter.intellij.pants.jps.incremental.serialization.PantsJpsModelSerializerExtension;
+import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
+import org.fest.util.Lists;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jps.cmdline.ClasspathBootstrap;
 
 import java.util.List;
 
 public class PantsBuildProcessParametersProvider extends BuildProcessParametersProvider {
+
+  private final Project myProject;
+
+  public PantsBuildProcessParametersProvider(Project project) {
+    myProject = project;
+  }
+
+
   @NotNull
   @Override
   public List<String> getClassPath() {
     // Hack to provide additional classpath to compilation process
     // in BuildManager. See scripts/prepare-ci-environment.sh
 
-    // IDEA 2016 moved `ExternalSystemException` out of `openapi.jar` and is not on the default classpaths anymore
-    // despite staying in the same package, so we have to explicitly add it to the external builder.
-    final List<String> classpath = ContainerUtil.newArrayList();
-    classpath.add(ClasspathBootstrap.getResourcePath(ExternalSystemException.class));
-
-    if (ApplicationManager.getApplication().isUnitTestMode()) {
-      classpath.add(ClasspathBootstrap.getResourcePath(PantsUtil.class));
-      classpath.add(ClasspathBootstrap.getResourcePath(PantsJpsModelSerializerExtension.class));
-      classpath.addAll(StringUtil.split(StringUtil.notNullize(System.getProperty("pants.jps.plugin.classpath")), ":"));
+    if (PantsUtil.isPantsProject(myProject)) {
+      throw new RuntimeException(PantsConstants.EXTERNAL_BUILDER_ERROR);
     }
 
-    return classpath;
+    //// IDEA 2016 moved `ExternalSystemException` out of `openapi.jar` and is not on the default classpaths anymore
+    //// despite staying in the same package, so we have to explicitly add it to the external builder.
+    //final List<String> classpath = ContainerUtil.newArrayList();
+    //classpath.add(ClasspathBootstrap.getResourcePath(ExternalSystemException.class));
+    //
+    //final IdeaPluginDescriptor plugin = PluginManager.getPlugin(PluginId.getId(PantsConstants.PLUGIN_ID));
+    //classpath.add(((IdeaPluginDescriptorImpl) plugin).getClassPath().toString());
+    //
+    ////if (ApplicationManager.getApplication().isUnitTestMode()) {
+    //  classpath.add(ClasspathBootstrap.getResourcePath(PantsUtil.class));
+    //  classpath.add(ClasspathBootstrap.getResourcePath(PantsJpsModelSerializerExtension.class));
+    //  classpath.addAll(StringUtil.split(StringUtil.notNullize(System.getProperty("pants.jps.plugin.classpath")), ":"));
+    ////}
+    //
+    return Lists.newArrayList();
   }
 }

--- a/src/com/twitter/intellij/pants/compiler/PantsBuildProcessParametersProvider.java
+++ b/src/com/twitter/intellij/pants/compiler/PantsBuildProcessParametersProvider.java
@@ -4,22 +4,11 @@
 package com.twitter.intellij.pants.compiler;
 
 import com.intellij.compiler.server.BuildProcessParametersProvider;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.IdeaPluginDescriptorImpl;
-import com.intellij.ide.plugins.PluginManager;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.extensions.PluginId;
-import com.intellij.openapi.externalSystem.model.ExternalSystemException;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
-import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.util.containers.ContainerUtil;
-import com.twitter.intellij.pants.jps.incremental.serialization.PantsJpsModelSerializerExtension;
 import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.fest.util.Lists;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.jps.cmdline.ClasspathBootstrap;
 
 import java.util.List;
 
@@ -35,27 +24,9 @@ public class PantsBuildProcessParametersProvider extends BuildProcessParametersP
   @NotNull
   @Override
   public List<String> getClassPath() {
-    // Hack to provide additional classpath to compilation process
-    // in BuildManager. See scripts/prepare-ci-environment.sh
-
     if (PantsUtil.isPantsProject(myProject)) {
       throw new RuntimeException(PantsConstants.EXTERNAL_BUILDER_ERROR);
     }
-
-    //// IDEA 2016 moved `ExternalSystemException` out of `openapi.jar` and is not on the default classpaths anymore
-    //// despite staying in the same package, so we have to explicitly add it to the external builder.
-    //final List<String> classpath = ContainerUtil.newArrayList();
-    //classpath.add(ClasspathBootstrap.getResourcePath(ExternalSystemException.class));
-    //
-    //final IdeaPluginDescriptor plugin = PluginManager.getPlugin(PluginId.getId(PantsConstants.PLUGIN_ID));
-    //classpath.add(((IdeaPluginDescriptorImpl) plugin).getClassPath().toString());
-    //
-    ////if (ApplicationManager.getApplication().isUnitTestMode()) {
-    //  classpath.add(ClasspathBootstrap.getResourcePath(PantsUtil.class));
-    //  classpath.add(ClasspathBootstrap.getResourcePath(PantsJpsModelSerializerExtension.class));
-    //  classpath.addAll(StringUtil.split(StringUtil.notNullize(System.getProperty("pants.jps.plugin.classpath")), ":"));
-    ////}
-    //
     return Lists.newArrayList();
   }
 }

--- a/src/com/twitter/intellij/pants/components/impl/PantsInitComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsInitComponentImpl.java
@@ -36,20 +36,6 @@ public class PantsInitComponentImpl implements PantsInitComponent {
 
   @Override
   public void initComponent() {
-    // The Pants plugin doesn't do so many computations for building a project
-    // to start an external JVM each time.
-    // The plugin only calls `export` goal and parses JSON response.
-    // So it will be in process all the time.
-    final String key = PantsConstants.SYSTEM_ID.getId() + ExternalSystemConstants.USE_IN_PROCESS_COMMUNICATION_REGISTRY_KEY_SUFFIX;
-    Registry.get(key).setValue(true);
-
-    // hack to trick BuildProcessClasspathManager
-    final String basePath = System.getProperty("pants.plugin.base.path");
-    final IdeaPluginDescriptor plugin = PluginManager.getPlugin(PluginId.getId(PantsConstants.PLUGIN_ID));
-    if (StringUtil.isNotEmpty(basePath) && plugin instanceof IdeaPluginDescriptorImpl) {
-      ((IdeaPluginDescriptorImpl) plugin).setPath(new File(basePath));
-    }
-
     registerPantsActions();
   }
 

--- a/src/com/twitter/intellij/pants/components/impl/PantsInitComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsInitComponentImpl.java
@@ -7,6 +7,8 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.IdeActions;
+import com.intellij.openapi.externalSystem.util.ExternalSystemConstants;
+import com.intellij.openapi.util.registry.Registry;
 import com.twitter.intellij.pants.compiler.actions.PantsCompileAllTargetsAction;
 import com.twitter.intellij.pants.compiler.actions.PantsCompileAllTargetsInModuleAction;
 import com.twitter.intellij.pants.compiler.actions.PantsRebuildAction;
@@ -28,6 +30,13 @@ public class PantsInitComponentImpl implements PantsInitComponent {
 
   @Override
   public void initComponent() {
+    // The Pants plugin doesn't do so many computations for building a project
+    // to start an external JVM each time.
+    // The plugin only calls `export` goal and parses JSON response.
+    // So it will be in process all the time.
+    final String key = PantsConstants.SYSTEM_ID.getId() + ExternalSystemConstants.USE_IN_PROCESS_COMMUNICATION_REGISTRY_KEY_SUFFIX;
+    Registry.get(key).setValue(true);
+
     registerPantsActions();
   }
 

--- a/src/com/twitter/intellij/pants/components/impl/PantsInitComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsInitComponentImpl.java
@@ -4,16 +4,9 @@
 package com.twitter.intellij.pants.components.impl;
 
 import com.intellij.icons.AllIcons;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.IdeaPluginDescriptorImpl;
-import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.IdeActions;
-import com.intellij.openapi.extensions.PluginId;
-import com.intellij.openapi.externalSystem.util.ExternalSystemConstants;
-import com.intellij.openapi.util.registry.Registry;
-import com.intellij.openapi.util.text.StringUtil;
 import com.twitter.intellij.pants.compiler.actions.PantsCompileAllTargetsAction;
 import com.twitter.intellij.pants.compiler.actions.PantsCompileAllTargetsInModuleAction;
 import com.twitter.intellij.pants.compiler.actions.PantsRebuildAction;
@@ -24,7 +17,6 @@ import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
 import java.util.Optional;
 
 public class PantsInitComponentImpl implements PantsInitComponent {

--- a/src/com/twitter/intellij/pants/settings/PantsSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsSettings.java
@@ -6,9 +6,6 @@ package com.twitter.intellij.pants.settings;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
-import com.intellij.openapi.components.Storage;
-import com.intellij.openapi.components.StoragePathMacros;
-import com.intellij.openapi.components.StorageScheme;
 import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettings;
 import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListener;
 import com.intellij.openapi.project.Project;
@@ -23,11 +20,7 @@ import java.util.Objects;
 import java.util.Set;
 
 @State(
-  name = "PantsSettings",
-  storages = {
-    @Storage(file = StoragePathMacros.PROJECT_FILE),
-    @Storage(file = StoragePathMacros.PROJECT_CONFIG_DIR + "/pants.xml", scheme = StorageScheme.DIRECTORY_BASED)
-  }
+  name = "PantsSettings"
 )
 public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings, PantsProjectSettings, PantsSettingsListener>
   implements PersistentStateComponent<PantsSettings.MyState> {


### PR DESCRIPTION
Resolves #360 #333

### Major changes
* `StoragePathMacros` no longer exists in the core, so `PantsSettings` will live in `misc.xml`
* `compileServer.plugin` is no longer and should not be used, only leaving `PantsBuildProcessParametersProvider` to throw an error in case user accidentally ran into it.
