### PR TITLE
[Refactoring] Make the boolean fields in `PantsProjectSettings` public

### DIFF
--- a/src/com/twitter/intellij/pants/PantsManager.java
+++ b/src/com/twitter/intellij/pants/PantsManager.java
@@ -130,10 +130,10 @@ public class PantsManager implements
           PantsProjectSettings pantsProjectSettings = (PantsProjectSettings) projectSettings;
           return new PantsExecutionSettings(
             pantsProjectSettings.getTargetSpecs(),
-            pantsProjectSettings.isLibsWithSources(),
-            pantsProjectSettings.isUseIdeaProjectJdk(),
-            pantsProjectSettings.isImportSourceDepsAsJars(),
-            pantsProjectSettings.isEnableIncrementalImport()
+            pantsProjectSettings.libsWithSources,
+            pantsProjectSettings.useIdeaProjectJdk,
+            pantsProjectSettings.importSourceDepsAsJars,
+            pantsProjectSettings.enableIncrementalImport
           );
         }
         else {

--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
@@ -13,11 +13,11 @@ import java.util.Objects;
 
 public class PantsProjectSettings extends ExternalProjectSettings implements PantsCompileOptions {
   private List<String> myTargetSpecs = ContainerUtilRt.newArrayList();
-  private boolean myLibsWithSources;
-  private boolean myEnableIncrementalImport;
-  private boolean myUseIdeaProjectJdk;
-  private boolean myImportSourceDepsAsJars;
-  private boolean myUseIntellijCompiler;
+  public boolean libsWithSources;
+  public boolean enableIncrementalImport;
+  public boolean useIdeaProjectJdk;
+  public boolean importSourceDepsAsJars;
+  public boolean useIntellijCompiler;
 
   /**
    * @param targetSpecs               targets explicted listed from `pants idea-plugin` goal.
@@ -39,11 +39,11 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
   ) {
     setExternalProjectPath(externalProjectPath);
     myTargetSpecs = targetSpecs;
-    myLibsWithSources = libsWithSources;
-    myEnableIncrementalImport = isEnableIncrementalImport;
-    myUseIdeaProjectJdk = isUseIdeaProjectJdk;
-    myImportSourceDepsAsJars = isImportSourceDepsAsJars;
-    myUseIdeaProjectJdk = isUseIntellijCompiler;
+    this.libsWithSources = libsWithSources;
+    enableIncrementalImport = isEnableIncrementalImport;
+    useIdeaProjectJdk = isUseIdeaProjectJdk;
+    importSourceDepsAsJars = isImportSourceDepsAsJars;
+    useIdeaProjectJdk = isUseIntellijCompiler;
   }
 
   public PantsProjectSettings() {
@@ -59,12 +59,12 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
       return false;
     }
     PantsProjectSettings other = (PantsProjectSettings) obj;
-    return Objects.equals(myLibsWithSources, other.myLibsWithSources)
-           && Objects.equals(myEnableIncrementalImport, other.myEnableIncrementalImport)
+    return Objects.equals(libsWithSources, other.libsWithSources)
+           && Objects.equals(enableIncrementalImport, other.enableIncrementalImport)
            && Objects.equals(myTargetSpecs, other.myTargetSpecs)
-           && Objects.equals(myUseIdeaProjectJdk, other.myUseIdeaProjectJdk)
-           && Objects.equals(myImportSourceDepsAsJars, other.myImportSourceDepsAsJars)
-           && Objects.equals(myUseIntellijCompiler, other.myUseIntellijCompiler);
+           && Objects.equals(useIdeaProjectJdk, other.useIdeaProjectJdk)
+           && Objects.equals(importSourceDepsAsJars, other.importSourceDepsAsJars)
+           && Objects.equals(useIntellijCompiler, other.useIntellijCompiler);
   }
 
   @NotNull
@@ -79,12 +79,12 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
   protected void copyTo(@NotNull ExternalProjectSettings receiver) {
     super.copyTo(receiver);
     if (receiver instanceof PantsProjectSettings) {
-      ((PantsProjectSettings) receiver).setLibsWithSources(isLibsWithSources());
       ((PantsProjectSettings) receiver).setTargetSpecs(getTargetSpecs());
-      ((PantsProjectSettings) receiver).setEnableIncrementalImport(isEnableIncrementalImport());
-      ((PantsProjectSettings) receiver).setUseIdeaProjectJdk(isUseIdeaProjectJdk());
-      ((PantsProjectSettings) receiver).setImportSourceDepsAsJars(isImportSourceDepsAsJars());
-      ((PantsProjectSettings) receiver).setUseIntellijCompiler(isUseIntellijCompiler());
+      ((PantsProjectSettings) receiver).libsWithSources = libsWithSources;
+      ((PantsProjectSettings) receiver).enableIncrementalImport = enableIncrementalImport;
+      ((PantsProjectSettings) receiver).useIdeaProjectJdk = useIdeaProjectJdk;
+      ((PantsProjectSettings) receiver).importSourceDepsAsJars = importSourceDepsAsJars;
+      ((PantsProjectSettings) receiver).useIntellijCompiler = useIntellijCompiler;
     }
   }
 
@@ -101,43 +101,14 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
     myTargetSpecs = targetSpecs;
   }
 
-  public boolean isLibsWithSources() {
-    return myLibsWithSources;
-  }
-
-  public void setLibsWithSources(boolean libsWithSources) {
-    myLibsWithSources = libsWithSources;
-  }
-
+  @Override
   public boolean isEnableIncrementalImport() {
-    return myEnableIncrementalImport;
+    return this.enableIncrementalImport;
   }
 
-  public void setEnableIncrementalImport(boolean enableIncrementalImport) {
-    myEnableIncrementalImport = enableIncrementalImport;
-  }
-
-  public boolean isUseIdeaProjectJdk() {
-    return myUseIdeaProjectJdk;
-  }
-
-  public void setUseIdeaProjectJdk(boolean useIdeaProjectJdk) {
-    myUseIdeaProjectJdk = useIdeaProjectJdk;
-  }
-
+  @Override
   public boolean isImportSourceDepsAsJars() {
-    return myImportSourceDepsAsJars;
+    return this.importSourceDepsAsJars;
   }
 
-  public void setImportSourceDepsAsJars(boolean importSourceDepsAsJars) {
-    myImportSourceDepsAsJars = importSourceDepsAsJars;
-  }
-
-  public boolean isUseIntellijCompiler() {
-    return myUseIntellijCompiler;
-  }
-
-  public void setUseIntellijCompiler(boolean useIntellijCompiler) {
-    myUseIntellijCompiler = useIntellijCompiler;
-  }
 }

--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
@@ -72,11 +72,11 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
   @Override
   protected void fillExtraControls(@NotNull PaintAwarePanel content, int indentLevel) {
 
-    myLibsWithSourcesCheckBox.setSelected(mySettings.isLibsWithSources());
-    myEnableIncrementalImportCheckBox.setSelected(mySettings.isEnableIncrementalImport());
-    myUseIdeaProjectJdkCheckBox.setSelected(mySettings.isUseIdeaProjectJdk());
-    myImportSourceDepsAsJarsCheckBox.setSelected(mySettings.isImportSourceDepsAsJars());
-    myUseIntellijCompilerCheckBox.setSelected(mySettings.isUseIntellijCompiler());
+    myLibsWithSourcesCheckBox.setSelected(mySettings.libsWithSources);
+    myEnableIncrementalImportCheckBox.setSelected(mySettings.enableIncrementalImport);
+    myUseIdeaProjectJdkCheckBox.setSelected(mySettings.useIdeaProjectJdk);
+    myImportSourceDepsAsJarsCheckBox.setSelected(mySettings.importSourceDepsAsJars);
+    myUseIntellijCompilerCheckBox.setSelected(mySettings.useIntellijCompiler);
 
     mySettings.getTargetSpecs().forEach(spec -> myTargetSpecsBox.addItem(spec, spec, true));
 
@@ -214,12 +214,12 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
 
   @Override
   protected void applyExtraSettings(@NotNull PantsProjectSettings settings) {
-    settings.setLibsWithSources(myLibsWithSourcesCheckBox.isSelected());
-    settings.setEnableIncrementalImport(myEnableIncrementalImportCheckBox.isSelected());
-    settings.setUseIdeaProjectJdk(myUseIdeaProjectJdkCheckBox.isSelected());
     settings.setTargetSpecs(getSelectedTargetSpecsFromBoxes());
-    settings.setImportSourceDepsAsJars(myImportSourceDepsAsJarsCheckBox.isSelected());
-    settings.setUseIntellijCompiler(myUseIntellijCompilerCheckBox.isSelected());
+    settings.libsWithSources = myLibsWithSourcesCheckBox.isSelected();
+    settings.enableIncrementalImport = myEnableIncrementalImportCheckBox.isSelected();
+    settings.useIdeaProjectJdk = myUseIdeaProjectJdkCheckBox.isSelected();
+    settings.importSourceDepsAsJars = myImportSourceDepsAsJarsCheckBox.isSelected();
+    settings.useIntellijCompiler = myUseIntellijCompilerCheckBox.isSelected();
   }
 
   @Override

--- a/src/com/twitter/intellij/pants/settings/PantsSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsSettings.java
@@ -77,7 +77,7 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
   }
 
   public void setEnableIncrementalImport(boolean enableIncrementalImport) {
-    getLinkedProjectsSettings().forEach(s -> s.setEnableIncrementalImport(enableIncrementalImport));
+    getLinkedProjectsSettings().forEach(s -> s.enableIncrementalImport = enableIncrementalImport);
   }
 
   public int getResolverVersion() {


### PR DESCRIPTION
Same as #440, except this time it'll not break the build.

The boolean fields in PantsProjectSettings all have identity accessors (public boolean is<whatever>() { return myWhatever; }) and mutators (setters), making them effectively public mutable variables.

If we make them public we can get rid of all the getters and setters, reducing some duplication in that file.