### PR TITLE
Create additional inspection to allow to automatically add Python Facets to modules

### DIFF
--- a/common/com/twitter/intellij/pants/PantsBundle.properties
+++ b/common/com/twitter/intellij/pants/PantsBundle.properties
@@ -11,6 +11,7 @@ pants.library.no.pex.file=Couldn't find pex file for version ''{0}''
 pants.title.project.files=Project Files Tree
 
 pants.info.python.plugin.missing=Please install Python Support plugin for code assistance in BUILD files.
+pants.info.python.facet.missing=Automatically add Python interpreter for a module containing this BUILD file.
 pants.info.mistreated.build.file=This file looks like a Pants BUILD file. Do you want to treat it as such?
 
 pants.settings.text.project.name=Project name\:

--- a/common/com/twitter/intellij/pants/PantsBundle.properties
+++ b/common/com/twitter/intellij/pants/PantsBundle.properties
@@ -13,6 +13,7 @@ pants.title.project.files=Project Files Tree
 pants.info.python.plugin.missing=Please install Python Support plugin for code assistance in BUILD files.
 pants.info.mistreated.build.file=This file looks like a Pants BUILD file. Do you want to treat it as such?
 
+pants.settings.text.project.name=Project name\:
 pants.settings.text.targets=Choose targets\:
 pants.settings.text.with.sources.and.docs=Load sources and docs for libraries
 pants.settings.text.with.jdk.enforcement=Use IDEA Project JDK for Pants compilation
@@ -25,6 +26,8 @@ pants.project.generated.with.old.version=Project ''{0}'' was imported with a dif
 
 pants.command.terminated=\nPants command was terminated\!
 
+pants.error.project.name.empty=Project name is empty\!
+pants.error.project.name.tooLong="Project name is too long (over 200 characters)"\!
 pants.error.file.not.exists=Project file ''{0}'' doesn't exist\!
 pants.error.no.pants.executable.by.path=Can''t find a Pants executable for path ''{0}''\!
 pants.error.no.targets.are.selected=No targets are selected\!

--- a/common/com/twitter/intellij/pants/model/PantsSourceType.java
+++ b/common/com/twitter/intellij/pants/model/PantsSourceType.java
@@ -15,7 +15,8 @@ public enum PantsSourceType {
   SOURCE(ExternalSystemSourceType.SOURCE),
   TEST(ExternalSystemSourceType.TEST),
   RESOURCE(ExternalSystemSourceType.RESOURCE),
-  TEST_RESOURCE(ExternalSystemSourceType.TEST_RESOURCE);
+  TEST_RESOURCE(ExternalSystemSourceType.TEST_RESOURCE),
+  SOURCE_GENERATED(ExternalSystemSourceType.SOURCE_GENERATED);
 
   private ExternalSystemSourceType myExternalType;
 

--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -30,6 +30,10 @@ public class TargetAddressInfo {
 
   private boolean is_code_gen;
 
+  public boolean isCodeGen() {
+    return is_code_gen;
+  }
+
   public void setIsTargetRoot(boolean is_target_root) {
     this.is_target_root = is_target_root;
   }

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -539,8 +539,11 @@ public class PantsUtil {
   }
 
   @NotNull
-  public static PantsSourceType getSourceTypeForTargetType(@Nullable String targetType) {
+  public static PantsSourceType getSourceTypeForTargetType(@Nullable String targetType, Boolean isCodeGen) {
     try {
+      if(isCodeGen && targetType != null) {
+        return PantsSourceType.SOURCE_GENERATED;
+      }
       return targetType == null ? PantsSourceType.SOURCE :
              PantsSourceType.valueOf(StringUtil.toUpperCase(targetType));
     }

--- a/resources/META-INF/pants-python.xml
+++ b/resources/META-INF/pants-python.xml
@@ -14,6 +14,9 @@
     <projectResolver implementation="com.twitter.intellij.pants.service.python.PythonRequirementsResolver"/>
   </extensions>
   <extensions defaultExtensionNs="com.intellij">
+    <localInspection bundle="com.twitter.intellij.pants.PantsBundle" key="pants.info.python.facet.missing"
+                     groupName="Pants" enabledByDefault="true"
+                     implementationClass="com.twitter.intellij.pants.inspection.PythonFacetInspection"/>
     <localInspection bundle="com.twitter.intellij.pants.PantsBundle" key="pants.info.mistreated.build.file"
                      groupName="Pants" enabledByDefault="true"
                      implementationClass="com.twitter.intellij.pants.inspection.BuildFileTypeInspection"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -120,6 +120,9 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <macro implementation="com.twitter.intellij.pants.macro.FilePathRelativeToBuiltRootMacro"/>
+    <localInspection bundle="com.twitter.intellij.pants.PantsBundle" key="pants.info.python.facet.missing"
+                     groupName="Pants" enabledByDefault="true"
+                     implementationClass="com.twitter.intellij.pants.inspection.PythonFacetInspection"/>
     <localInspection bundle="com.twitter.intellij.pants.PantsBundle" key="pants.info.python.plugin.missing"
                      groupName="Pants" enabledByDefault="true"
                      implementationClass="com.twitter.intellij.pants.inspection.PythonPluginInspection"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -120,9 +120,6 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <macro implementation="com.twitter.intellij.pants.macro.FilePathRelativeToBuiltRootMacro"/>
-    <localInspection bundle="com.twitter.intellij.pants.PantsBundle" key="pants.info.python.facet.missing"
-                     groupName="Pants" enabledByDefault="true"
-                     implementationClass="com.twitter.intellij.pants.inspection.PythonFacetInspection"/>
     <localInspection bundle="com.twitter.intellij.pants.PantsBundle" key="pants.info.python.plugin.missing"
                      groupName="Pants" enabledByDefault="true"
                      implementationClass="com.twitter.intellij.pants.inspection.PythonPluginInspection"/>

--- a/resources/inspectionDescriptions/BuildFileType.html
+++ b/resources/inspectionDescriptions/BuildFileType.html
@@ -1,0 +1,11 @@
+<!-- Copyright 2019 Pants project contributors (see CONTRIBUTORS.md). -->
+<!-- Licensed under the Apache License, Version 2.0 (see LICENSE). -->
+
+<html>
+<body>
+<p>Detects if a file might be a PANTS build file.
+</p>
+<!-- tooltip end -->
+<p></p>
+</body>
+</html>

--- a/resources/inspectionDescriptions/PantsLibNotConfigured.html
+++ b/resources/inspectionDescriptions/PantsLibNotConfigured.html
@@ -1,8 +1,0 @@
-<!-- Copyright 2014 Pants project contributors (see CONTRIBUTORS.md). -->
-<!-- Licensed under the Apache License, Version 2.0 (see LICENSE). -->
-
-<html>
-<body>
-Checks if Pants library is configured for a module.
-</body>
-</html>

--- a/resources/inspectionDescriptions/PantsLibNotFound.html
+++ b/resources/inspectionDescriptions/PantsLibNotFound.html
@@ -1,8 +1,0 @@
-<!-- Copyright 2014 Pants project contributors (see CONTRIBUTORS.md). -->
-<!-- Licensed under the Apache License, Version 2.0 (see LICENSE). -->
-
-<html>
-<body>
-Checks if Pants library is configured for the project(.pex file with sources).
-</body>
-</html>

--- a/resources/inspectionDescriptions/PythonFacet.html
+++ b/resources/inspectionDescriptions/PythonFacet.html
@@ -1,0 +1,10 @@
+<!-- Copyright 2019 Pants project contributors (see CONTRIBUTORS.md). -->
+<!-- Licensed under the Apache License, Version 2.0 (see LICENSE). -->
+
+<html>
+<body>
+<p>Detects whether BUILD files have a specified Python interpreter and provides an option add it.
+</p>
+<p></p>
+</body>
+</html>

--- a/resources/inspectionDescriptions/PythonPlugin.html
+++ b/resources/inspectionDescriptions/PythonPlugin.html
@@ -1,0 +1,10 @@
+<!-- Copyright 2019 Pants project contributors (see CONTRIBUTORS.md). -->
+<!-- Licensed under the Apache License, Version 2.0 (see LICENSE). -->
+
+<html>
+<body>
+<p>Detects if the Python plugin is available, which is necessary for editing the Pants BUILD files
+</p>
+<p></p>
+</body>
+</html>

--- a/src/com/twitter/intellij/pants/PantsManager.java
+++ b/src/com/twitter/intellij/pants/PantsManager.java
@@ -129,6 +129,7 @@ public class PantsManager implements
         if (projectSettings instanceof PantsProjectSettings) {
           PantsProjectSettings pantsProjectSettings = (PantsProjectSettings) projectSettings;
           return new PantsExecutionSettings(
+            pantsProjectSettings.getProjectName(),
             pantsProjectSettings.getSelectedTargetSpecs(),
             pantsProjectSettings.libsWithSources,
             pantsProjectSettings.useIdeaProjectJdk,

--- a/src/com/twitter/intellij/pants/inspection/PythonFacetInspection.java
+++ b/src/com/twitter/intellij/pants/inspection/PythonFacetInspection.java
@@ -1,0 +1,56 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.inspection;
+
+import com.intellij.codeInspection.InspectionManager;
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.psi.PsiFile;
+import com.twitter.intellij.pants.PantsBundle;
+import com.twitter.intellij.pants.quickfix.AddPythonFacetQuickFix;
+import com.twitter.intellij.pants.util.PantsPythonSdkUtil;
+import com.twitter.intellij.pants.util.PantsUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PythonFacetInspection extends LocalInspectionTool {
+  @Override
+  @Nullable
+  public ProblemDescriptor[] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
+    if (shouldAddPythonSdk(file)) {
+      LocalQuickFix[] fixes = new LocalQuickFix[]{new AddPythonFacetQuickFix()};
+      ProblemDescriptor descriptor = manager.createProblemDescriptor(
+        file.getNavigationElement(),
+        PantsBundle.message("pants.info.python.facet.missing"),
+        isOnTheFly,
+        fixes,
+        ProblemHighlightType.GENERIC_ERROR_OR_WARNING
+      );
+
+      return new ProblemDescriptor[]{descriptor};
+    }
+    return null;
+  }
+
+  private boolean shouldAddPythonSdk(@NotNull PsiFile file) {
+    if (!PantsUtil.isPantsProject(file.getProject())) {
+      return false;
+    }
+
+    if (!PantsUtil.isBUILDFileName(file.getName())) {
+      return false;
+    }
+
+    final Module module = ModuleUtil.findModuleForPsiElement(file);
+    if (module == null) {
+      return false;
+    }
+
+    return PantsPythonSdkUtil.hasNoPythonSdk(module);
+  }
+}

--- a/src/com/twitter/intellij/pants/quickfix/AddPythonFacetQuickFix.java
+++ b/src/com/twitter/intellij/pants/quickfix/AddPythonFacetQuickFix.java
@@ -1,0 +1,147 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.quickfix;
+
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.facet.FacetManager;
+import com.intellij.facet.ModifiableFacetModel;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.psi.PsiFile;
+import com.jetbrains.python.facet.PythonFacet;
+import com.jetbrains.python.facet.PythonFacetConfiguration;
+import com.jetbrains.python.facet.PythonFacetType;
+import com.jetbrains.python.sdk.PythonSdkType;
+import com.jetbrains.python.sdk.add.PyAddSdkDialog;
+import com.twitter.intellij.pants.util.PantsConstants;
+import com.twitter.intellij.pants.util.PantsPythonSdkUtil;
+import icons.PantsIcons;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+public class AddPythonFacetQuickFix extends PantsQuickFix {
+
+  @NotNull
+  @Override
+  public String getName() {
+    return "Add Python facet";
+  }
+
+  @Override
+  public boolean startInWriteAction() {
+    return false;
+  }
+
+  @NotNull
+  @Override
+  public String getText() {
+    return "Add Python facet";
+  }
+
+  @Override
+  public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile file) {
+    return true;
+  }
+
+  @Override
+  public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
+    invoke(project, null, descriptor.getPsiElement().getContainingFile());
+  }
+
+  @Override
+  public void invoke(@NotNull final Project project, Editor editor, PsiFile psiFile) {
+    Sdk sdk = resolveSdk(project, psiFile);
+    if (sdk == null) {
+      displayError();
+    }
+    else {
+      setPythonSdkToAllApplicableModules(project, sdk);
+    }
+  }
+
+  @Nullable
+  private Sdk resolveSdk(Project project, PsiFile file) {
+    final AtomicReference<Sdk> pythonSdk = new AtomicReference<>();
+    final ProjectJdkTable jdkTable = ProjectJdkTable.getInstance();
+    List<Sdk> sdks = jdkTable.getSdksOfType(PythonSdkType.getInstance());
+
+    if (sdks.isEmpty()) {
+      final Module module = ModuleUtil.findModuleForPsiElement(file);
+      PyAddSdkDialog.show(project, module, sdks, pythonSdk::set);
+      if (pythonSdk.get() != null) {
+        ApplicationManager.getApplication().runWriteAction(() -> {
+          jdkTable.addJdk(pythonSdk.get());
+        });
+      }
+
+      return pythonSdk.get();
+    }
+    else {
+      return sdks.get(0);
+    }
+  }
+
+  private void setPythonSdkToAllApplicableModules(Project project, Sdk sdk) {
+    List<Module> modules = Arrays.stream(ModuleManager.getInstance(project).getModules())
+      .filter(PantsPythonSdkUtil::hasNoPythonSdk)
+      .collect(Collectors.toList());
+
+    for (Module module : modules) {
+      FacetManager facetManager = FacetManager.getInstance(module);
+      Optional<PythonFacet> facetWithoutSdk = facetManager
+        .getFacetsByType(PythonFacet.ID)
+        .stream().filter(facet -> facet.getConfiguration().getSdk() == null)
+        .findFirst();
+
+      ApplicationManager.getApplication().runWriteAction(() -> {
+        /* Remove existing facets if python interpreter is not selected
+         * this is a more resilient method than just adding sdk.
+         */
+        ModifiableFacetModel model = facetManager.createModifiableModel();
+        facetWithoutSdk.ifPresent(facet -> {
+          model.removeFacet(facet);
+          model.commit();
+        });
+
+        PythonFacetType type = PythonFacetType.getInstance();
+        PythonFacetConfiguration conf = type.createDefaultConfiguration();
+        conf.setSdk(sdk);
+
+        String facetName = module.getName() + "-default-python";
+        PythonFacet facet = type.createFacet(module, facetName, conf, null);
+
+        model.addFacet(facet);
+        model.commit();
+      });
+    }
+  }
+
+  private void displayError() {
+    Notification notification = new Notification(
+      PantsConstants.PANTS,
+      PantsIcons.Icon,
+      "Cannot find Python SDK",
+      null,
+      "Python SDK might need to be added manually",
+      NotificationType.ERROR,
+      null
+    );
+    Notifications.Bus.notify(notification);
+  }
+}

--- a/src/com/twitter/intellij/pants/quickfix/AddPythonPluginQuickFix.java
+++ b/src/com/twitter/intellij/pants/quickfix/AddPythonPluginQuickFix.java
@@ -45,11 +45,7 @@ public class AddPythonPluginQuickFix extends PantsQuickFix {
   @Override
   public void invoke(@NotNull final Project project, Editor editor, PsiFile psiFile) throws IncorrectOperationException {
     UIUtil.invokeLaterIfNeeded(
-      new Runnable() {
-        public void run() {
-          ShowSettingsUtil.getInstance().showSettingsDialog(project, "Plugins");
-        }
-      }
+      () -> ShowSettingsUtil.getInstance().showSettingsDialog(project, "Plugins")
     );
   }
 }

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -109,7 +109,7 @@ public class PantsCompileOptionsExecutor {
 
   @NotNull
   @Nls
-  public String getProjectName() {
+  public String getDefaultProjectName() {
     final String buildRootName = getBuildRoot().getName();
     List<String> buildRootPrefixedSpecs = myOptions.getSelectedTargetSpecs().stream()
       .map(s -> buildRootName + File.separator + s)

--- a/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
@@ -126,7 +126,7 @@ public class TargetInfo {
       new Condition<TargetAddressInfo>() {
         @Override
         public boolean value(TargetAddressInfo info) {
-          return PantsUtil.getSourceTypeForTargetType(info.getTargetType()).toExternalSystemSourceType().isTest();
+          return PantsUtil.getSourceTypeForTargetType(info.getTargetType(), info.isCodeGen()).toExternalSystemSourceType().isTest();
         }
       }
     );
@@ -138,8 +138,9 @@ public class TargetInfo {
     // the type of common module should be in the order of
     // source -> test source -> resource -> test resources. (like Ranked Value in Pants options)
     // e.g. if source and resources get combined, the common module should be source type.
+
     Set<PantsSourceType> allTypes = getAddressInfos().stream()
-      .map(s -> PantsUtil.getSourceTypeForTargetType(s.getTargetType()))
+      .map(s -> PantsUtil.getSourceTypeForTargetType(s.getTargetType(), s.isCodeGen()))
       .collect(Collectors.toSet());
 
     Optional<PantsSourceType> topRankedType = Arrays.stream(PantsSourceType.values())

--- a/src/com/twitter/intellij/pants/service/project/model/TargetInfoDeserializer.java
+++ b/src/com/twitter/intellij/pants/service/project/model/TargetInfoDeserializer.java
@@ -34,6 +34,7 @@ public class TargetInfoDeserializer implements JsonDeserializer<TargetInfo> {
       }
     );
     final TargetAddressInfo addressInfo = context.deserialize(element, TargetAddressInfo.class);
+    final boolean isCodeGen = object.getAsJsonPrimitive("is_code_gen").getAsBoolean();
     return new TargetInfo(
       new HashSet<>(Collections.singleton(addressInfo)),
       new HashSet<>(targets),

--- a/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
@@ -10,8 +10,10 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class PantsExecutionSettings extends ExternalSystemExecutionSettings implements PantsExecutionOptions {
+  private final String myName;
   private final boolean myLibsWithSourcesAndDocs;
   private final boolean myUseIdeaProjectJdk;
   private final boolean myEnableIncrementalImport;
@@ -19,6 +21,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
   private final boolean myImportSourceDepsAsJars;
   private final List<String> myTargetSpecs;
 
+  private static final String DEFAULT_PROJECT_NAME = null;
   private static final List<String> DEFAULT_TARGET_SPECS = Collections.emptyList();
   private static final boolean DEFAULT_WITH_SOURCES_AND_DOCS = true;
   private static final boolean DEFAULT_USE_IDEA_PROJECT_SDK = false;
@@ -28,6 +31,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
 
   public static PantsExecutionSettings createDefault() {
     return new PantsExecutionSettings(
+      DEFAULT_PROJECT_NAME,
       DEFAULT_TARGET_SPECS,
       DEFAULT_WITH_SOURCES_AND_DOCS,
       DEFAULT_USE_IDEA_PROJECT_SDK,
@@ -35,6 +39,24 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
       DEFAULT_ENABLE_INCREMENTAL_IMPORT,
       DEFAULT_USE_INTELLIJ_COMPILER
     );
+  }
+
+  public PantsExecutionSettings(
+    String name,
+    List<String> targetSpecs,
+    boolean libsWithSourcesAndDocs,
+    boolean useIdeaProjectJdk,
+    boolean importSourceDepsAsJars,
+    boolean enableIncrementalImport,
+    boolean useIntellijCompiler
+  ){
+    myName = name;
+    myTargetSpecs = targetSpecs;
+    myLibsWithSourcesAndDocs = libsWithSourcesAndDocs;
+    myUseIdeaProjectJdk = useIdeaProjectJdk;
+    myImportSourceDepsAsJars = importSourceDepsAsJars;
+    myEnableIncrementalImport = enableIncrementalImport;
+    myUseIntellijCompiler = useIntellijCompiler;
   }
 
   /**
@@ -51,12 +73,12 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     boolean enableIncrementalImport,
     boolean useIntellijCompiler
   ) {
-    myTargetSpecs = targetSpecs;
-    myLibsWithSourcesAndDocs = libsWithSourcesAndDocs;
-    myUseIdeaProjectJdk = useIdeaProjectJdk;
-    myImportSourceDepsAsJars = importSourceDepsAsJars;
-    myEnableIncrementalImport = enableIncrementalImport;
-    myUseIntellijCompiler = useIntellijCompiler;
+    this(DEFAULT_PROJECT_NAME, targetSpecs, libsWithSourcesAndDocs, useIdeaProjectJdk, importSourceDepsAsJars, enableIncrementalImport, useIntellijCompiler);
+  }
+
+  public Optional<String> getProjectName(){
+    return Optional.ofNullable(myName)
+      .filter(name -> !name.isEmpty());
   }
 
   @NotNull

--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
@@ -6,12 +6,14 @@ package com.twitter.intellij.pants.settings;
 import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
 import com.twitter.intellij.pants.model.PantsCompileOptions;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public class PantsProjectSettings extends ExternalProjectSettings implements PantsCompileOptions {
+  private String projectName;
   private List<String> mySelectedTargetSpecs = new ArrayList<>();
   private List<String> myAllAvailableTargetSpecs = new ArrayList<>();
   public boolean libsWithSources;
@@ -63,7 +65,8 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
       return false;
     }
     PantsProjectSettings other = (PantsProjectSettings) obj;
-    return Objects.equals(libsWithSources, other.libsWithSources)
+    return Objects.equals(projectName, other.projectName)
+           && Objects.equals(libsWithSources, other.libsWithSources)
            && Objects.equals(myAllAvailableTargetSpecs, other.myAllAvailableTargetSpecs)
            && Objects.equals(enableIncrementalImport, other.enableIncrementalImport)
            && Objects.equals(mySelectedTargetSpecs, other.mySelectedTargetSpecs)
@@ -84,6 +87,7 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
   protected void copyTo(@NotNull ExternalProjectSettings receiver) {
     super.copyTo(receiver);
     if (receiver instanceof PantsProjectSettings) {
+      ((PantsProjectSettings) receiver).setProjectName(getProjectName());
       ((PantsProjectSettings) receiver).setSelectedTargetSpecs(getSelectedTargetSpecs());
       ((PantsProjectSettings) receiver).setAllAvailableTargetSpecs(getAllAvailableTargetSpecs());
       ((PantsProjectSettings) receiver).libsWithSources = libsWithSources;
@@ -126,4 +130,12 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
     return this.importSourceDepsAsJars;
   }
 
+  void setProjectName(String projectName) {
+    this.projectName = projectName;
+  }
+
+  @Nullable
+  public String getProjectName() {
+    return projectName;
+  }
 }

--- a/src/com/twitter/intellij/pants/util/PantsPythonSdkUtil.java
+++ b/src/com/twitter/intellij/pants/util/PantsPythonSdkUtil.java
@@ -1,0 +1,16 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.util;
+
+import com.intellij.facet.FacetManager;
+import com.intellij.openapi.module.Module;
+import com.jetbrains.python.facet.PythonFacet;
+import org.jetbrains.annotations.NotNull;
+
+public final class PantsPythonSdkUtil {
+  public static boolean hasNoPythonSdk(@NotNull Module module) {
+    PythonFacet facet = FacetManager.getInstance(module).getFacetByType(PythonFacet.ID);
+    return facet == null || facet.getConfiguration().getSdk() == null;
+  }
+}

--- a/tests/com/twitter/intellij/pants/highlighting/AddPythonFacetQuickFixTest.java
+++ b/tests/com/twitter/intellij/pants/highlighting/AddPythonFacetQuickFixTest.java
@@ -1,0 +1,74 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.highlighting;
+
+import com.intellij.codeInspection.InspectionManager;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.QuickFix;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.jetbrains.python.sdk.PyDetectedSdk;
+import com.twitter.intellij.pants.inspection.PythonFacetInspection;
+import com.twitter.intellij.pants.quickfix.AddPythonFacetQuickFix;
+import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+import com.twitter.intellij.pants.util.PantsPythonSdkUtil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AddPythonFacetQuickFixTest extends OSSPantsIntegrationTest {
+
+  public void testMissingPythonInterpreter() {
+    String helloProjectPath = "examples/src/scala/org/pantsbuild/example/hello/";
+    doImport(helloProjectPath);
+
+    VirtualFile vfile = myProjectRoot.findFileByRelativePath(helloProjectPath + "BUILD");
+    assertNotNull(vfile);
+    PsiFile build = PsiManager.getInstance(myProject).findFile(vfile);
+    PythonFacetInspection inspection = new PythonFacetInspection();
+    InspectionManager manager = InspectionManager.getInstance(myProject);
+
+    boolean noSdkInModules = Arrays.stream(ModuleManager.getInstance(myProject).getModules())
+      .allMatch(PantsPythonSdkUtil::hasNoPythonSdk);
+    assertTrue(noSdkInModules);
+
+    // We should not have any interpreter selected for the BUILD file
+    ProblemDescriptor[] problems = inspection.checkFile(build, manager, false);
+    assertSize(1, problems);
+
+    QuickFix[] fixes = problems[0].getFixes();
+    assertSize(1, fixes);
+
+    AddPythonFacetQuickFix expected = new AddPythonFacetQuickFix();
+    assertEquals(fixes[0].getName(), expected.getName());
+
+    AddPythonFacetQuickFix actual = (AddPythonFacetQuickFix) fixes[0];
+    final ProjectJdkTable jdkTable = ProjectJdkTable.getInstance();
+
+    // Create Sdk in order not to invoke the interpreter choosing modal
+    Sdk sdk = new PyDetectedSdk("FakeSdk");
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      jdkTable.addJdk(sdk, myTestFixture.getTestRootDisposable());
+    });
+
+    // invoke the quickfix in order to automatically add the python facet to the module containing the BUILD file
+    actual.invoke(myProject, null, build);
+
+    ProblemDescriptor[] problemsAfterFix = inspection.checkFile(build, manager, false);
+    assertNull(problemsAfterFix);
+
+    List<Module> modulesWithoutSdk = Arrays.stream(ModuleManager.getInstance(myProject).getModules())
+      .filter(PantsPythonSdkUtil::hasNoPythonSdk)
+      .collect(Collectors.toList());
+
+    assertEmpty(modulesWithoutSdk);
+  }
+}

--- a/tests/com/twitter/intellij/pants/integration/PantsCompileOptionsExecutorTest.java
+++ b/tests/com/twitter/intellij/pants/integration/PantsCompileOptionsExecutorTest.java
@@ -30,7 +30,7 @@ public class PantsCompileOptionsExecutorTest extends OSSPantsIntegrationTest {
       settings
     );
 
-    String projectName = executor.getProjectName();
+    String projectName = executor.getDefaultProjectName();
     assertNotContainsSubstring(projectName, File.separator);
     assertEquals(PantsCompileOptionsExecutor.PROJECT_NAME_LIMIT, projectName.length());
   }

--- a/tests/com/twitter/intellij/pants/settings/PantsProjectSettingsTest.java
+++ b/tests/com/twitter/intellij/pants/settings/PantsProjectSettingsTest.java
@@ -61,6 +61,9 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
     CheckBoxList<String> checkBoxList = getTargetSpecCheckBoxList();
     assertFalse("Check box list should be disabled, but it is not.", checkBoxList.isEnabled());
 
+    String expectedProjectName = defaultProjectName("examples/src/java/org/pantsbuild/example/hello");
+    assertEquals(expectedProjectName, myFromPantsControl.getProjectSettings().getProjectName());
+
     assertEquals(
       ContainerUtil.newArrayList("examples/src/java/org/pantsbuild/example/hello/::"),
       myFromPantsControl.getProjectSettings().getSelectedTargetSpecs()
@@ -74,6 +77,9 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
     );
 
     updateSettingsBasedOnGuiStates();
+
+    String expectedProjectName = defaultProjectName("examples/src/java/org/pantsbuild/example/hello/main");
+    assertEquals(expectedProjectName, myFromPantsControl.getProjectSettings().getProjectName());
 
     // Checkbox is made, but it none of the targets should be selected.
     assertEquals(
@@ -157,5 +163,11 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
     updateSettingsBasedOnGuiStates();
     assertPantsProjectNotFound();
     assertNoTargets();
+  }
+
+  private String defaultProjectName(String relativePath) {
+    String buildRoot = getProjectFolder().getName();
+    String projectPath = buildRoot + File.separator + relativePath;
+    return projectPath.replace(File.separator, ".");
   }
 }

--- a/tests/com/twitter/intellij/pants/util/PantsPsiUtilTest.java
+++ b/tests/com/twitter/intellij/pants/util/PantsPsiUtilTest.java
@@ -34,31 +34,37 @@ public class PantsPsiUtilTest extends PantsCodeInsightFixtureTestCase {
     assertEquals(
       "Source type correctly set",
       PantsSourceType.SOURCE,
-      PantsUtil.getSourceTypeForTargetType("source")
+      PantsUtil.getSourceTypeForTargetType("source", false)
+    );
+
+    assertEquals(
+      "Generated source type correctly set",
+      PantsSourceType.SOURCE_GENERATED,
+      PantsUtil.getSourceTypeForTargetType("source", true)
     );
 
     assertEquals(
       "Resource type correctly set",
       PantsSourceType.RESOURCE,
-      PantsUtil.getSourceTypeForTargetType("resource")
+      PantsUtil.getSourceTypeForTargetType("resource", false)
     );
 
     assertEquals(
       "Test Source type correctly set",
       PantsSourceType.TEST,
-      PantsUtil.getSourceTypeForTargetType("TEST")
+      PantsUtil.getSourceTypeForTargetType("TEST", false)
     );
 
     assertEquals(
       "Test Resource type correctly set",
       PantsSourceType.TEST_RESOURCE,
-      PantsUtil.getSourceTypeForTargetType("TEST_RESOURCE")
+      PantsUtil.getSourceTypeForTargetType("TEST_RESOURCE", false)
     );
 
     assertEquals(
       "Source type correctly set for gibberish",
       PantsSourceType.SOURCE,
-      PantsUtil.getSourceTypeForTargetType("gibberish")
+      PantsUtil.getSourceTypeForTargetType("gibberish", false)
     );
   }
 


### PR DESCRIPTION
All BUILD files require a python interpreter and if a module doesn't contain one, there will be a warning shown unless the inspection is disabled. Now, we add an actionable quickfix that will automatically add a Python facet to a module in order to not replace a possible Java Jdk set already.

Overall quickfix algorithm:
1. If there is no python interpreter for the project, a window pops up where the user can choose the python interpreter to use. Otherwise skip.
2. If there is an already existing empty facet we remove it.
3. We add a new facet with either and existing interpreter or the one chosen in 1. step.

2. is needed since just adding an SDK is a flaky and I wasn't able to make it visible in the UI.

![facets](https://user-images.githubusercontent.com/3807253/71019078-01109c00-20fa-11ea-866f-eeb3e79a9064.gif)
