### PR TITLE
Fix freeze attaching SDK annotation

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -16,10 +16,10 @@ import com.intellij.ide.SaveAndSyncHandler;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.impl.EditorImpl;
@@ -43,9 +43,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.JavaSdk;
 import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.projectRoots.SdkModificator;
 import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
-import com.intellij.openapi.projectRoots.impl.JavaSdkImpl;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.ui.Messages;
@@ -850,13 +848,6 @@ public class PantsUtil {
       .findFirst();
 
     if (sdkForPants.isPresent()) {
-      SdkModificator modificator = sdkForPants.get().getSdkModificator();
-      JavaSdkImpl.attachJdkAnnotations(modificator);
-      ApplicationManager.getApplication().invokeAndWait(() -> {
-          ApplicationManager.getApplication().runWriteAction(() -> {
-              modificator.commitChanges();
-          });
-      });
       return sdkForPants;
     }
 

--- a/pants.ini
+++ b/pants.ini
@@ -52,6 +52,7 @@ parallel_threads: 1
 strict_deps: True
 
 [scala]
+# This needs to remain custom to match the scala version used to build scala plugin.
 version: custom
 suffix_version: 2.12
 scala_repl: //:scala-repl

--- a/pants.ini
+++ b/pants.ini
@@ -5,7 +5,7 @@ local_artifact_cache = %(buildroot)s/.cache
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [GLOBAL]
-pants_version: 1.19.0
+pants_version: 1.20.0rc2
 print_exception_stacktrace: True
 pants_ignore: +[
     'out/',
@@ -32,7 +32,7 @@ write_to = ["%(local_artifact_cache)s/bootstrap"]
 read: False
 write: False
 
-[compile.zinc]
+[compile.rsc]
 debug_symbols: True
 
 [jvm]
@@ -52,7 +52,10 @@ parallel_threads: 1
 strict_deps: True
 
 [scala]
-version: 2.12
+version: custom
+suffix_version: 2.12
+scala_repl: //:scala-repl
+strict_deps: True
 
 [jvm-distributions]
 minimum_version: 1.8.0

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -4,6 +4,7 @@
 package com.twitter.intellij.pants.components.impl;
 
 import com.intellij.ProjectTopics;
+import com.intellij.codeInspection.magicConstant.MagicConstantInspection;
 import com.intellij.execution.RunManagerListener;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.ide.impl.NewProjectUtil;
@@ -225,11 +226,12 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
         return;
       }
 
-      Optional<Sdk> sdk = PantsUtil.getDefaultJavaSdk(pantsExecutable.get().getPath(), null);
+      Optional<Sdk> sdk = PantsUtil.getDefaultJavaSdk(pantsExecutable.get().getPath(), myProject);
       if (!sdk.isPresent()) {
         return;
       }
 
+      MagicConstantInspection.getAttachAnnotationsJarFix(myProject).run();
       NewProjectUtil.applyJdkToProject(myProject, sdk.get());
     });
   }


### PR DESCRIPTION
# Problem

There was unsafe code trying to commit changes for a SDK.

# Solution

Use IntelliJ's built-in function for it instead.