### PR TITLE
Remove -forkSocket from --jvm-test-junit-options

### DIFF
--- a/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
+++ b/src/com/twitter/intellij/pants/service/task/PantsTaskManager.java
@@ -3,6 +3,7 @@
 
 package com.twitter.intellij.pants.service.task;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.intellij.execution.ExecutionException;
@@ -24,7 +25,6 @@ import com.twitter.intellij.pants.model.PantsTargetAddress;
 import com.twitter.intellij.pants.settings.PantsExecutionSettings;
 import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
-import org.fest.util.VisibleForTesting;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/tests/com/twitter/intellij/pants/service/task/PantsTaskManagerTest.java
+++ b/tests/com/twitter/intellij/pants/service/task/PantsTaskManagerTest.java
@@ -1,0 +1,15 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.service.task;
+
+import junit.framework.TestCase;
+
+public class PantsTaskManagerTest extends TestCase {
+
+  public void testGetCleanedDebugSetup() {
+    String cleanedSetup =
+      PantsTaskManager.getCleanedDebugSetup("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=63212 -forkSocket63213");
+    assertEquals("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=63212", cleanedSetup);
+  }
+}


### PR DESCRIPTION
Resolves #369

### Problem

In IJ 2018.2, `-forkSocket` parameter is added debug setup param, which Pants does not need.

### Solution

Remove `-forkSocket` from `--jvm-test-junit-options`