### PR TITLE
Add `.ic.iterate.rc` file to pants main and test invovation 

### DIFF
--- a/common/com/twitter/intellij/pants/model/IJRC.java
+++ b/common/com/twitter/intellij/pants/model/IJRC.java
@@ -15,14 +15,24 @@ import java.util.Optional;
 public class IJRC {
 
   public static final String IMPORT_RC_FILENAME = ".ij.import.rc";
+  public static final String ITERATE_RC_FILENAME = ".ij.iterate.rc";
 
   // TODO(wisechengyi): add functionality for runConfiguration stage.
 
+  // At import time.
   public static Optional<String> getImportPantsRc(@NotNull final String buildRoot) {
+    return getPantsRc(buildRoot, IMPORT_RC_FILENAME);
+  }
+
+  public static Optional<String> getIteratePantsRc(@NotNull final String buildRoot) {
+    return getPantsRc(buildRoot, ITERATE_RC_FILENAME);
+  }
+
+  private static Optional<String> getPantsRc(@NotNull final String buildRoot, String rcFilename) {
     // At import time.
-    File importRc = new File(buildRoot, IMPORT_RC_FILENAME);
-    if (importRc.isFile()) {
-      return Optional.of("--pantsrc-files=" + importRc.getPath());
+    File rcFile = new File(buildRoot, rcFilename);
+    if (rcFile.isFile()) {
+      return Optional.of("--pantsrc-files=" + rcFile.getPath());
     }
     return Optional.empty();
   }

--- a/src/com/twitter/intellij/pants/execution/PantsJUnitTestRunConfigurationProducer.java
+++ b/src/com/twitter/intellij/pants/execution/PantsJUnitTestRunConfigurationProducer.java
@@ -19,6 +19,7 @@ import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiPackage;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.testIntegration.TestIntegrationUtils;
+import com.twitter.intellij.pants.model.IJRC;
 import com.twitter.intellij.pants.util.PantsConstants;
 import org.jetbrains.annotations.NotNull;
 
@@ -77,6 +78,8 @@ public class PantsJUnitTestRunConfigurationProducer extends PantsTestRunConfigur
 
     final PsiClass psiClass = TestIntegrationUtils.findOuterClass(psiLocation);
     final PsiMethod psiMethod = PsiTreeUtil.getParentOfType(psiLocation, PsiMethod.class, false);
+    final Optional<String> rcIterate = IJRC.getIteratePantsRc(buildRoot.getPath());
+    rcIterate.map(scriptParameters::add);
 
     if (psiMethod != null) {
       sourceElement.set(psiMethod);

--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -41,6 +41,7 @@ import com.intellij.openapi.wm.ex.ToolWindowManagerEx;
 import com.twitter.intellij.pants.PantsBundle;
 import com.twitter.intellij.pants.file.FileChangeTracker;
 import com.twitter.intellij.pants.metrics.PantsExternalMetricsListenerManager;
+import com.twitter.intellij.pants.model.IJRC;
 import com.twitter.intellij.pants.model.PantsOptions;
 import com.twitter.intellij.pants.settings.PantsSettings;
 import com.twitter.intellij.pants.ui.PantsConsoleManager;
@@ -252,6 +253,10 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
         return PantsExecuteTaskResult.emptyFailure();
       }
     }
+
+    /* Add `.ic.iterate.rc` file */
+    final Optional<String> rcIterate = IJRC.getIteratePantsRc(commandLine.getWorkDirectory().getPath());
+    rcIterate.ifPresent(commandLine::addParameter);
 
     /* Goals and targets section. */
     commandLine.addParameters(tasks);

--- a/src/com/twitter/intellij/pants/execution/PantsPythonTestRunConfigurationProducer.java
+++ b/src/com/twitter/intellij/pants/execution/PantsPythonTestRunConfigurationProducer.java
@@ -18,6 +18,7 @@ import com.jetbrains.python.psi.PyClass;
 import com.jetbrains.python.psi.PyFile;
 import com.jetbrains.python.psi.PyFunction;
 import com.jetbrains.python.testing.PythonUnitTestUtil;
+import com.twitter.intellij.pants.model.IJRC;
 import com.twitter.intellij.pants.util.PantsConstants;
 import org.jetbrains.annotations.NotNull;
 
@@ -101,6 +102,9 @@ public class PantsPythonTestRunConfigurationProducer extends PantsTestRunConfigu
     taskSettings.setExternalProjectPath(path);
     String scriptParams = StringUtil.join(targets, " ");
     scriptParams += " " + PantsConstants.PANTS_CLI_OPTION_PYTEST + "=\"-k " + elemStr + "\"";
+    final Optional<String> rcIterate = IJRC.getIteratePantsRc(path);
+    scriptParams += rcIterate.orElse("");
+
     taskSettings.setExecutionName(elemStr);
     taskSettings.setScriptParameters(scriptParams);
     return true;

--- a/tests/com/twitter/intellij/pants/rc/IJRCTest.java
+++ b/tests/com/twitter/intellij/pants/rc/IJRCTest.java
@@ -12,28 +12,28 @@ import java.io.IOException;
 import java.util.Optional;
 
 public class IJRCTest extends UsefulTestCase {
-  private File temp;
 
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-    temp = new File(getHomePath(), IJRC.IMPORT_RC_FILENAME);
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
+  public void testInvalidPath() {
+    File temp = new File(getHomePath(), IJRC.IMPORT_RC_FILENAME);
+    assertFalse(IJRC.getImportPantsRc("/invalid/").isPresent());
     temp.delete();
   }
 
-  public void testInvalidPath() {
-    assertFalse(IJRC.getImportPantsRc("/invalid/").isPresent());
-  }
-
   public void testRcPickup() throws IOException {
+    File temp = new File(getHomePath(), IJRC.IMPORT_RC_FILENAME);
     FileUtil.writeToFile(temp, "123");
     Optional<String> rc = IJRC.getImportPantsRc(temp.getParent());
     assertTrue(rc.isPresent());
     assertEquals(String.format("--pantsrc-files=%s", temp.getPath()), rc.get());
+    temp.delete();
+  }
+
+  public void testIterateRcPickup() throws IOException {
+    File temp = new File(getHomePath(), IJRC.ITERATE_RC_FILENAME);
+    FileUtil.writeToFile(temp, "123");
+    Optional<String> rc = IJRC.getIteratePantsRc(temp.getParent());
+    assertTrue(rc.isPresent());
+    assertEquals(String.format("--pantsrc-files=%s", temp.getPath()), rc.get());
+    temp.delete();
   }
 }


### PR DESCRIPTION
Add `.ic.iterate.rc` file to pants main and test invocation when the file is available in a workspace

Fixes https://github.com/pantsbuild/intellij-pants-plugin/issues/436

Had a quick look at the issue - @wisechengyi let me know if this is what you're after.
It would be nice to create some test projects also locally for the plugin repo, but not sure what is the convention here.