### PR TITLE
Disable closing in pants console window

### DIFF
--- a/src/com/twitter/intellij/pants/ui/PantsConsoleManager.java
+++ b/src/com/twitter/intellij/pants/ui/PantsConsoleManager.java
@@ -41,6 +41,7 @@ public class PantsConsoleManager {
     final boolean isLockable = true;
     final String displayName = "";
     Content pantsConsoleContent = ContentFactory.SERVICE.getInstance().createContent(pantsConsoleViewPanel, displayName, isLockable);
+    pantsConsoleContent.setCloseable(false);
     window.getContentManager().addContent(pantsConsoleContent);
   }
 


### PR DESCRIPTION
## Problem

Users accidentally closed the Pants console tab in IntelliJ, and the only way to restore it was to restart the IDE.

## Solution

After exploring various listener-based solutions, disabling closing entirely seems like the better option, since:
- There should be exactly one tab at all times.
- Closing this tab was mostly accidental.
- In case there have to be more tabs in the future, the other solutions (which messed with the `ToolWindow`) would have made adding them more difficult.