### PR TITLE
Don't drop list of targets while saving settings

### DIFF
--- a/common/com/twitter/intellij/pants/model/PantsExecutionOptions.java
+++ b/common/com/twitter/intellij/pants/model/PantsExecutionOptions.java
@@ -10,7 +10,7 @@ import java.util.List;
 public interface PantsExecutionOptions {
 
   @NotNull
-  List<String> getTargetSpecs();
+  List<String> getSelectedTargetSpecs();
 
   boolean isEnableIncrementalImport();
   boolean isImportSourceDepsAsJars();

--- a/common/com/twitter/intellij/pants/util/PantsConstants.java
+++ b/common/com/twitter/intellij/pants/util/PantsConstants.java
@@ -34,6 +34,7 @@ public class PantsConstants {
   public static final String PANTS_LIBRARY_EXCLUDES_KEY = "pants.library.excludes";
   public static final String PANTS_TARGET_ADDRESSES_KEY = "pants.target.addresses";
   public static final String PANTS_TARGET_ADDRESS_INFOS_KEY = "pants.target.address.infos";
+  public static final String PANTS_TARGET_MODULE_TYPE =  "pants.module";
 
   public static final String PANTS_OPTION_PANTS_WORKDIR = "pants_workdir";
   public static final String PANTS_OPTION_TEST_JUNIT_STRICT_JVM_VERSION = "test.junit.strict_jvm_version";

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -39,6 +39,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl;
 import com.intellij.openapi.roots.ContentEntry;
@@ -67,11 +68,13 @@ import com.twitter.intellij.pants.model.PantsOptions;
 import com.twitter.intellij.pants.model.PantsSourceType;
 import com.twitter.intellij.pants.model.PantsTargetAddress;
 import com.twitter.intellij.pants.model.SimpleExportResult;
+import org.bouncycastle.math.raw.Mod;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.jps.incremental.ModuleLevelBuilder;
 import org.jetbrains.jps.model.JpsProject;
 import org.jetbrains.jps.model.java.JpsJavaSdkType;
 import org.jetbrains.jps.model.library.JpsLibrary;
@@ -90,6 +93,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -611,6 +615,14 @@ public class PantsUtil {
   public static void refreshAllProjects(@NotNull Project project) {
     if (!isPantsProject(project) && !isSeedPantsProject(project)) {
       return;
+    }
+
+    Module[] modules = ModuleManager.getInstance(project).getModules();
+
+    for (Module module : modules) {
+      if(Objects.equals(ExternalSystemModulePropertyManager.getInstance(module).getExternalModuleType(), PantsConstants.PANTS_TARGET_MODULE_TYPE)) {
+        ModuleManager.getInstance(project).disposeModule(module);
+      }
     }
 
     // This code needs to run on the dispatch thread, but in some cases

--- a/src/com/twitter/intellij/pants/PantsManager.java
+++ b/src/com/twitter/intellij/pants/PantsManager.java
@@ -129,7 +129,7 @@ public class PantsManager implements
         if (projectSettings instanceof PantsProjectSettings) {
           PantsProjectSettings pantsProjectSettings = (PantsProjectSettings) projectSettings;
           return new PantsExecutionSettings(
-            pantsProjectSettings.getTargetSpecs(),
+            pantsProjectSettings.getSelectedTargetSpecs(),
             pantsProjectSettings.libsWithSources,
             pantsProjectSettings.useIdeaProjectJdk,
             pantsProjectSettings.importSourceDepsAsJars,

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -43,6 +43,7 @@ import icons.PantsIcons;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -149,7 +150,7 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
           final boolean useIntellijCompiler = false;
           final PantsProjectSettings pantsProjectSettings =
             new PantsProjectSettings(
-              targetSpecs, projectPath, loadLibsAndSources, enableIncrementalImport, useIdeaProjectJdk, enableExportDepAsJar, useIntellijCompiler);
+              targetSpecs, new ArrayList<>(), projectPath, loadLibsAndSources, enableIncrementalImport, useIdeaProjectJdk, enableExportDepAsJar, useIntellijCompiler);
 
           /**
            * Following procedures in {@link com.intellij.openapi.externalSystem.util.ExternalSystemUtil#refreshProjects}:

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -20,7 +20,6 @@ import com.twitter.intellij.pants.metrics.PantsMetrics;
 import com.twitter.intellij.pants.model.IJRC;
 import com.twitter.intellij.pants.model.PantsCompileOptions;
 import com.twitter.intellij.pants.model.PantsExecutionOptions;
-import com.twitter.intellij.pants.model.PantsOptions;
 import com.twitter.intellij.pants.settings.PantsExecutionSettings;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.Nls;
@@ -112,7 +111,7 @@ public class PantsCompileOptionsExecutor {
   @Nls
   public String getProjectName() {
     final String buildRootName = getBuildRoot().getName();
-    List<String> buildRootPrefixedSpecs = myOptions.getTargetSpecs().stream()
+    List<String> buildRootPrefixedSpecs = myOptions.getSelectedTargetSpecs().stream()
       .map(s -> buildRootName + File.separator + s)
       .collect(Collectors.toList());
     String candidateName = String.join("__", buildRootPrefixedSpecs).replaceAll(File.separator, ".");
@@ -238,7 +237,7 @@ public class PantsCompileOptionsExecutor {
   @NotNull
   private List<String> getTargetSpecs() {
     // If project is opened via pants cli, the targets are in specs.
-    return Collections.unmodifiableList(getOptions().getTargetSpecs());
+    return Collections.unmodifiableList(getOptions().getSelectedTargetSpecs());
   }
 
   /**
@@ -276,8 +275,8 @@ public class PantsCompileOptionsExecutor {
     }
 
     @NotNull
-    public List<String> getTargetSpecs() {
-      return myExecutionOptions.getTargetSpecs();
+    public List<String> getSelectedTargetSpecs() {
+      return myExecutionOptions.getSelectedTargetSpecs();
     }
 
     public boolean isEnableIncrementalImport() {

--- a/src/com/twitter/intellij/pants/service/project/metadata/PantsMetadataService.java
+++ b/src/com/twitter/intellij/pants/service/project/metadata/PantsMetadataService.java
@@ -3,6 +3,7 @@
 
 package com.twitter.intellij.pants.service.project.metadata;
 
+import com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.Key;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
@@ -48,6 +49,7 @@ public class PantsMetadataService implements ProjectDataService<TargetMetadata, 
         module.setOption(PantsConstants.PANTS_LIBRARY_EXCLUDES_KEY, PantsUtil.dehydrateTargetAddresses(metadata.getLibraryExcludes()));
         module.setOption(PantsConstants.PANTS_TARGET_ADDRESSES_KEY, PantsUtil.dehydrateTargetAddresses(metadata.getTargetAddresses()));
         module.setOption(PantsConstants.PANTS_TARGET_ADDRESS_INFOS_KEY, gson.toJson(metadata.getTargetAddressInfoSet()));
+        ExternalSystemModulePropertyManager.getInstance(module).setExternalModuleType(PantsConstants.PANTS_TARGET_MODULE_TYPE);
       }
     }
   }

--- a/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
@@ -55,7 +55,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
   }
 
   @NotNull
-  public List<String> getTargetSpecs() {
+  public List<String> getSelectedTargetSpecs() {
     return myTargetSpecs;
   }
 

--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
@@ -4,15 +4,16 @@
 package com.twitter.intellij.pants.settings;
 
 import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
-import com.intellij.util.containers.ContainerUtilRt;
 import com.twitter.intellij.pants.model.PantsCompileOptions;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public class PantsProjectSettings extends ExternalProjectSettings implements PantsCompileOptions {
-  private List<String> myTargetSpecs = ContainerUtilRt.newArrayList();
+  private List<String> mySelectedTargetSpecs = new ArrayList<>();
+  private List<String> myAllAvailableTargetSpecs = new ArrayList<>();
   public boolean libsWithSources;
   public boolean enableIncrementalImport;
   public boolean useIdeaProjectJdk;
@@ -20,7 +21,8 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
   public boolean useIntellijCompiler;
 
   /**
-   * @param targetSpecs               targets explicted listed from `pants idea-plugin` goal.
+   * @param allAvailableTargetSpecs   targets explicted listed from `pants idea-plugin` goal.
+   * @param selectedTargetSpecs       targets selected by the user to import
    * @param externalProjectPath       path to the Pants project.
    * @param libsWithSources           whether to import sources and docs when resolving for jars.
    * @param isEnableIncrementalImport whether to enabled incremental import.
@@ -29,7 +31,8 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
    * @param isUseIntellijCompiler     whether to use the IntelliJ compiler to compile the project (as opposed to using pants).
    */
   public PantsProjectSettings(
-    List<String> targetSpecs,
+    List<String> allAvailableTargetSpecs,
+    List<String> selectedTargetSpecs,
     String externalProjectPath,
     boolean libsWithSources,
     boolean isEnableIncrementalImport,
@@ -38,7 +41,8 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
     boolean isUseIntellijCompiler
   ) {
     setExternalProjectPath(externalProjectPath);
-    myTargetSpecs = targetSpecs;
+    mySelectedTargetSpecs = selectedTargetSpecs;
+    myAllAvailableTargetSpecs = allAvailableTargetSpecs;
     this.libsWithSources = libsWithSources;
     enableIncrementalImport = isEnableIncrementalImport;
     useIdeaProjectJdk = isUseIdeaProjectJdk;
@@ -60,8 +64,9 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
     }
     PantsProjectSettings other = (PantsProjectSettings) obj;
     return Objects.equals(libsWithSources, other.libsWithSources)
+           && Objects.equals(myAllAvailableTargetSpecs, other.myAllAvailableTargetSpecs)
            && Objects.equals(enableIncrementalImport, other.enableIncrementalImport)
-           && Objects.equals(myTargetSpecs, other.myTargetSpecs)
+           && Objects.equals(mySelectedTargetSpecs, other.mySelectedTargetSpecs)
            && Objects.equals(useIdeaProjectJdk, other.useIdeaProjectJdk)
            && Objects.equals(importSourceDepsAsJars, other.importSourceDepsAsJars)
            && Objects.equals(useIntellijCompiler, other.useIntellijCompiler);
@@ -79,7 +84,8 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
   protected void copyTo(@NotNull ExternalProjectSettings receiver) {
     super.copyTo(receiver);
     if (receiver instanceof PantsProjectSettings) {
-      ((PantsProjectSettings) receiver).setTargetSpecs(getTargetSpecs());
+      ((PantsProjectSettings) receiver).setSelectedTargetSpecs(getSelectedTargetSpecs());
+      ((PantsProjectSettings) receiver).setAllAvailableTargetSpecs(getAllAvailableTargetSpecs());
       ((PantsProjectSettings) receiver).libsWithSources = libsWithSources;
       ((PantsProjectSettings) receiver).enableIncrementalImport = enableIncrementalImport;
       ((PantsProjectSettings) receiver).useIdeaProjectJdk = useIdeaProjectJdk;
@@ -89,16 +95,25 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
   }
 
 
+
+  public List<String> getAllAvailableTargetSpecs() {
+    return myAllAvailableTargetSpecs;
+  }
+
+  public void setAllAvailableTargetSpecs(List<String> allAvailableTargetSpecs) {
+    this.myAllAvailableTargetSpecs = allAvailableTargetSpecs;
+  }
+
   /**
    * Get the target specs used to launched `pants idea-plugin`.
    */
   @NotNull
-  public List<String> getTargetSpecs() {
-    return myTargetSpecs;
+  public List<String> getSelectedTargetSpecs() {
+    return mySelectedTargetSpecs;
   }
 
-  public void setTargetSpecs(List<String> targetSpecs) {
-    myTargetSpecs = targetSpecs;
+  public void setSelectedTargetSpecs(List<String> selectedTargetSpecs) {
+    mySelectedTargetSpecs = selectedTargetSpecs;
   }
 
   @Override

--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
@@ -36,6 +36,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class PantsProjectSettingsControl extends AbstractExternalProjectSettingsControl<PantsProjectSettings> {
 
@@ -78,7 +80,8 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
     myImportSourceDepsAsJarsCheckBox.setSelected(mySettings.importSourceDepsAsJars);
     myUseIntellijCompilerCheckBox.setSelected(mySettings.useIntellijCompiler);
 
-    mySettings.getTargetSpecs().forEach(spec -> myTargetSpecsBox.addItem(spec, spec, true));
+    myTargetSpecsBox.setItems( mySettings.getAllAvailableTargetSpecs(), x->x);
+    mySettings.getSelectedTargetSpecs().forEach(spec -> myTargetSpecsBox.setItemSelected(spec, true));
 
     List<JComponent> boxes = ContainerUtil.newArrayList(
       myLibsWithSourcesCheckBox,
@@ -114,6 +117,7 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
 
     PantsProjectSettings newSettings = new PantsProjectSettings(
       getSelectedTargetSpecsFromBoxes(),
+      getAllTargetSpecsFromBoxes(),
       // Project path is not visible to user, so it will stay the same.
       getInitialSettings().getExternalProjectPath(),
       myLibsWithSourcesCheckBox.isSelected(),
@@ -132,7 +136,6 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
     //     The values of all the settings are either their initial values,
     //     or whatever they were last set to, so you can't reuse them.
     lastPath = "";
-    myTargetSpecsBox.clear();
     errors.clear();
   }
 
@@ -214,12 +217,19 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
 
   @Override
   protected void applyExtraSettings(@NotNull PantsProjectSettings settings) {
-    settings.setTargetSpecs(getSelectedTargetSpecsFromBoxes());
+    settings.setSelectedTargetSpecs(getSelectedTargetSpecsFromBoxes());
+    settings.setAllAvailableTargetSpecs(getAllTargetSpecsFromBoxes());
     settings.libsWithSources = myLibsWithSourcesCheckBox.isSelected();
     settings.enableIncrementalImport = myEnableIncrementalImportCheckBox.isSelected();
     settings.useIdeaProjectJdk = myUseIdeaProjectJdkCheckBox.isSelected();
     settings.importSourceDepsAsJars = myImportSourceDepsAsJarsCheckBox.isSelected();
     settings.useIntellijCompiler = myUseIntellijCompilerCheckBox.isSelected();
+  }
+
+  @NotNull
+  private List<String> getAllTargetSpecsFromBoxes() {
+    return IntStream.range(0, myTargetSpecsBox.getItemsCount()).mapToObj(i -> myTargetSpecsBox.getItemAt(i)).collect(
+      Collectors.toList());
   }
 
   @Override

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -309,7 +309,7 @@ public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTe
   protected void doImport(@NotNull String projectFolderPathToImport, String... targetNames) {
     System.out.println("Import: " + projectFolderPathToImport);
     myRelativeProjectPath = projectFolderPathToImport;
-    myProjectSettings.setTargetSpecs(PantsUtil.convertToTargetSpecs(projectFolderPathToImport, Arrays.asList(targetNames)));
+    myProjectSettings.setSelectedTargetSpecs(PantsUtil.convertToTargetSpecs(projectFolderPathToImport, Arrays.asList(targetNames)));
     final String pantsExecutablePath = PantsUtil.findPantsExecutable(getProjectPath()).get().getPath();
     getDefaultJavaSdk(pantsExecutablePath).ifPresent(sdk -> {
       ApplicationManager.getApplication().invokeAndWait(() -> {

--- a/tests/com/twitter/intellij/pants/settings/PantsProjectSettingsTest.java
+++ b/tests/com/twitter/intellij/pants/settings/PantsProjectSettingsTest.java
@@ -5,6 +5,7 @@ package com.twitter.intellij.pants.settings;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.intellij.openapi.externalSystem.util.PaintAwarePanel;
 import com.intellij.ui.CheckBoxList;
 import com.intellij.util.containers.ContainerUtil;
 import com.twitter.intellij.pants.testFramework.OSSPantsImportIntegrationTest;
@@ -48,7 +49,7 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
   private void assertNoTargets() {
     assertEquals("no target specs should be specified",
                  Lists.newArrayList(),
-                 myFromPantsControl.getProjectSettings().getTargetSpecs());
+                 myFromPantsControl.getProjectSettings().getSelectedTargetSpecs());
     assertTrue("no target should be listed as a check box in the gui",
                getTargetSpecCheckBoxList().isEmpty());
   }
@@ -62,7 +63,7 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
 
     assertEquals(
       ContainerUtil.newArrayList("examples/src/java/org/pantsbuild/example/hello/::"),
-      myFromPantsControl.getProjectSettings().getTargetSpecs()
+      myFromPantsControl.getProjectSettings().getSelectedTargetSpecs()
     );
   }
 
@@ -78,7 +79,7 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
     assertEquals(
       "None of the target specs should be selected, but some are.",
       ContainerUtil.emptyList(),
-      myFromPantsControl.getProjectSettings().getTargetSpecs()
+      myFromPantsControl.getProjectSettings().getSelectedTargetSpecs()
     );
 
     CheckBoxList<String> checkBoxList = getTargetSpecCheckBoxList();
@@ -99,7 +100,28 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
       "examples/src/java/org/pantsbuild/example/hello/main:readme",
       "examples/src/java/org/pantsbuild/example/hello/main:main-bin"
                  ))
-      , Sets.newLinkedHashSet(myFromPantsControl.getProjectSettings().getTargetSpecs()));
+      , Sets.newLinkedHashSet(myFromPantsControl.getProjectSettings().getSelectedTargetSpecs()));
+  }
+
+  public void testSettingsEdition() {
+    myFromPantsControl.onLinkedProjectPathChange(
+      getProjectPath() + File.separator +
+      "examples/src/java/org/pantsbuild/example/hello/main/BUILD"
+    );
+
+    updateSettingsBasedOnGuiStates();
+    PantsProjectSettingsControl pantsSettingsControl = (PantsProjectSettingsControl)
+      myFromPantsControl.getProjectSettingsControl();
+
+    pantsSettingsControl.myTargetSpecsBox.setItemSelected(pantsSettingsControl.myTargetSpecsBox.getItemAt(1), true);
+    updateSettingsBasedOnGuiStates();
+    pantsSettingsControl.fillExtraControls((PaintAwarePanel) this.myFromPantsControl.getComponent(), 0);
+    pantsSettingsControl.resetExtraSettings(false);
+
+    assertEquals(pantsSettingsControl.myTargetSpecsBox.getItemsCount(), 3);
+    assertFalse(pantsSettingsControl.myTargetSpecsBox.isItemSelected(0));
+    assertTrue(pantsSettingsControl.myTargetSpecsBox.isItemSelected(1));
+    assertFalse(pantsSettingsControl.myTargetSpecsBox.isItemSelected(2));
   }
 
   public void testInvalidImportPath() {


### PR DESCRIPTION
Before this commit, the list of the targets were stored in
`PantsProjectSettings::myTargetSpecs` field. Unfortunately, this list was based on the
contents of `myTargetSpecsBox` widget, which was cleared each time
when the "Pants->Settings" window was opened. As a result, the list
of targets was cleared each time during settings save.

The fix to this is just not to clean the list of targets in the
window.

But this led to a new issue. When the list of targets is presented
to the user, it's also possible for him to deselect target. During
save, the `myTargetSpecs` variable was based on the list of selected
targets, so after deselection and save, it was not possible to select
it again.

In order to overcome this, I put two lists to `PantsProjectSettings`
instead of `myTargetSpecs`:

 1. `allAvailableTargetSpecs` - used to build `myTargetSpecsBox` widget
 2. `selectedTargetSpecs` - to inform `pants` which targets it should
operate on

fixes #457