### PR TITLE
Move --target-spec-file before goals and use target spec file only

### DIFF
--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -203,14 +203,7 @@ public class PantsCompileOptionsExecutor {
     // Grab the import stage pants rc file for IntelliJ.
     Optional<String> rcArg = IJRC.getImportPantsRc(commandLine.getWorkDirectory().getPath());
     rcArg.ifPresent(commandLine::addParameter);
-
-    commandLine.addParameter("--no-quiet");
-    commandLine.addParameter("export");
-    commandLine.addParameter("--formatted"); // json outputs in a compact format
-    if (myResolveSourcesAndDocsForJars) {
-      commandLine.addParameter("--export-libraries-sources");
-      commandLine.addParameter("--export-libraries-javadocs");
-    }
+    
     // If there are a large number of target specs, pass them to pants via a
     // file to avoid exceeding the OS command line length limit.
     final List<String> targetSpecs = getTargetSpecs();
@@ -225,6 +218,14 @@ public class PantsCompileOptionsExecutor {
       commandLine.addParameter("--target-spec-file=" + targetSpecsFile.getPath());
     } else {
       commandLine.addParameters(targetSpecs);
+    }
+    
+    commandLine.addParameter("--no-quiet");
+    commandLine.addParameter("export");
+    commandLine.addParameter("--formatted"); // json outputs in a compact format
+    if (myResolveSourcesAndDocsForJars) {
+      commandLine.addParameter("--export-libraries-sources");
+      commandLine.addParameter("--export-libraries-javadocs");
     }
     commandLine.addParameter("--export-output-file=" + outputFile.getPath());
     return commandLine;

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -203,23 +203,16 @@ public class PantsCompileOptionsExecutor {
     // Grab the import stage pants rc file for IntelliJ.
     Optional<String> rcArg = IJRC.getImportPantsRc(commandLine.getWorkDirectory().getPath());
     rcArg.ifPresent(commandLine::addParameter);
-    
-    // If there are a large number of target specs, pass them to pants via a
-    // file to avoid exceeding the OS command line length limit.
-    final List<String> targetSpecs = getTargetSpecs();
-    if (targetSpecs.size() > 100) {
-      final File targetSpecsFile = FileUtil.createTempFile("pants_target_specs", ".in");
-      try (FileWriter targetSpecsFileWriter = new FileWriter(targetSpecsFile)) {
-        for (String targetSpec : targetSpecs) {
-          targetSpecsFileWriter.write(targetSpec);
-          targetSpecsFileWriter.write('\n');
-        }
+
+    final File targetSpecsFile = FileUtil.createTempFile("pants_target_specs", ".in");
+    try (FileWriter targetSpecsFileWriter = new FileWriter(targetSpecsFile)) {
+      for (String targetSpec : getTargetSpecs()) {
+        targetSpecsFileWriter.write(targetSpec);
+        targetSpecsFileWriter.write('\n');
       }
-      commandLine.addParameter("--target-spec-file=" + targetSpecsFile.getPath());
-    } else {
-      commandLine.addParameters(targetSpecs);
     }
-    
+    commandLine.addParameter("--target-spec-file=" + targetSpecsFile.getPath());
+
     commandLine.addParameter("--no-quiet");
     commandLine.addParameter("export");
     commandLine.addParameter("--formatted"); // json outputs in a compact format


### PR DESCRIPTION
To fix:
```
pants --pantsrc-files=/Users/srohankar/devel_workspace/source/.ij.import.rc --no-quiet export --formatted --export-libraries-sources --export-libraries-javadocs --target-spec-file=/private/var/folders/h7/zbp8j4zj6jd8mpvcvbf4cbhw0000gn/T/pants_target_specs1.in --export-output-file=/private/var/folders/h7/zbp8j4zj6jd8mpvcvbf4cbhw0000gn/T/pants_depmap_run2.out
Exit code: 1
...
Exception message: Unrecognized command line flags on scope 'export': --target-spec-file. Suggestions:
--target-spec-file: [--target-spec-file]
```