### PR TITLE
Don't retreive pants options in Event Dispatch Thread

### DIFF
--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettin
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.ModuleListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
@@ -25,6 +26,7 @@ import com.intellij.openapi.vcs.changes.ChangeListManagerImpl;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.twitter.intellij.pants.PantsBundle;
+import com.twitter.intellij.pants.PantsException;
 import com.twitter.intellij.pants.components.PantsProjectComponent;
 import com.twitter.intellij.pants.execution.PantsMakeBeforeRun;
 import com.twitter.intellij.pants.file.FileChangeTracker;
@@ -43,9 +45,12 @@ import icons.PantsIcons;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class PantsProjectComponentImpl extends AbstractProjectComponent implements PantsProjectComponent {
   protected PantsProjectComponentImpl(Project project) {
@@ -101,7 +106,12 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
           }
 
           subscribeToRunConfigurationAddition();
-          FileChangeTracker.registerProject(myProject);
+
+          ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            Optional<PantsOptions> pantsOptions = PantsOptions.getPantsOptions(myProject);
+            pantsOptions.ifPresent(po -> FileChangeTracker.registerProject(myProject, po));
+          });
+
           final AbstractExternalSystemSettings pantsSettings = ExternalSystemApiUtil.getSettings(myProject, PantsConstants.SYSTEM_ID);
           final boolean resolverVersionMismatch =
             pantsSettings instanceof PantsSettings && ((PantsSettings) pantsSettings).getResolverVersion() != PantsResolver.VERSION;

--- a/src/com/twitter/intellij/pants/file/FileChangeTracker.java
+++ b/src/com/twitter/intellij/pants/file/FileChangeTracker.java
@@ -104,10 +104,10 @@ public class FileChangeTracker {
     return instance;
   }
 
-  private static void markDirty(@NotNull VirtualFile file, @NotNull VirtualFileListener listener) {
+  private static void markDirty(@NotNull VirtualFile file,final PantsOptions pantsOptions, @NotNull VirtualFileListener listener) {
     Project project = listenToProjectMap.get(listener);
 
-    ChangeType changeType = detectChangeType(project, file);
+    ChangeType changeType = detectChangeType(project, pantsOptions, file);
     LOG.debug(String.format("Changed: %s. In project: %s", file.getPath(), changeType));
     if (changeType == ChangeType.UNRELATED) {
       return;
@@ -126,7 +126,7 @@ public class FileChangeTracker {
     OTHER;
   }
 
-  private static ChangeType detectChangeType(Project project, @NotNull VirtualFile file) {
+  private static ChangeType detectChangeType(Project project,final PantsOptions pantsOptions, @NotNull VirtualFile file) {
     ProjectRootManager rootManager = ProjectRootManager.getInstance(project);
 
     if (rootManager.getFileIndex().getContentRootForFile(file) != null) {
@@ -135,8 +135,7 @@ public class FileChangeTracker {
 
       Path filePath = Paths.get(file.getPath());
       boolean shouldBeIgnored =
-        PantsOptions.getPantsOptions(project)
-          .flatMap(options -> options.get(PantsConstants.PANTS_OPTION_PANTS_WORKDIR))
+          pantsOptions.get(PantsConstants.PANTS_OPTION_PANTS_WORKDIR)
           .map(workdir -> filePath.startsWith(Paths.get(workdir).toAbsolutePath()))
           .orElse(filePath.toUri().toString().contains("/.pants.d/"));
 
@@ -278,8 +277,8 @@ public class FileChangeTracker {
     projectStates.put(project, new ProjectState(isDirty, LocalTime.now(), Optional.of(snapshot)));
   }
 
-  public static void registerProject(@NotNull Project project) {
-    VirtualFileListener listener = getNewListener();
+  public static void registerProject(@NotNull Project project, final PantsOptions pantsOptions) {
+    VirtualFileListener listener = getNewListener(pantsOptions);
     LocalFileSystem.getInstance().addVirtualFileListener(listener);
     listenToProjectMap.put(listener, project);
   }
@@ -298,36 +297,41 @@ public class FileChangeTracker {
       });
   }
 
-  private static VirtualFileListener getNewListener() {
+  private static VirtualFileListener getNewListener(final PantsOptions pantsOptions) {
     return new VirtualFileListener() {
+
+      void markDirty(VirtualFile file) {
+        FileChangeTracker.markDirty(file, pantsOptions, this);
+      }
+
       @Override
       public void propertyChanged(@NotNull VirtualFilePropertyEvent event) {
-        FileChangeTracker.markDirty(event.getFile(), this);
+        markDirty(event.getFile());
       }
 
       @Override
       public void contentsChanged(@NotNull VirtualFileEvent event) {
-        FileChangeTracker.markDirty(event.getFile(), this);
+        markDirty(event.getFile());
       }
 
       @Override
       public void fileCreated(@NotNull VirtualFileEvent event) {
-        FileChangeTracker.markDirty(event.getFile(), this);
+        markDirty(event.getFile());
       }
 
       @Override
       public void fileDeleted(@NotNull VirtualFileEvent event) {
-        FileChangeTracker.markDirty(event.getFile(), this);
+        markDirty(event.getFile());
       }
 
       @Override
       public void fileMoved(@NotNull VirtualFileMoveEvent event) {
-        FileChangeTracker.markDirty(event.getFile(), this);
+        markDirty(event.getFile());
       }
 
       @Override
       public void fileCopied(@NotNull VirtualFileCopyEvent event) {
-        FileChangeTracker.markDirty(event.getFile(), this);
+        markDirty(event.getFile());
       }
 
       @Override

--- a/src/com/twitter/intellij/pants/service/project/metadata/PantsMetadataService.java
+++ b/src/com/twitter/intellij/pants/service/project/metadata/PantsMetadataService.java
@@ -3,6 +3,7 @@
 
 package com.twitter.intellij.pants.service.project.metadata;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.Key;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
@@ -11,7 +12,11 @@ import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataSer
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.twitter.intellij.pants.file.FileChangeTracker;
+import com.twitter.intellij.pants.model.PantsOptions;
 import com.twitter.intellij.pants.service.project.PantsResolver;
+import com.twitter.intellij.pants.settings.PantsProjectSettings;
 import com.twitter.intellij.pants.settings.PantsSettings;
 import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
@@ -19,8 +24,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import com.google.gson.Gson;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 
 public class PantsMetadataService implements ProjectDataService<TargetMetadata, Module> {
@@ -39,6 +47,15 @@ public class PantsMetadataService implements ProjectDataService<TargetMetadata, 
     @NotNull Project project,
     @NotNull IdeModifiableModelsProvider modelsProvider
   ) {
+    ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      if(projectData != null) {
+        PantsUtil.findPantsExecutable(projectData.getLinkedExternalProjectPath()).ifPresent(pantsExecutable -> {
+          PantsOptions pantsOptions = PantsOptions.getPantsOptions(pantsExecutable.getPath());
+          FileChangeTracker.registerProject(project, pantsOptions);
+        });
+      }
+    });
+
     // for existing projects. for new projects PantsSettings.defaultSettings will provide the version.
     PantsSettings.getInstance(project).setResolverVersion(PantsResolver.VERSION);
     for (DataNode<TargetMetadata> node : toImport) {

--- a/src/com/twitter/intellij/pants/service/project/metadata/PantsMetadataService.java
+++ b/src/com/twitter/intellij/pants/service/project/metadata/PantsMetadataService.java
@@ -47,15 +47,6 @@ public class PantsMetadataService implements ProjectDataService<TargetMetadata, 
     @NotNull Project project,
     @NotNull IdeModifiableModelsProvider modelsProvider
   ) {
-    ApplicationManager.getApplication().executeOnPooledThread(() -> {
-      if(projectData != null) {
-        PantsUtil.findPantsExecutable(projectData.getLinkedExternalProjectPath()).ifPresent(pantsExecutable -> {
-          PantsOptions pantsOptions = PantsOptions.getPantsOptions(pantsExecutable.getPath());
-          FileChangeTracker.registerProject(project, pantsOptions);
-        });
-      }
-    });
-
     // for existing projects. for new projects PantsSettings.defaultSettings will provide the version.
     PantsSettings.getInstance(project).setResolverVersion(PantsResolver.VERSION);
     for (DataNode<TargetMetadata> node : toImport) {


### PR DESCRIPTION
FileChangeTracker methods are always called in Event Dispatch Thread.
Pants Plugin implementation sometimes needs to retrieve pants options
in order to decide, whether to mark project as dirty. Unfortunatly,
Pants Options are retrieved via an external process call, what is
forbidded in Event Dispatch Thread.

In this commit, the bahvior of the listener is changed in that way,
the pants options are retrieved before the listener is initialized,
on a thread from thread pool, and they're passed to listener's
constructor.

Fixes #463