### PR TITLE
Project lifecycle issues

### DIFF
--- a/src/com/twitter/intellij/pants/components/impl/PantsInitComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsInitComponentImpl.java
@@ -43,7 +43,7 @@ public class PantsInitComponentImpl implements PantsInitComponent {
   @Override
   public void disposeComponent() {
     PantsUtil.scheduledThreadPool.shutdown();
-    PantsMetrics.indexThreadPool.shutdown();
+    PantsMetrics.globalCleanup();
   }
 
   //  Registers the rebuild action to Pants rebuild action.

--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -355,7 +355,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
   }
 
   private void prepareIDE(Project project) {
-    ApplicationManager.getApplication().invokeLater(new Runnable() {
+    ApplicationManager.getApplication().invokeAndWait(new Runnable() {
       @Override
       public void run() {
         /* Clear message window. */

--- a/src/com/twitter/intellij/pants/metrics/PantsMetrics.java
+++ b/src/com/twitter/intellij/pants/metrics/PantsMetrics.java
@@ -106,15 +106,19 @@ public class PantsMetrics {
     }, 0, 1, TimeUnit.SECONDS);
   }
 
+  public static void globalCleanup() {
+    // Thread related things.
+    if (indexThreadPool != null && !indexThreadPool.isShutdown()) {
+      indexThreadPool.shutdown();
+    }
+  }
+
   public static void initialize() {
     timers.put(METRIC_EXPORT, Stopwatch.createUnstarted());
     timers.put(METRIC_LOAD, Stopwatch.createUnstarted());
     timers.put(METRIC_INDEXING, Stopwatch.createUnstarted());
 
-    // Thread related things.
-    if (indexThreadPool != null && !indexThreadPool.isShutdown()) {
-      indexThreadPool.shutdown();
-    }
+    globalCleanup();
     indexThreadPool = Executors.newSingleThreadScheduledExecutor(
       new ThreadFactory() {
         @Override

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -514,7 +514,6 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
       "Timer",
       "FileBasedIndex"
     );
-    try {
       if (myCompilerTester != null) {
         myCompilerTester.tearDown();
       }
@@ -530,13 +529,6 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
       // fail with leaky sdk errors, broaden this to include the leaked sdks.
       removeJdks(jdk -> jdk.getName().contains("pants"));
       super.tearDown();
-    }
-    catch (Throwable throwable) {
-      // Discard error containing "Already disposed".
-      if (throwable.getMessage() == null || !throwable.getMessage().contains("Already disposed")) {
-        throw throwable;
-      }
-    }
   }
 
   @Override


### PR DESCRIPTION
Fix #444: two project lifecycle issues

1. Null Pointer Exception when closing IntelliJ if no projects has been opened
2. "Already disposed" exception in tests' teardown