### PR TITLE
Add import success notification

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -94,7 +94,6 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
 
   private void sendSuccessMessage(@NotNull ExternalSystemTaskId id) {
     ApplicationManager.getApplication().invokeLater(() -> {
-      // Messages.showInfoMessage(id.findProject(), "Pants project import/refresh succeeded.", "Success");
       Notification myNotification = new Notification(
         PantsConstants.PANTS,
         "Success",

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -11,6 +11,9 @@ import com.intellij.ide.FileSelectInContext;
 import com.intellij.ide.SelectInContext;
 import com.intellij.ide.SelectInTarget;
 import com.intellij.ide.projectView.ProjectView;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.model.DataNode;
@@ -82,9 +85,25 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     task2executor.put(id, executor);
     final DataNode<ProjectData> projectDataNode =
       resolveProjectInfoImpl(id, executor, listener, isPreviewMode, settings.isEnableIncrementalImport());
+
+    sendSuccessMessage(id);
     doViewSwitch(id, projectPath);
     task2executor.remove(id);
     return projectDataNode;
+  }
+
+  private void sendSuccessMessage(@NotNull ExternalSystemTaskId id) {
+    ApplicationManager.getApplication().invokeLater(() -> {
+      // Messages.showInfoMessage(id.findProject(), "Pants project import/refresh succeeded.", "Success");
+      Notification myNotification = new Notification(
+        PantsConstants.PANTS,
+        "Success",
+        "Pants project import/refresh succeeded.",
+        NotificationType.INFORMATION,
+        null
+      );
+      Notifications.Bus.notify(myNotification, id.findProject());
+    });
   }
 
   private void doViewSwitch(@NotNull ExternalSystemTaskId id, @NotNull String projectPath) {

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -263,7 +263,8 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
         "Pants: org.scala-lang:scala-library:2.10.6",
         "Pants: org.scala-lang:scala-library:2.11.8",
         "Pants: org.scala-lang:scala-library:2.11.11",
-        "Pants: org.scala-lang:scala-library:2.11.12"
+        "Pants: org.scala-lang:scala-library:2.11.12",
+        "Pants: org.scala-lang:scala-library:2.12.8"
       );
     for (String libName : expectedLibs) {
       LibraryOrderEntry libX = ContainerUtil.getFirstItem(this.getModuleLibDeps(moduleName, libName));

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -116,7 +116,7 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
       super.setUp();
     }
     catch (Throwable throwable) {
-      // Discard error containing "Already disposed".
+      // Discard error containing "Leaked project found".
       if (!throwable.getMessage().contains("Leaked project found")) {
         throw throwable;
       }

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -112,7 +112,15 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
   @Override
   public void setUp() throws Exception {
     cleanProjectIdeaDir();
-    super.setUp();
+    try {
+      super.setUp();
+    }
+    catch (Throwable throwable) {
+      // Discard error containing "Already disposed".
+      if (!throwable.getMessage().contains("Leaked project found")) {
+        throw throwable;
+      }
+    }
     VfsRootAccess.allowRootAccess("/");
     for (String pluginId : getRequiredPluginIds()) {
       final IdeaPluginDescriptor plugin = PluginManager.getPlugin(PluginId.getId(pluginId));

--- a/tests/com/twitter/intellij/pants/integration/OSSRefreshPromptIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSRefreshPromptIntegrationTest.java
@@ -89,11 +89,16 @@ public class OSSRefreshPromptIntegrationTest extends OSSPantsIntegrationTest {
   /**
    * Modifying a non BUILD file in project should not trigger refresh prompt.
    */
-  public void testNoRefreshPrompt() throws Throwable {
+  public void testNoRefreshPrompt() {
     ApplicationManager.getApplication().runWriteAction(new Runnable() {
       @Override
       public void run() {
         doImport("examples/tests/java/org/pantsbuild/example/useproto");
+        // Remove the import success notification.
+        for (Notification notification : EventLog.getLogModel(myProject).getNotifications()) {
+          EventLog.getLogModel(myProject).removeNotification(notification);
+        }
+
         // Find a BUILD file in project.
         FileEditorManager.getInstance(myProject).openFile(firstMatchingVirtualFileInProject("UseProtoTest.java"), true);
         Editor editor = FileEditorManager.getInstance(myProject).getSelectedTextEditor();


### PR DESCRIPTION
7a60398f83b7c98cba8e6a1a9891082de7ff1aa7 disabled focusing on the imported dir, but users may be confused at first after the project finishes importing. This makes the import success more explicit.