### PR TITLE
Resolve names inside BUILD files to take into account available target types

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -9,9 +9,6 @@ import com.intellij.openapi.externalSystem.model.ProjectSystemId;
 import com.twitter.intellij.pants.model.JdkRef;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
-
 public class PantsConstants {
   public static final String PANTS = "pants";
   public static final String PANTS_CONSOLE_NAME = "Pants Console";

--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -9,6 +9,8 @@ import com.intellij.openapi.externalSystem.model.ProjectSystemId;
 import com.twitter.intellij.pants.model.JdkRef;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 
 public class PantsConstants {
   public static final String PANTS = "pants";
@@ -43,6 +45,7 @@ public class PantsConstants {
   // Used to initialize project sdk therefore use project processing weight, i.e, the highest.
   public static final Key<JdkRef> SDK_KEY = Key.create(JdkRef.class, ProjectKeys.PROJECT.getProcessingWeight());
 
+  public static final String PANTS_AVAILABLE_TARGETS_KEY = "available_targets";
   public static final String PANTS_CLI_OPTION_EXPORT_OUTPUT_FILE = "--export-output-file";
   public static final String PANTS_CLI_OPTION_LIST_OUTPUT_FILE = "--list-output-file";
   public static final String PANTS_CLI_OPTION_EXPORT_CLASSPATH_MANIFEST_JAR = "--export-classpath-manifest-jar-only";

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -105,9 +105,12 @@ import java.util.stream.Stream;
 
 public class PantsUtil {
   public static final Gson gson = new Gson();
-  public static final Type TYPE_LIST_STRING = new TypeToken<List<String>>() {}.getType();
-  public static final Type TYPE_SET_STRING = new TypeToken<Set<String>>() {}.getType();
-  public static final Type TYPE_MAP_STRING_INTEGER = new TypeToken<Map<String, Integer>>() {}.getType();
+  public static final Type TYPE_LIST_STRING = new TypeToken<List<String>>() {
+  }.getType();
+  public static final Type TYPE_SET_STRING = new TypeToken<Set<String>>() {
+  }.getType();
+  public static final Type TYPE_MAP_STRING_INTEGER = new TypeToken<Map<String, Integer>>() {
+  }.getType();
   public static final ScheduledExecutorService scheduledThreadPool = Executors.newSingleThreadScheduledExecutor(
     new ThreadFactory() {
       @Override
@@ -209,6 +212,18 @@ public class PantsUtil {
 
   public static Optional<VirtualFile> findPantsIniFile(Optional<VirtualFile> workingDir) {
     return workingDir.map(file -> file.findChild(PantsConstants.PANTS_INI));
+  }
+
+  public static boolean isCompatiblePantsVersion(String projectPath, String minVersion) {
+    return PantsUtil.findPantsExecutable(projectPath)
+      .flatMap(exec -> PantsOptions.getPantsOptions(exec.getPath()).get("pants_version"))
+      .map(version -> PantsUtil.isCompatibleVersion(version, minVersion))
+      .orElse(false);
+  }
+
+  public static boolean isCompatibleVersion(String current, String minimum) {
+    String currentVersion = current.replaceAll("rc.+", "").trim();
+    return versionCompare(currentVersion, minimum) >= 0;
   }
 
   private static Optional<String> findVersionInFile(@NotNull VirtualFile file) {
@@ -376,13 +391,16 @@ public class PantsUtil {
       }
       else {
         List<String> errorLogs = Lists.newArrayList(
-          String.format("Could not list targets: Pants exited with status %d",
-                        processOutput.getExitCode()),
+          String.format(
+            "Could not list targets: Pants exited with status %d",
+            processOutput.getExitCode()
+          ),
           String.format("argv: '%s'", cmd.getCommandLineString()),
           "stdout:",
           processOutput.getStdout(),
           "stderr:",
-          processOutput.getStderr());
+          processOutput.getStderr()
+        );
         final String errorMessage = String.join("\n", errorLogs);
         LOG.warn(errorMessage);
         throw new PantsException(errorMessage);
@@ -390,9 +408,11 @@ public class PantsUtil {
     }
     catch (IOException | ExecutionException e) {
       final String processCreationFailureMessage =
-        String.format("Could not execute command: '%s' due to error: '%s'",
-                      cmd.getCommandLineString(),
-                      e.getMessage());
+        String.format(
+          "Could not execute command: '%s' due to error: '%s'",
+          cmd.getCommandLineString(),
+          e.getMessage()
+        );
       LOG.warn(processCreationFailureMessage, e);
       throw new PantsException(processCreationFailureMessage);
     }
@@ -506,7 +526,7 @@ public class PantsUtil {
     }
     if (versionCompare(version, PANTS_IDEA_PLUGIN_VERESION_MIN) < 0 ||
         versionCompare(version, PANTS_IDEA_PLUGIN_VERESION_MAX) > 0
-      ) {
+    ) {
       Messages.showInfoMessage(project, PantsBundle.message("pants.idea.plugin.goal.version.unsupported"), "Version Error");
       return false;
     }
@@ -829,15 +849,15 @@ public class PantsUtil {
   }
 
   /**
-   * @param pantsExecutable path to the pants executable file for the
-   * project. This function will return erroneous output if you use a directory path. The
-   * pants executable can be found from a project path with {@link #findPantsExecutable(String)}.
+   * @param pantsExecutable  path to the pants executable file for the
+   *                         project. This function will return erroneous output if you use a directory path. The
+   *                         pants executable can be found from a project path with {@link #findPantsExecutable(String)}.
    * @param parentDisposable Disposable object to use if a new JDK is added to
-   * the project jdk table (otherwise null). Integration tests should use getTestRootDisposable() for
-   * this argument to avoid exceptions during teardown.
+   *                         the project jdk table (otherwise null). Integration tests should use getTestRootDisposable() for
+   *                         this argument to avoid exceptions during teardown.
    * @return The default Sdk object to use for the project at the given pants
    * executable path.
-   *
+   * <p>
    * This method will add a JDK to the project JDK table if it needs to create
    * one, which mutates global state (protected by a read/write lock).
    */

--- a/pants.ini
+++ b/pants.ini
@@ -5,7 +5,7 @@ local_artifact_cache = %(buildroot)s/.cache
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [GLOBAL]
-pants_version: 1.20.0rc2
+pants_version: 1.23.0rc0
 print_exception_stacktrace: True
 pants_ignore: +[
     'out/',

--- a/pants.ini
+++ b/pants.ini
@@ -5,7 +5,7 @@ local_artifact_cache = %(buildroot)s/.cache
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [GLOBAL]
-pants_version: 1.23.0rc0
+pants_version: 1.22.0
 print_exception_stacktrace: True
 pants_ignore: +[
     'out/',

--- a/src/com/twitter/intellij/pants/psi/resolve/PantsReferenceResolveProvider.java
+++ b/src/com/twitter/intellij/pants/psi/resolve/PantsReferenceResolveProvider.java
@@ -3,6 +3,7 @@
 
 package com.twitter.intellij.pants.psi.resolve;
 
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.Function;
@@ -12,20 +13,36 @@ import com.jetbrains.python.psi.resolve.PyReferenceResolveProvider;
 import com.jetbrains.python.psi.resolve.RatedResolveResult;
 import com.jetbrains.python.psi.types.TypeEvalContext;
 import com.twitter.intellij.pants.index.PantsTargetIndex;
+import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class PantsReferenceResolveProvider implements PyReferenceResolveProvider {
+
   @NotNull
   @Override
   public List<RatedResolveResult> resolveName(@NotNull PyQualifiedExpression expression, @NotNull TypeEvalContext context) {
     PsiFile containingFile = expression.getContainingFile();
-    return PantsUtil.isBUILDFileName(containingFile.getName()) ?
-           resolvePantsName(expression) :
-           Collections.<RatedResolveResult>emptyList();
+    if (isOneOfAvailableTargetTypes(expression)) {
+      List<RatedResolveResult> resolved = new LinkedList<>();
+      resolved.add(new RatedResolveResult(RatedResolveResult.RATE_NORMAL, expression));
+      return resolved;
+    }
+    else {
+      return PantsUtil.isBUILDFileName(containingFile.getName()) ?
+             resolvePantsName(expression) :
+             Collections.<RatedResolveResult>emptyList();
+    }
+  }
+
+  private boolean isOneOfAvailableTargetTypes(@NotNull PyQualifiedExpression expression) {
+    String[] allBuildTypes = PropertiesComponent.getInstance().getValues(PantsConstants.PANTS_AVAILABLE_TARGETS_KEY);
+    return allBuildTypes != null && Arrays.asList(allBuildTypes).contains(expression.getReferencedName());
   }
 
   private List<RatedResolveResult> resolvePantsName(@NotNull PyQualifiedExpression element) {

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -196,8 +196,22 @@ public class PantsCompileOptionsExecutor {
     return processOutput;
   }
 
+  private boolean isAtLeastPantsVersion(int major, int minor) throws ExecutionException {
+    String pantsVersion = getPantsVersion();
+    String[] splitVersion = pantsVersion.trim().split("\\.");
+    return splitVersion.length >= 3 && Integer.parseInt(splitVersion[0]) >= major && Integer.parseInt(splitVersion[1]) >= minor;
+  }
+
   @NotNull
-  private GeneralCommandLine getPantsExportCommand(final File outputFile, @NotNull Consumer<String> statusConsumer) throws IOException {
+  private String getPantsVersion() throws ExecutionException {
+    final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(getProjectPath());
+    commandLine.addParameter("--version");
+    return getProcessOutput(commandLine).getStdout();
+  }
+
+  @NotNull
+  private GeneralCommandLine getPantsExportCommand(final File outputFile, @NotNull Consumer<String> statusConsumer)
+    throws IOException, ExecutionException {
     final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(getProjectPath());
 
     // Grab the import stage pants rc file for IntelliJ.
@@ -213,6 +227,11 @@ public class PantsCompileOptionsExecutor {
     }
     commandLine.addParameter("--target-spec-file=" + targetSpecsFile.getPath());
     commandLine.addParameter("--no-quiet");
+
+    boolean exportAvailableTypes = isAtLeastPantsVersion(1, 23);
+    if (exportAvailableTypes) {
+      commandLine.addParameter("--export-available-target-types");
+    }
     if (getOptions().isImportSourceDepsAsJars()) {
       commandLine.addParameter("export-dep-as-jar");
     }

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -20,6 +20,7 @@ import com.twitter.intellij.pants.metrics.PantsMetrics;
 import com.twitter.intellij.pants.model.IJRC;
 import com.twitter.intellij.pants.model.PantsCompileOptions;
 import com.twitter.intellij.pants.model.PantsExecutionOptions;
+import com.twitter.intellij.pants.model.PantsOptions;
 import com.twitter.intellij.pants.settings.PantsExecutionSettings;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.Nls;
@@ -196,22 +197,9 @@ public class PantsCompileOptionsExecutor {
     return processOutput;
   }
 
-  private boolean isAtLeastPantsVersion(int major, int minor) throws ExecutionException {
-    String pantsVersion = getPantsVersion();
-    String[] splitVersion = pantsVersion.trim().split("\\.");
-    return splitVersion.length >= 3 && Integer.parseInt(splitVersion[0]) >= major && Integer.parseInt(splitVersion[1]) >= minor;
-  }
-
-  @NotNull
-  private String getPantsVersion() throws ExecutionException {
-    final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(getProjectPath());
-    commandLine.addParameter("--version");
-    return getProcessOutput(commandLine).getStdout();
-  }
-
   @NotNull
   private GeneralCommandLine getPantsExportCommand(final File outputFile, @NotNull Consumer<String> statusConsumer)
-    throws IOException, ExecutionException {
+    throws IOException {
     final GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(getProjectPath());
 
     // Grab the import stage pants rc file for IntelliJ.
@@ -228,10 +216,10 @@ public class PantsCompileOptionsExecutor {
     commandLine.addParameter("--target-spec-file=" + targetSpecsFile.getPath());
     commandLine.addParameter("--no-quiet");
 
-    boolean exportAvailableTypes = isAtLeastPantsVersion(1, 23);
-    if (exportAvailableTypes) {
+    if (PantsUtil.isCompatiblePantsVersion(getProjectPath(), "1.24.0")) {
       commandLine.addParameter("--export-available-target-types");
     }
+
     if (getOptions().isImportSourceDepsAsJars()) {
       commandLine.addParameter("export-dep-as-jar");
     }

--- a/src/com/twitter/intellij/pants/service/project/PantsResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsResolver.java
@@ -6,6 +6,7 @@ package com.twitter.intellij.pants.service.project;
 import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.ExternalSystemException;
@@ -20,6 +21,7 @@ import com.twitter.intellij.pants.model.SimpleExportResult;
 import com.twitter.intellij.pants.service.PantsCompileOptionsExecutor;
 import com.twitter.intellij.pants.service.project.model.graph.BuildGraph;
 import com.twitter.intellij.pants.service.project.model.ProjectInfo;
+import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -100,6 +102,7 @@ public class PantsResolver {
 
     Optional<BuildGraph> buildGraph = constructBuildGraph(projectInfoDataNode);
 
+    PropertiesComponent.getInstance().setValues(PantsConstants.PANTS_AVAILABLE_TARGETS_KEY, myProjectInfo.getAvailableTargetTypes());
     final Map<String, DataNode<ModuleData>> modules = new HashMap<>();
     for (PantsResolverExtension resolver : PantsResolverExtension.EP_NAME.getExtensions()) {
       resolver.resolve(myProjectInfo, myExecutor, projectInfoDataNode, modules, buildGraph);

--- a/src/com/twitter/intellij/pants/service/project/model/ProjectInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/ProjectInfo.java
@@ -43,6 +43,11 @@ public class ProjectInfo {
   // name to info
   protected Map<String, TargetInfo> targets;
 
+  /* This might need to be expanded to show all properties that
+   * a target type can contain like:
+   *
+   * {"java_library" : [{ "dependencies" : "list(str)" }]}
+   */
   @SerializedName("available_target_types")
   protected String[] availableTargetTypes = {};
 
@@ -59,7 +64,7 @@ public class ProjectInfo {
   private static <T> List<Map.Entry<String, T>> getSortedEntries(Map<String, T> map) {
     return ContainerUtil.sorted(
       map.entrySet(),
-      new Comparator<Map.Entry<String,T>>() {
+      new Comparator<Map.Entry<String, T>>() {
         @Override
         public int compare(Map.Entry<String, T> o1, Map.Entry<String, T> o2) {
           return StringUtil.naturalCompare(o1.getKey(), o2.getKey());
@@ -92,6 +97,7 @@ public class ProjectInfo {
     this.targets = targets;
   }
 
+  @NotNull
   public String[] getAvailableTargetTypes() {
     return availableTargetTypes;
   }

--- a/src/com/twitter/intellij/pants/service/project/model/ProjectInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/ProjectInfo.java
@@ -4,6 +4,7 @@
 package com.twitter.intellij.pants.service.project.model;
 
 import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.containers.ContainerUtil;
@@ -12,6 +13,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -39,6 +42,9 @@ public class ProjectInfo {
   protected Map<String, LibraryInfo> libraries;
   // name to info
   protected Map<String, TargetInfo> targets;
+
+  @SerializedName("available_target_types")
+  protected String[] availableTargetTypes = {};
 
   protected String version;
 
@@ -84,6 +90,10 @@ public class ProjectInfo {
 
   public void setTargets(Map<String, TargetInfo> targets) {
     this.targets = targets;
+  }
+
+  public String[] getAvailableTargetTypes() {
+    return availableTargetTypes;
   }
 
   @Nullable

--- a/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
@@ -63,7 +63,7 @@ abstract public class OSSPantsIntegrationTest extends PantsIntegrationTestCase {
    * Assert Project has the right JDK and language level (JVM project only).
    */
   protected void assertProjectJdkAndLanguageLevel() {
-    final String pantsExecutablePath = PantsUtil.findPantsExecutable(getParentPath()).get().getPath();
+    final String pantsExecutablePath = PantsUtil.findPantsExecutable(getProjectPath()).get().getPath();
     assertEquals(
       ProjectRootManager.getInstance(myProject).getProjectSdk().getHomePath(),
       getDefaultJavaSdk(pantsExecutablePath).get().getHomePath()

--- a/tests/com/twitter/intellij/pants/highlighting/PantsHighlightingIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/highlighting/PantsHighlightingIntegrationTest.java
@@ -3,31 +3,24 @@
 
 package com.twitter.intellij.pants.highlighting;
 
-import com.google.common.collect.Lists;
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
-import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerEx;
-import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.codeInsight.intention.IntentionAction;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.RangeMarker;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
-import com.intellij.openapi.fileEditor.TextEditor;
-import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
-import com.intellij.psi.PsiFile;
 import com.intellij.util.containers.ContainerUtil;
 import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
 
 abstract public class PantsHighlightingIntegrationTest extends OSSPantsIntegrationTest {

--- a/tests/com/twitter/intellij/pants/integration/OSSProjectInfoResolveTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSProjectInfoResolveTest.java
@@ -16,8 +16,10 @@ import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 public class OSSProjectInfoResolveTest extends OSSPantsIntegrationTest {
   private static Consumer<String> STRING_CONSUMER = new Consumer<String>() {
@@ -61,6 +63,15 @@ public class OSSProjectInfoResolveTest extends OSSPantsIntegrationTest {
     final TargetInfo greetTarget = info.getTarget("examples/src/java/org/pantsbuild/example/hello/greet:greet");
     assertNotNull(greetTarget);
     assertFalse(greetTarget.isScalaTarget());
+  }
+
+  public void testAvailableTargetTypes() {
+    final ProjectInfo info = resolveProjectInfo("examples/src/scala/org/pantsbuild/example/hello/");
+
+    final List<String> availableTargetTypes = Arrays.asList(info.getAvailableTargetTypes());
+    assertNotNull(availableTargetTypes);
+    assertNotEmpty(availableTargetTypes);
+    assertContain(availableTargetTypes, "scala_library", "java_library");
   }
 
   public void testTargetJars() {

--- a/tests/com/twitter/intellij/pants/integration/OSSProjectInfoResolveTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSProjectInfoResolveTest.java
@@ -31,6 +31,14 @@ public class OSSProjectInfoResolveTest extends OSSPantsIntegrationTest {
     assertTrue(String.format("%s is not found in path %s", jarName, path), path.endsWith(jarName));
   }
 
+  private boolean isMinimalVersion(String version, int major, int minor, int patch) {
+    String[] split = version.split("\\.");
+    return split.length >= 3 &&
+           Integer.parseInt(split[0]) >= major &&
+           Integer.parseInt(split[1]) >= minor &&
+           Integer.parseInt(split[2]) >= patch;
+  }
+
   @NotNull
   private ProjectInfo resolveProjectInfo(@NotNull String targetSpec) {
     final boolean libsWithSourcesAndDocs = true;
@@ -68,10 +76,13 @@ public class OSSProjectInfoResolveTest extends OSSPantsIntegrationTest {
   public void testAvailableTargetTypes() {
     final ProjectInfo info = resolveProjectInfo("examples/src/scala/org/pantsbuild/example/hello/");
 
-    final List<String> availableTargetTypes = Arrays.asList(info.getAvailableTargetTypes());
-    assertNotNull(availableTargetTypes);
-    assertNotEmpty(availableTargetTypes);
-    assertContain(availableTargetTypes, "scala_library", "java_library");
+    // this should be only tested after export version 1.0.13
+    if (isMinimalVersion(info.getVersion(), 1, 0,13)) {
+      final List<String> availableTargetTypes = Arrays.asList(info.getAvailableTargetTypes());
+      assertNotNull(availableTargetTypes);
+      assertNotEmpty(availableTargetTypes);
+      assertContain(availableTargetTypes, "scala_library", "java_library");
+    }
   }
 
   public void testTargetJars() {

--- a/tests/com/twitter/intellij/pants/integration/OSSProjectInfoResolveTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSProjectInfoResolveTest.java
@@ -31,14 +31,6 @@ public class OSSProjectInfoResolveTest extends OSSPantsIntegrationTest {
     assertTrue(String.format("%s is not found in path %s", jarName, path), path.endsWith(jarName));
   }
 
-  private boolean isMinimalVersion(String version, int major, int minor, int patch) {
-    String[] split = version.split("\\.");
-    return split.length >= 3 &&
-           Integer.parseInt(split[0]) >= major &&
-           Integer.parseInt(split[1]) >= minor &&
-           Integer.parseInt(split[2]) >= patch;
-  }
-
   @NotNull
   private ProjectInfo resolveProjectInfo(@NotNull String targetSpec) {
     final boolean libsWithSourcesAndDocs = true;
@@ -77,9 +69,8 @@ public class OSSProjectInfoResolveTest extends OSSPantsIntegrationTest {
     final ProjectInfo info = resolveProjectInfo("examples/src/scala/org/pantsbuild/example/hello/");
 
     // this should be only tested after export version 1.0.13
-    if (isMinimalVersion(info.getVersion(), 1, 0,13)) {
+    if (PantsUtil.isCompatibleVersion(info.getVersion(), "1.0.13")) {
       final List<String> availableTargetTypes = Arrays.asList(info.getAvailableTargetTypes());
-      assertNotNull(availableTargetTypes);
       assertNotEmpty(availableTargetTypes);
       assertContain(availableTargetTypes, "scala_library", "java_library");
     }

--- a/tests/com/twitter/intellij/pants/integration/TargetFileResolutionIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/TargetFileResolutionIntegrationTest.java
@@ -1,0 +1,32 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.integration;
+
+import com.intellij.codeInsight.TargetElementUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.PsiReference;
+import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class TargetFileResolutionIntegrationTest extends OSSPantsIntegrationTest {
+
+  public void testAvailableTargetTypes() throws IOException {
+    doImport("examples/src/scala/org/pantsbuild/example/hello/");
+    VirtualFile vfile  = myProjectRoot.findFileByRelativePath("BUILD");
+    assertNotNull(vfile);
+    PsiFile build = PsiManager.getInstance(myProject).findFile(vfile);
+    String input = new String(myProjectRoot.findFileByRelativePath("BUILD").contentsToByteArray());
+    final PsiReference reference = build.findReferenceAt(input.indexOf("files(") + 1);
+    assertNotNull("no reference", reference);
+    final Collection<PsiElement> elements = TargetElementUtil.getInstance().getTargetCandidates(reference);
+    assertNotNull(elements);
+    assertEquals(1, elements.size());
+  }
+
+}

--- a/tests/com/twitter/intellij/pants/integration/TargetFileResolutionIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/TargetFileResolutionIntegrationTest.java
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiReference;
 import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+import com.twitter.intellij.pants.util.PantsUtil;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -17,16 +18,19 @@ import java.util.Collection;
 public class TargetFileResolutionIntegrationTest extends OSSPantsIntegrationTest {
 
   public void testAvailableTargetTypes() throws IOException {
-    doImport("examples/src/scala/org/pantsbuild/example/hello/");
-    VirtualFile vfile  = myProjectRoot.findFileByRelativePath("BUILD");
-    assertNotNull(vfile);
-    PsiFile build = PsiManager.getInstance(myProject).findFile(vfile);
-    String input = new String(myProjectRoot.findFileByRelativePath("BUILD").contentsToByteArray());
-    final PsiReference reference = build.findReferenceAt(input.indexOf("files(") + 1);
-    assertNotNull("no reference", reference);
-    final Collection<PsiElement> elements = TargetElementUtil.getInstance().getTargetCandidates(reference);
-    assertNotNull(elements);
-    assertEquals(1, elements.size());
+    String helloProjectPath = "examples/src/scala/org/pantsbuild/example/hello/";
+    doImport(helloProjectPath);
+    // should be only tested with pants versions above 1.24.0
+    if (PantsUtil.isCompatiblePantsVersion(myProjectRoot.getPath(), "1.24.0")) {
+      VirtualFile vfile = myProjectRoot.findFileByRelativePath(helloProjectPath + "BUILD");
+      assertNotNull(vfile);
+      String input = new String(vfile.contentsToByteArray());
+      PsiFile build = PsiManager.getInstance(myProject).findFile(vfile);
+      final PsiReference reference = build.findReferenceAt(input.indexOf("target(") + 1);
+      assertNotNull("no reference", reference);
+      final Collection<PsiElement> elements = TargetElementUtil.getInstance().getTargetCandidates(reference);
+      assertNotNull(elements);
+      assertEquals(1, elements.size());
+    }
   }
-
 }

--- a/tests/com/twitter/intellij/pants/model/SimpleExportResultTest.java
+++ b/tests/com/twitter/intellij/pants/model/SimpleExportResultTest.java
@@ -100,12 +100,12 @@ public class SimpleExportResultTest extends LightPlatformTestCase {
   }
 
   public void testExportCache() {
-    SimpleExportResult export_a = SimpleExportResult.getExportResult("./pants");
-    SimpleExportResult export_b = SimpleExportResult.getExportResult("./pants");
+    SimpleExportResult export_a = SimpleExportResult.getExportResult("./.cache/pants/pants");
+    SimpleExportResult export_b = SimpleExportResult.getExportResult("./.cache/pants/pants");
     // export_b should be cached result, so identical to export_a
     assertTrue(export_a == export_b);
     SimpleExportResult.clearCache();
-    SimpleExportResult export_c = SimpleExportResult.getExportResult("./pants");
+    SimpleExportResult export_c = SimpleExportResult.getExportResult("./.cache/pants/pants");
     assertTrue(export_a != export_c);
   }
 

--- a/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
+++ b/tests/com/twitter/intellij/pants/util/PantsUtilTest.java
@@ -30,6 +30,20 @@ public class PantsUtilTest extends OSSPantsImportIntegrationTest {
       .collect(Collectors.toList());
   }
 
+  public void testIsCompatibleVersion() {
+    assertTrue(PantsUtil.isCompatibleVersion("2.2.3", "1.2.3"));
+    assertTrue(PantsUtil.isCompatibleVersion("1.4.4", "1.2.3"));
+    assertTrue(PantsUtil.isCompatibleVersion("1.2.4", "1.2.3"));
+    assertTrue(PantsUtil.isCompatibleVersion("1.2.4rc0", "1.2.3"));
+    assertTrue(PantsUtil.isCompatibleVersion("1.2.4.dev0", "1.2.3"));
+    assertTrue(PantsUtil.isCompatibleVersion("1.2.3", "1.2.3"));
+
+    assertFalse(PantsUtil.isCompatibleVersion("1.2.0rc122", "1.2.3"));
+    assertFalse(PantsUtil.isCompatibleVersion("2.34.43", "2.34.44"));
+    assertFalse(PantsUtil.isCompatibleVersion("2.33.44", "2.34.44"));
+    assertFalse(PantsUtil.isCompatibleVersion("1.34.44", "2.34.44"));
+  }
+
   public void testFindJdk() {
     final File executable = PantsUtil.findPantsExecutable(getProjectFolder()).get();
     assertEquals(Lists.newArrayList(), getAllJdks().collect(Collectors.toList()));


### PR DESCRIPTION
Previously, all BUILD files would have functions like `scala_library` or `java_library` underlined red despite them being valid.

Now, we additionally query while exporting for available target types and save them to the `PropertiesComponent`.

This will work with newest pants version, so we might need to wait until there is nightly release. Not sure what is the procedure for changes both to pants and this plugin.

Fixes https://github.com/pantsbuild/intellij-pants-plugin/issues/355