### PR TITLE
Replace Sdk with a Jdk reference as the project data

### DIFF
--- a/common/com/twitter/intellij/pants/model/JdkRef.java
+++ b/common/com/twitter/intellij/pants/model/JdkRef.java
@@ -1,0 +1,55 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.model;
+
+import com.intellij.openapi.projectRoots.JavaSdk;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.serialization.PropertyMapping;
+import com.twitter.intellij.pants.util.PantsUtil;
+
+import java.util.Objects;
+
+public final class JdkRef {
+  private final String myName;
+  private final String myHome;
+
+  public static JdkRef fromSdk(Sdk sdk) {
+    return new JdkRef(sdk.getName(), sdk.getHomePath());
+  }
+
+  @PropertyMapping({"myName", "myHome"})
+  private JdkRef(String myName, String myHome) {
+    this.myName = myName;
+    this.myHome = myHome;
+
+}
+  public Sdk toSdk() {
+    JavaSdk javaSdk = JavaSdk.getInstance();
+    return ProjectJdkTable.getInstance().getSdksOfType(javaSdk).stream()
+      .filter(sdk -> myHome.equals(sdk.getHomePath()))
+      .filter(sdk -> myName.equals(sdk.getName()))
+      .findFirst()
+      .orElseGet(() -> PantsUtil.createJdk(myName, myHome, null));
+  }
+
+  @Override
+  public String toString() {
+    return myName + " @ " + myHome;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof JdkRef)) return false;
+    JdkRef ref = (JdkRef) o;
+    return Objects.equals(myName, ref.myName) &&
+           Objects.equals(myHome, ref.myHome);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(myName, myHome);
+  }
+}

--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -6,7 +6,7 @@ package com.twitter.intellij.pants.util;
 import com.intellij.openapi.externalSystem.model.Key;
 import com.intellij.openapi.externalSystem.model.ProjectKeys;
 import com.intellij.openapi.externalSystem.model.ProjectSystemId;
-import com.intellij.openapi.projectRoots.Sdk;
+import com.twitter.intellij.pants.model.JdkRef;
 import org.jetbrains.annotations.NotNull;
 
 
@@ -41,7 +41,7 @@ public class PantsConstants {
   public static final String PANTS_OPTION_ASYNC_CLEAN_ALL = "clean-all.async";
 
   // Used to initialize project sdk therefore use project processing weight, i.e, the highest.
-  public static final Key<Sdk> SDK_KEY = Key.create(Sdk.class, ProjectKeys.PROJECT.getProcessingWeight());
+  public static final Key<JdkRef> SDK_KEY = Key.create(JdkRef.class, ProjectKeys.PROJECT.getProcessingWeight());
 
   public static final String PANTS_CLI_OPTION_EXPORT_OUTPUT_FILE = "--export-output-file";
   public static final String PANTS_CLI_OPTION_LIST_OUTPUT_FILE = "--list-output-file";

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -879,17 +879,24 @@ public class PantsUtil {
 
     // Finally if we need to create a new JDK, it needs to be registered in the `ProjectJdkTable` on the IDE level
     // before it can be used.
-    Sdk jdk = JavaSdk.getInstance().createJdk(jdkName, jdkHome.get());
-    ApplicationManager.getApplication().invokeAndWait(() -> {
-        ApplicationManager.getApplication().runWriteAction(() -> {
-            if (parentDisposable == null) {
-              ProjectJdkTable.getInstance().addJdk(jdk);
-            } else {
-              ProjectJdkTable.getInstance().addJdk(jdk, parentDisposable);
-            }
-        });
-    });
+    Sdk jdk = createJdk(jdkName, jdkHome.get(), parentDisposable);
     return Optional.of(jdk);
+  }
+
+  public static Sdk createJdk(String name, String home, Disposable disposable) {
+    Sdk jdk = JavaSdk.getInstance().createJdk(name, home);
+    ApplicationManager.getApplication().invokeAndWait(() -> {
+      ApplicationManager.getApplication().runWriteAction(() -> {
+        if (disposable == null) {
+          ProjectJdkTable.getInstance().addJdk(jdk);
+        }
+        else {
+          ProjectJdkTable.getInstance().addJdk(jdk, disposable);
+        }
+      });
+    });
+
+    return jdk;
   }
 
   /**

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -40,6 +40,7 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.util.Consumer;
 import com.intellij.util.messages.MessageBusConnection;
 import com.twitter.intellij.pants.metrics.PantsExternalMetricsListenerManager;
+import com.twitter.intellij.pants.model.JdkRef;
 import com.twitter.intellij.pants.projectview.PantsProjectPaneSelectInTarget;
 import com.twitter.intellij.pants.projectview.ProjectFilesViewPane;
 import com.twitter.intellij.pants.service.PantsCompileOptionsExecutor;
@@ -165,6 +166,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
 
     PantsUtil.findPantsExecutable(executor.getProjectPath())
       .flatMap(file -> PantsUtil.getDefaultJavaSdk(file.getPath(), null))
+      .map(JdkRef::fromSdk)
       .ifPresent(sdk -> projectDataNode.createChild(PantsConstants.SDK_KEY, sdk));
 
     if (!isPreviewMode) {

--- a/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportBuilder.java
+++ b/src/com/twitter/intellij/pants/service/project/wizard/PantsProjectImportBuilder.java
@@ -4,17 +4,15 @@
 package com.twitter.intellij.pants.service.project.wizard;
 
 import com.intellij.ide.util.projectWizard.WizardContext;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
 import com.intellij.openapi.externalSystem.service.project.ProjectDataManager;
 import com.intellij.openapi.externalSystem.service.project.wizard.AbstractExternalProjectImportBuilder;
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.projectRoots.JavaSdk;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.twitter.intellij.pants.PantsBundle;
+import com.twitter.intellij.pants.model.JdkRef;
 import com.twitter.intellij.pants.settings.ImportFromPantsControl;
 import com.twitter.intellij.pants.util.PantsConstants;
 import icons.PantsIcons;
@@ -22,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Icon;
 import java.io.File;
-import java.util.List;
 
 public class PantsProjectImportBuilder extends AbstractExternalProjectImportBuilder<ImportFromPantsControl> {
 
@@ -65,31 +62,10 @@ public class PantsProjectImportBuilder extends AbstractExternalProjectImportBuil
       return;
     }
 
-    final DataNode<Sdk> sdkNode = ExternalSystemApiUtil.find(node, PantsConstants.SDK_KEY);
+    final DataNode<JdkRef> sdkNode = ExternalSystemApiUtil.find(node, PantsConstants.SDK_KEY);
     if (sdkNode != null) {
-      Sdk pantsSdk = sdkNode.getData();
-      context.setProjectJdk(addIfNotExists(pantsSdk));
+      Sdk pantsSdk = sdkNode.getData().toSdk();
+      context.setProjectJdk(pantsSdk);
     }
-  }
-
-  /**
-   * Find if pants sdk is already configured, return the existing sdk if it exists,
-   * otherwise add to the config and return.
-   */
-  private Sdk addIfNotExists(final Sdk pantsSdk) {
-    final JavaSdk javaSdk = JavaSdk.getInstance();
-    List<Sdk> sdks = ProjectJdkTable.getInstance().getSdksOfType(javaSdk);
-    for (Sdk sdk : sdks) {
-      if (javaSdk.getVersion(sdk) == javaSdk.getVersion(pantsSdk)) {
-        return sdk;
-      }
-    }
-    ApplicationManager.getApplication().runWriteAction(new Runnable() {
-      @Override
-      public void run() {
-        ProjectJdkTable.getInstance().addJdk(pantsSdk);
-      }
-    });
-    return pantsSdk;
   }
 }


### PR DESCRIPTION
This closes #426 by replacing the Sdk with a Jdk reference data class (with java home and jsk name). The data class, unlike the Sdk, doesn't contain any primitives unsupported by the IntelliJ serializer.