### PR TITLE
Fix 'no jdk specified' during java app run

### DIFF
--- a/src/com/twitter/intellij/pants/execution/PantsClasspathRunConfigurationExtension.java
+++ b/src/com/twitter/intellij/pants/execution/PantsClasspathRunConfigurationExtension.java
@@ -102,10 +102,9 @@ public class PantsClasspathRunConfigurationExtension extends RunConfigurationExt
   private Set<String> calculatePathsAllowed(JavaParameters params) throws CantRunException {
 
     String homePath = PathManager.getHomePath();
-    String jdkPath = params.getJdkPath();
     String pluginPath = PathManager.getPluginsPath();
 
-    Set<String> pathsAllowed = Sets.newHashSet(jdkPath, homePath, pluginPath);
+    Set<String> pathsAllowed = Sets.newHashSet(homePath, pluginPath);
 
     if (ApplicationManager.getApplication().isUnitTestMode()) {
       pathsAllowed.add(


### PR DESCRIPTION
We can no longer access the JDK info as upstream moved the sequence. https://github.com/JetBrains/intellij-community/commit/79663d926ccac6492a516c4522de2dd0225f7c31#diff-e7c89079e491cd2b6647555f38663370

Removing our related code does not seem to cause ClassNotFound issue.