### PR TITLE
Fix idea plugin SDK setup

### DIFF
--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -241,8 +241,9 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
         return;
       }
 
-      Optional.ofNullable(MagicConstantInspection.getAttachAnnotationsJarFix(myProject)).ifPresent(Runnable::run);
       NewProjectUtil.applyJdkToProject(myProject, sdk.get());
+      Runnable fix = MagicConstantInspection.getAttachAnnotationsJarFix(myProject);
+      Optional.ofNullable(fix).ifPresent(Runnable::run);
     });
   }
 }


### PR DESCRIPTION
### Problem

Earlier attaching annotations to project sdk before project sdk is set could be lead the exceptions during `getAttachAnnotationsJarFix `, so when using `idea-plugin`, the project sdk would be invalid.