### PR TITLE
[Incremental import] Auto target alias expansion

### DIFF
--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -3,6 +3,7 @@
 
 package com.twitter.intellij.pants.model;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -79,6 +80,7 @@ public class TargetAddressInfo {
     return pants_target_type;
   }
 
+  @VisibleForTesting
   public void setPantsTargetType(@NotNull String type) {
     pants_target_type = type;
   }

--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -96,4 +96,6 @@ public class TargetAddressInfo {
   public boolean isJarLibrary() {
     return StringUtil.equals("jar_library", getInternalPantsTargetType());
   }
+
+  public boolean isTargetAlias() { return pants_target_type != null && (pants_target_type.equals("alias") || pants_target_type.equals("target"));}
 }

--- a/src/com/twitter/intellij/pants/service/project/model/graph/BuildGraphNode.java
+++ b/src/com/twitter/intellij/pants/service/project/model/graph/BuildGraphNode.java
@@ -48,6 +48,10 @@ public class BuildGraphNode {
     return myTargetInfo.getAddressInfos().stream().anyMatch(TargetAddressInfo::isTargetRoot);
   }
 
+  public boolean isAliasTarget() {
+    return myTargetInfo.getAddressInfos().stream().anyMatch(TargetAddressInfo::isTargetAlias);
+  }
+
   public void addDependency(BuildGraphNode node) {
     myDependencies.add(node);
   }

--- a/tests/com/twitter/intellij/pants/service/project/model/graph/BuildGraphTest.java
+++ b/tests/com/twitter/intellij/pants/service/project/model/graph/BuildGraphTest.java
@@ -152,12 +152,12 @@ public class BuildGraphTest extends TestCase {
     Map<String, TargetInfo> targets,
     String targetAddress,
     String targetType,
-    String internalPantsTypeType,
+    String internalPantsTargetType,
     boolean is_target_root,
     Optional<String> dependee
   ) {
     TargetInfo info = injectTargetInfo(targets, targetAddress, targetType, is_target_root, dependee);
-    info.getAddressInfos().stream().forEach(s -> s.setPantsTargetType(internalPantsTypeType));
+    info.getAddressInfos().stream().forEach(s -> s.setPantsTargetType(internalPantsTargetType));
   }
 
   private TargetInfo injectTargetInfo(

--- a/tests/com/twitter/intellij/pants/service/project/model/graph/BuildGraphTest.java
+++ b/tests/com/twitter/intellij/pants/service/project/model/graph/BuildGraphTest.java
@@ -131,6 +131,7 @@ public class BuildGraphTest extends TestCase {
     // a (root) -> b, level 1
     assertEquals(1, new BuildGraph(targets).getMaxDepth());
     assertEquals(1, new BuildGraph(targets).getNodesUpToLevel(0).size());
+    assertEquals(2, new BuildGraph(targets).getNodesUpToLevel(1).size());
   }
 
   public void testTargetAliasExpansion4() {


### PR DESCRIPTION
### Problem

Previously with incremental import, target aliases `target` and `alias` will get counted as one level, causing user having to expand more levels.

### Solution

This patch adds the mechanism that if a target alias is included in the query, it automatically adds its dependencies into the final results.