### PR TITLE
Fix #431

### DIFF
--- a/src/com/twitter/intellij/pants/file/BUILDFileTypeDetector.java
+++ b/src/com/twitter/intellij/pants/file/BUILDFileTypeDetector.java
@@ -12,11 +12,18 @@ import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 public class BUILDFileTypeDetector implements FileTypeRegistry.FileTypeDetector {
   @Nullable
   @Override
   public FileType detect(@NotNull VirtualFile file, @NotNull ByteSequence firstBytes, @Nullable CharSequence firstCharsIfText) {
     return PantsUtil.isBUILDFileName(file.getName()) ? PythonFileType.INSTANCE : null;
+  }
+
+  @Nullable
+  public Collection<? extends FileType> getDetectedFileTypes() {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
Fix this error:
```
com.intellij.diagnostic.PluginException: File type detector com.twitter.intellij.pants.file.BUILDFileTypeDetector@292dba72 does not implement getDetectedFileTypes(), leading to suboptimal performance. Please implement the method. [Plugin: com.intellij.plugins.pants]
	at com.intellij.ide.plugins.PluginManagerCore.createPluginException(PluginManagerCore.java:399)
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:12)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:58)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.getDetectorsForType(FileTypeManagerImpl.java:1128)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.isFileOfType(FileTypeManagerImpl.java:1182)
```