### PR TITLE
Save incremental import depth setting

### DIFF
--- a/common/com/twitter/intellij/pants/model/PantsExecutionOptions.java
+++ b/common/com/twitter/intellij/pants/model/PantsExecutionOptions.java
@@ -6,12 +6,13 @@ package com.twitter.intellij.pants.model;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PantsExecutionOptions {
 
   @NotNull
   List<String> getSelectedTargetSpecs();
 
-  boolean isEnableIncrementalImport();
+  Optional<Integer> incrementalImportDepth();
   boolean isImportSourceDepsAsJars();
 }

--- a/src/com/twitter/intellij/pants/PantsManager.java
+++ b/src/com/twitter/intellij/pants/PantsManager.java
@@ -134,7 +134,7 @@ public class PantsManager implements
             pantsProjectSettings.libsWithSources,
             pantsProjectSettings.useIdeaProjectJdk,
             pantsProjectSettings.importSourceDepsAsJars,
-            pantsProjectSettings.enableIncrementalImport,
+            pantsProjectSettings.incrementalImportEnabled ? Optional.of(pantsProjectSettings.incrementalImportDepth) : Optional.empty(),
             pantsProjectSettings.useIntellijCompiler
           );
         }

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -139,8 +139,8 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
           }
           // TODO: This is actually an integer value: if we replaced the incremental import
           // checkbox with an integer optional, we could propagate this value through.
-          final boolean enableIncrementalImport =
-            PropertiesComponent.getInstance(myProject).getValue("incremental_import") != null;
+          final Optional<Integer> enableIncrementalImport =
+            Optional.ofNullable(PropertiesComponent.getInstance(myProject).getValue("incremental_import")).map(Integer::parseInt);
 
           final boolean enableExportDepAsJar =
             Boolean.parseBoolean(Optional.ofNullable(PropertiesComponent.getInstance(myProject).getValue("dep_as_jar")).orElse("false"));
@@ -154,7 +154,7 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
           final boolean useIntellijCompiler = false;
           final PantsProjectSettings pantsProjectSettings =
             new PantsProjectSettings(
-              targetSpecs, targetSpecs, projectPath, loadLibsAndSources, enableIncrementalImport, useIdeaProjectJdk, enableExportDepAsJar, useIntellijCompiler);
+              targetSpecs, targetSpecs, projectPath, loadLibsAndSources, enableIncrementalImport.isPresent(), enableIncrementalImport.orElse(0), useIdeaProjectJdk, enableExportDepAsJar, useIntellijCompiler);
 
           /**
            * Following procedures in {@link com.intellij.openapi.externalSystem.util.ExternalSystemUtil#refreshProjects}:

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -44,6 +44,7 @@ public class PantsCompileOptionsExecutor {
   private final PantsCompileOptions myOptions;
   private final File myBuildRoot;
   private final boolean myResolveSourcesAndDocsForJars;
+  private final Optional<Integer> myIncrementalImportDepth;
 
   @NotNull
   public static PantsCompileOptionsExecutor create(
@@ -62,7 +63,8 @@ public class PantsCompileOptionsExecutor {
     return new PantsCompileOptionsExecutor(
       buildRoot.get(),
       options,
-      executionOptions.isLibsWithSourcesAndDocs()
+      executionOptions.isLibsWithSourcesAndDocs(),
+      executionOptions.incrementalImportDepth()
     );
   }
 
@@ -72,7 +74,8 @@ public class PantsCompileOptionsExecutor {
     return new PantsCompileOptionsExecutor(
       new File("/"),
       new MyPantsCompileOptions("", PantsExecutionSettings.createDefault()),
-      true
+      true,
+      Optional.of(1)
     ) {
     };
   }
@@ -80,15 +83,22 @@ public class PantsCompileOptionsExecutor {
   private PantsCompileOptionsExecutor(
     @NotNull File buildRoot,
     @NotNull PantsCompileOptions compilerOptions,
-    boolean resolveSourcesAndDocsForJars
+    boolean resolveSourcesAndDocsForJars,
+    @NotNull Optional<Integer> incrementalImportDepth
   ) {
     myBuildRoot = buildRoot;
     myOptions = compilerOptions;
     myResolveSourcesAndDocsForJars = resolveSourcesAndDocsForJars;
+    myIncrementalImportDepth = incrementalImportDepth;
   }
 
   public String getProjectRelativePath() {
     return PantsUtil.getRelativeProjectPath(getBuildRoot(), getProjectPath()).get();
+  }
+
+  @NotNull
+  public Optional<Integer> getIncrementalImportDepth() {
+    return myIncrementalImportDepth;
   }
 
   @NotNull
@@ -285,8 +295,8 @@ public class PantsCompileOptionsExecutor {
       return myExecutionOptions.getSelectedTargetSpecs();
     }
 
-    public boolean isEnableIncrementalImport() {
-      return myExecutionOptions.isEnableIncrementalImport();
+    public Optional<Integer> incrementalImportDepth() {
+      return myExecutionOptions.incrementalImportDepth();
     }
 
     @Override

--- a/src/com/twitter/intellij/pants/service/project/PantsResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsResolver.java
@@ -118,7 +118,7 @@ public class PantsResolver {
 
   private Optional<BuildGraph> constructBuildGraph(@NotNull DataNode<ProjectData> projectInfoDataNode) {
     Optional<BuildGraph> buildGraph;
-    if (myExecutor.getOptions().isEnableIncrementalImport()) {
+    if (myExecutor.getOptions().incrementalImportDepth().isPresent()) {
       Optional<VirtualFile> pantsExecutable = PantsUtil.findPantsExecutable(projectInfoDataNode.getData().getLinkedExternalProjectPath());
       SimpleExportResult result = SimpleExportResult.getExportResult(pantsExecutable.get().getPath());
       if (PantsUtil.versionCompare(result.getVersion(), "1.0.9") < 0) {

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -78,7 +78,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
                         {
                           Module[] modules = ModuleManager.getInstance(project).getModules();
                           for (Module module : modules) {
-                            if (Objects.equals(module.getOptionValue(PantsConstants.PANTS_OPTION_LINKED_PROJECT_PATH), projectPath)) {
+                            if (Objects.equals(module.getOptionValue(PantsConstants.PANTS_OPTION_LINKED_PROJECT_PATH), Paths.get(projectPath).normalize().toString())) {
                               ModuleManager.getInstance(project).disposeModule(module);
                             }
                           }

--- a/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
+++ b/src/com/twitter/intellij/pants/service/project/PantsSystemProjectResolver.java
@@ -103,6 +103,9 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
     checkForDifferentPantsExecutables(id, projectPath);
     final PantsCompileOptionsExecutor executor = PantsCompileOptionsExecutor.create(projectPath, settings);
     task2executor.put(id, executor);
+
+    Optional<Integer> incrementalImportDepth = settings.incrementalImportDepth();
+
     final DataNode<ProjectData> projectDataNode =
       resolveProjectInfoImpl(id, executor, listener, settings, isPreviewMode);
     // We do not want to repeatedly force switching to 'Project Files Tree' view if
@@ -201,7 +204,7 @@ public class PantsSystemProjectResolver implements ExternalSystemProjectResolver
       .ifPresent(sdk -> projectDataNode.createChild(PantsConstants.SDK_KEY, sdk));
 
     if (!isPreviewMode) {
-      PantsExternalMetricsListenerManager.getInstance().logIsIncrementalImport(settings.isEnableIncrementalImport());
+      PantsExternalMetricsListenerManager.getInstance().logIsIncrementalImport(settings.incrementalImportDepth().isPresent());
       resolveUsingPantsGoal(id, executor, listener, projectDataNode);
 
       if (!containsContentRoot(projectDataNode, executor.getProjectDir())) {

--- a/src/com/twitter/intellij/pants/service/project/metadata/PantsMetadataService.java
+++ b/src/com/twitter/intellij/pants/service/project/metadata/PantsMetadataService.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import com.google.gson.Gson;
 
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -49,7 +50,7 @@ public class PantsMetadataService implements ProjectDataService<TargetMetadata, 
         module.setOption(PantsConstants.PANTS_LIBRARY_EXCLUDES_KEY, PantsUtil.dehydrateTargetAddresses(metadata.getLibraryExcludes()));
         module.setOption(PantsConstants.PANTS_TARGET_ADDRESSES_KEY, PantsUtil.dehydrateTargetAddresses(metadata.getTargetAddresses()));
         module.setOption(PantsConstants.PANTS_TARGET_ADDRESS_INFOS_KEY, gson.toJson(metadata.getTargetAddressInfoSet()));
-        module.setOption(PantsConstants.PANTS_OPTION_LINKED_PROJECT_PATH, projectData.getLinkedExternalProjectPath());
+        module.setOption(PantsConstants.PANTS_OPTION_LINKED_PROJECT_PATH, Paths.get(projectData.getLinkedExternalProjectPath()).normalize().toString());
         ExternalSystemModulePropertyManager.getInstance(module).setExternalModuleType(PantsConstants.PANTS_TARGET_MODULE_TYPE);
       }
     }

--- a/src/com/twitter/intellij/pants/service/project/resolver/PantsCreateModulesExtension.java
+++ b/src/com/twitter/intellij/pants/service/project/resolver/PantsCreateModulesExtension.java
@@ -52,7 +52,7 @@ public class PantsCreateModulesExtension implements PantsResolverExtension {
     Set<TargetInfo> targetInfoWithinLevel = null;
     if (buildGraph.isPresent()) {
       final int maxDepth = buildGraph.get().getMaxDepth();
-      getDepthToImportFromUser(maxDepth);
+      depthToInclude = executor.getIncrementalImportDepth().orElse(null);
       if (depthToInclude == null) {
         throw new PantsException("Task cancelled");
       }
@@ -88,30 +88,6 @@ public class PantsCreateModulesExtension implements PantsResolverExtension {
         );
       modules.put(targetName, moduleData);
     }
-  }
-
-  private void getDepthToImportFromUser(final int maxDepth) {
-    ApplicationManager.getApplication().invokeAndWait(new Runnable() {
-      @Override
-      public void run() {
-        String result = Messages.showInputDialog(
-          String.format(
-            "Enter the depth of transitive dependencies to import min: 0, max: %s.\n" +
-            "0: root level.\n" +
-            "1: up to direct dependency.\n" +
-            "%s: entire build graph", maxDepth, maxDepth
-          ),
-          "Incremental Import",
-          PantsIcons.Icon, //icon
-          String.valueOf(maxDepth),  //initial number
-          null //validator per keystroke, not necessary in this case.
-        );
-        depthToInclude = result == null ? null : Integer.valueOf(result);
-        if (depthToInclude == null || depthToInclude < 0 || depthToInclude > maxDepth) {
-          throw new PantsException("Invalid input");
-        }
-      }
-    }, ModalityState.NON_MODAL);
   }
 
   @NotNull

--- a/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
@@ -4,6 +4,7 @@
 package com.twitter.intellij.pants.settings;
 
 import com.intellij.openapi.externalSystem.model.settings.ExternalSystemExecutionSettings;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import com.twitter.intellij.pants.model.PantsExecutionOptions;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,8 +17,9 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
   private final String myName;
   private final boolean myLibsWithSourcesAndDocs;
   private final boolean myUseIdeaProjectJdk;
-  private final boolean myEnableIncrementalImport;
   private final boolean myUseIntellijCompiler;
+  private final Optional<Integer> myIncrementalImportDepth;
+
   private final boolean myImportSourceDepsAsJars;
   private final List<String> myTargetSpecs;
 
@@ -25,7 +27,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
   private static final List<String> DEFAULT_TARGET_SPECS = Collections.emptyList();
   private static final boolean DEFAULT_WITH_SOURCES_AND_DOCS = true;
   private static final boolean DEFAULT_USE_IDEA_PROJECT_SDK = false;
-  private static final boolean DEFAULT_ENABLE_INCREMENTAL_IMPORT = false;
+  private static final Optional<Integer> DEFAULT_INCREMENTAL_IMPORT = Optional.empty();
   private static final boolean DEFAULT_IMPORT_SOURCE_DEPS_AS_JARS = false;
   private static final boolean DEFAULT_USE_INTELLIJ_COMPILER = false;
 
@@ -36,7 +38,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
       DEFAULT_WITH_SOURCES_AND_DOCS,
       DEFAULT_USE_IDEA_PROJECT_SDK,
       DEFAULT_IMPORT_SOURCE_DEPS_AS_JARS,
-      DEFAULT_ENABLE_INCREMENTAL_IMPORT,
+      DEFAULT_INCREMENTAL_IMPORT,
       DEFAULT_USE_INTELLIJ_COMPILER
     );
   }
@@ -47,7 +49,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     boolean libsWithSourcesAndDocs,
     boolean useIdeaProjectJdk,
     boolean importSourceDepsAsJars,
-    boolean enableIncrementalImport,
+    Optional<Integer> enableIncrementalImport,
     boolean useIntellijCompiler
   ){
     myName = name;
@@ -55,7 +57,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     myLibsWithSourcesAndDocs = libsWithSourcesAndDocs;
     myUseIdeaProjectJdk = useIdeaProjectJdk;
     myImportSourceDepsAsJars = importSourceDepsAsJars;
-    myEnableIncrementalImport = enableIncrementalImport;
+    myIncrementalImportDepth = enableIncrementalImport;
     myUseIntellijCompiler = useIntellijCompiler;
   }
 
@@ -70,7 +72,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     boolean libsWithSourcesAndDocs,
     boolean useIdeaProjectJdk,
     boolean importSourceDepsAsJars,
-    boolean enableIncrementalImport,
+    Optional<Integer> enableIncrementalImport,
     boolean useIntellijCompiler
   ) {
     this(DEFAULT_PROJECT_NAME, targetSpecs, libsWithSourcesAndDocs, useIdeaProjectJdk, importSourceDepsAsJars, enableIncrementalImport, useIntellijCompiler);
@@ -94,8 +96,8 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     return myUseIdeaProjectJdk;
   }
 
-  public boolean isEnableIncrementalImport() {
-    return myEnableIncrementalImport;
+  public Optional<Integer> incrementalImportDepth() {
+    return myIncrementalImportDepth;
   }
 
   @Override
@@ -111,7 +113,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
 
     PantsExecutionSettings settings = (PantsExecutionSettings) o;
     return Objects.equals(myUseIdeaProjectJdk, settings.myUseIdeaProjectJdk) &&
-           Objects.equals(myEnableIncrementalImport, settings.myEnableIncrementalImport) &&
+           Objects.equals(myIncrementalImportDepth, settings.myIncrementalImportDepth) &&
            Objects.equals(myUseIntellijCompiler, settings.myUseIntellijCompiler) &&
            Objects.equals(myLibsWithSourcesAndDocs, settings.myLibsWithSourcesAndDocs) &&
            Objects.equals(myTargetSpecs, settings.myTargetSpecs);
@@ -123,7 +125,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
       myTargetSpecs,
       myLibsWithSourcesAndDocs,
       myUseIdeaProjectJdk,
-      myEnableIncrementalImport,
+      myIncrementalImportDepth,
       myUseIntellijCompiler
     );
   }

--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
@@ -11,16 +11,28 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class PantsProjectSettings extends ExternalProjectSettings implements PantsCompileOptions {
   private String projectName;
   private List<String> mySelectedTargetSpecs = new ArrayList<>();
   private List<String> myAllAvailableTargetSpecs = new ArrayList<>();
   public boolean libsWithSources;
-  public boolean enableIncrementalImport;
+  public boolean incrementalImportEnabled;
+
+  public boolean isIncrementalImportEnabled() {
+    return incrementalImportEnabled;
+  }
+
+  public int getIncrementalImportDepth() {
+    return incrementalImportDepth;
+  }
+
+  public int incrementalImportDepth;
   public boolean useIdeaProjectJdk;
   public boolean importSourceDepsAsJars;
   public boolean useIntellijCompiler;
+
 
   /**
    * @param allAvailableTargetSpecs   targets explicted listed from `pants idea-plugin` goal.
@@ -38,6 +50,7 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
     String externalProjectPath,
     boolean libsWithSources,
     boolean isEnableIncrementalImport,
+    int incrementalImportDepth,
     boolean isUseIdeaProjectJdk,
     boolean isImportSourceDepsAsJars,
     boolean isUseIntellijCompiler
@@ -46,7 +59,8 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
     mySelectedTargetSpecs = selectedTargetSpecs;
     myAllAvailableTargetSpecs = allAvailableTargetSpecs;
     this.libsWithSources = libsWithSources;
-    enableIncrementalImport = isEnableIncrementalImport;
+    incrementalImportEnabled = isEnableIncrementalImport;
+    this.incrementalImportDepth = incrementalImportDepth;
     useIdeaProjectJdk = isUseIdeaProjectJdk;
     importSourceDepsAsJars = isImportSourceDepsAsJars;
     useIdeaProjectJdk = isUseIntellijCompiler;
@@ -68,8 +82,9 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
     return Objects.equals(projectName, other.projectName)
            && Objects.equals(libsWithSources, other.libsWithSources)
            && Objects.equals(myAllAvailableTargetSpecs, other.myAllAvailableTargetSpecs)
-           && Objects.equals(enableIncrementalImport, other.enableIncrementalImport)
            && Objects.equals(mySelectedTargetSpecs, other.mySelectedTargetSpecs)
+           && Objects.equals(incrementalImportEnabled, other.incrementalImportEnabled)
+           && Objects.equals(incrementalImportDepth, other.incrementalImportDepth)
            && Objects.equals(useIdeaProjectJdk, other.useIdeaProjectJdk)
            && Objects.equals(importSourceDepsAsJars, other.importSourceDepsAsJars)
            && Objects.equals(useIntellijCompiler, other.useIntellijCompiler);
@@ -91,7 +106,8 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
       ((PantsProjectSettings) receiver).setSelectedTargetSpecs(getSelectedTargetSpecs());
       ((PantsProjectSettings) receiver).setAllAvailableTargetSpecs(getAllAvailableTargetSpecs());
       ((PantsProjectSettings) receiver).libsWithSources = libsWithSources;
-      ((PantsProjectSettings) receiver).enableIncrementalImport = enableIncrementalImport;
+      ((PantsProjectSettings) receiver).incrementalImportDepth = incrementalImportDepth;
+      ((PantsProjectSettings) receiver).incrementalImportEnabled = incrementalImportEnabled;
       ((PantsProjectSettings) receiver).useIdeaProjectJdk = useIdeaProjectJdk;
       ((PantsProjectSettings) receiver).importSourceDepsAsJars = importSourceDepsAsJars;
       ((PantsProjectSettings) receiver).useIntellijCompiler = useIntellijCompiler;
@@ -121,8 +137,8 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
   }
 
   @Override
-  public boolean isEnableIncrementalImport() {
-    return this.enableIncrementalImport;
+  public Optional<Integer> incrementalImportDepth() {
+    return incrementalImportEnabled ? Optional.of(incrementalImportDepth) : Optional.empty();
   }
 
   @Override

--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettingsControl.java
@@ -36,6 +36,11 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JTextField;
 import java.io.File;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+
+import java.awt.FlowLayout;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -56,15 +61,31 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
 
   private final JTextField myNameField = new JTextField();
 
+  private JSpinner newImportDepthSpinner(){
+    JSpinner spinner = new JSpinner();
+    spinner.setModel(new SpinnerNumberModel(0, 0, Integer.MAX_VALUE, 1));
+    return spinner;
+  }
+
+  private JBCheckBox newEnableIcrementalImportCheckbox(){
+    JBCheckBox checkbox = new JBCheckBox(PantsBundle.message("pants.settings.text.with.incremental.import"));
+    checkbox.addActionListener(evt -> {
+      myImportDepthSpinner.setValue(((JBCheckBox) evt.getSource()).isSelected() ? mySettings.incrementalImportDepth : 0);
+      myImportDepthSpinner.setEnabled(((JBCheckBox) evt.getSource()).isSelected());
+    });
+    return checkbox;
+  }
+
   @VisibleForTesting
   protected CheckBoxList<String> myTargetSpecsBox = new CheckBoxList<>();
 
   private JBCheckBox myLibsWithSourcesCheckBox = new JBCheckBox(PantsBundle.message("pants.settings.text.with.sources.and.docs"));
-  private JBCheckBox myEnableIncrementalImportCheckBox = new JBCheckBox(PantsBundle.message("pants.settings.text.with.incremental.import"));
+  private JSpinner myImportDepthSpinner = newImportDepthSpinner();
+  private JBCheckBox myEnableIncrementalImportCheckBox = newEnableIcrementalImportCheckbox();
   private JBCheckBox myUseIdeaProjectJdkCheckBox = new JBCheckBox(PantsBundle.message("pants.settings.text.with.jdk.enforcement"));
   private JBCheckBox myImportSourceDepsAsJarsCheckBox = new JBCheckBox(PantsBundle.message("pants.settings.text.import.deps.as.jars"));
   private JBCheckBox myUseIntellijCompilerCheckBox = new JBCheckBox(PantsBundle.message("pants.settings.text.use.intellij.compiler"));
-
+  private JPanel myImportDepthPanel = importDepthPanel(myImportDepthSpinner);
   @VisibleForTesting
   protected Set<String> errors = new HashSet<>();
 
@@ -79,11 +100,22 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
     mySettings = settings;
   }
 
+  private static JPanel importDepthPanel(JSpinner importDepthSpinner) {
+    JPanel importDepthPanel = new JPanel();
+    importDepthPanel.setAlignmentX(JPanel.LEFT_ALIGNMENT);
+    importDepthPanel.setLayout(new FlowLayout(FlowLayout.LEFT));
+    importDepthPanel.add(new JLabel("Import depth: "));
+    importDepthPanel.add(importDepthSpinner);
+    return importDepthPanel;
+
+  }
+
   @Override
   protected void fillExtraControls(@NotNull PaintAwarePanel content, int indentLevel) {
 
     myLibsWithSourcesCheckBox.setSelected(mySettings.libsWithSources);
-    myEnableIncrementalImportCheckBox.setSelected(mySettings.enableIncrementalImport);
+    myEnableIncrementalImportCheckBox.setSelected(mySettings.incrementalImportEnabled);
+    myImportDepthSpinner.setValue(mySettings.incrementalImportDepth);
     myUseIdeaProjectJdkCheckBox.setSelected(mySettings.useIdeaProjectJdk);
     myImportSourceDepsAsJarsCheckBox.setSelected(mySettings.importSourceDepsAsJars);
     myUseIntellijCompilerCheckBox.setSelected(mySettings.useIntellijCompiler);
@@ -102,6 +134,7 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
     List<JComponent> boxes = ContainerUtil.newArrayList(
       myLibsWithSourcesCheckBox,
       myEnableIncrementalImportCheckBox,
+      myImportDepthPanel,
       myUseIdeaProjectJdkCheckBox,
       myImportSourceDepsAsJarsCheckBox,
       myUseIntellijCompilerCheckBox,
@@ -145,6 +178,7 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
       getInitialSettings().getExternalProjectPath(),
       myLibsWithSourcesCheckBox.isSelected(),
       myEnableIncrementalImportCheckBox.isSelected(),
+      (Integer)(myImportDepthSpinner.getValue()),
       myUseIdeaProjectJdkCheckBox.isSelected(),
       myImportSourceDepsAsJarsCheckBox.isSelected(),
       myUseIntellijCompilerCheckBox.isSelected()
@@ -170,7 +204,6 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
       return;
     }
     lastPath = projectPath;
-
     myTargetSpecsBox.clear();
     errors.clear();
     final VirtualFile file = VirtualFileManager.getInstance().findFileByUrl(VfsUtil.pathToUrl(projectPath));
@@ -284,7 +317,8 @@ public class PantsProjectSettingsControl extends AbstractExternalProjectSettings
     settings.setSelectedTargetSpecs(getSelectedTargetSpecsFromBoxes());
     settings.setAllAvailableTargetSpecs(getAllTargetSpecsFromBoxes());
     settings.libsWithSources = myLibsWithSourcesCheckBox.isSelected();
-    settings.enableIncrementalImport = myEnableIncrementalImportCheckBox.isSelected();
+    settings.incrementalImportEnabled = myEnableIncrementalImportCheckBox.isSelected();
+    settings.incrementalImportDepth = (Integer) (myImportDepthSpinner.getValue());
     settings.useIdeaProjectJdk = myUseIdeaProjectJdkCheckBox.isSelected();
     settings.importSourceDepsAsJars = myImportSourceDepsAsJarsCheckBox.isSelected();
     settings.useIntellijCompiler = myUseIntellijCompilerCheckBox.isSelected();

--- a/src/com/twitter/intellij/pants/settings/PantsSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsSettings.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 @State(
@@ -73,15 +74,19 @@ public class PantsSettings extends AbstractExternalSystemSettings<PantsSettings,
   }
 
   public boolean isEnableIncrementalImport() {
-    return getLinkedProjectsSettings().stream().anyMatch(PantsProjectSettings::isEnableIncrementalImport);
+    return getLinkedProjectsSettings().stream().anyMatch(x -> x.incrementalImportDepth().isPresent());
   }
+
 
   public boolean isUseIntellijCompiler() {
     return getLinkedProjectsSettings().stream().anyMatch(s -> s.useIntellijCompiler);
   }
-
-  public void setEnableIncrementalImport(boolean enableIncrementalImport) {
-    getLinkedProjectsSettings().forEach(s -> s.enableIncrementalImport = enableIncrementalImport);
+  public void setEnableIncrementalImport(Optional<Integer> incrementalImportDepth) {
+    getLinkedProjectsSettings().forEach(s ->
+                                        {
+                                          s.incrementalImportEnabled = incrementalImportDepth.isPresent();
+                                          s.incrementalImportDepth = incrementalImportDepth.orElse(0);
+                                        });
   }
 
   public int getResolverVersion() {

--- a/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/PantsIntegrationTestCase.java
@@ -98,6 +98,11 @@ import java.util.stream.Stream;
 public abstract class PantsIntegrationTestCase extends ExternalSystemImportingTestCase {
 
   private final boolean readOnly;
+
+  public void setProjectSettings(PantsProjectSettings projectSettings) {
+    myProjectSettings = projectSettings;
+  }
+
   private PantsProjectSettings myProjectSettings;
   private String myRelativeProjectPath = null;
   private CompilerTester myCompilerTester;

--- a/tests/com/twitter/intellij/pants/integration/NoopCompileTest.java
+++ b/tests/com/twitter/intellij/pants/integration/NoopCompileTest.java
@@ -14,16 +14,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.Optional;
 
 public class NoopCompileTest extends OSSPantsIntegrationTest {
-
-  private static class ScalaProjectData {
-    static final String path = "examples/tests/scala/org/pantsbuild/example/hello/welcome";
-    static final String HELLO_SRC_JAVA_MODULE = "examples_src_java_org_pantsbuild_example_hello_greet_greet";
-    static final String HELLO_SRC_SCALA_MODULE = "examples_src_scala_org_pantsbuild_example_hello_welcome_welcome";
-    static final String HELLO_TEST_MODULE = "examples_tests_scala_org_pantsbuild_example_hello_welcome_welcome";
-    static final String HELLO_RESOURCES_MODULE = "examples_src_resources_org_pantsbuild_example_hello_hello";
-  }
 
   @Override
   public void setUp() throws Exception {
@@ -31,12 +24,12 @@ public class NoopCompileTest extends OSSPantsIntegrationTest {
   }
 
   private void importScalaHello() {
-    doImport(ScalaProjectData.path);
+    doImport(ScalaWelcomeProjectData.path);
     assertFirstSourcePartyModules(
-      ScalaProjectData.HELLO_RESOURCES_MODULE,
-      ScalaProjectData.HELLO_SRC_JAVA_MODULE,
-      ScalaProjectData.HELLO_SRC_SCALA_MODULE,
-      ScalaProjectData.HELLO_TEST_MODULE
+      ScalaWelcomeProjectData.HELLO_RESOURCES_MODULE,
+      ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE,
+      ScalaWelcomeProjectData.HELLO_SRC_SCALA_MODULE,
+      ScalaWelcomeProjectData.HELLO_TEST_MODULE
     );
   }
 
@@ -140,13 +133,13 @@ public class NoopCompileTest extends OSSPantsIntegrationTest {
   public void testCompileDifferentModule() throws Throwable {
     importScalaHello();
 
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
-    assertPantsCompileNoop(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileNoop(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
     // Compile a different module, should not noop.
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_SCALA_MODULE));
-    assertPantsCompileNoop(pantsCompileModule(ScalaProjectData.HELLO_SRC_SCALA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_SCALA_MODULE));
+    assertPantsCompileNoop(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_SCALA_MODULE));
     // Switch back should compile again.
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
   }
 
   public void testCompileProjectSettings() throws Throwable {
@@ -154,11 +147,11 @@ public class NoopCompileTest extends OSSPantsIntegrationTest {
 
     PantsSettings settings = PantsSettings.getInstance(myProject);
     settings.setUseIdeaProjectJdk(false);
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
-    assertPantsCompileNoop(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileNoop(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
 
     settings.setUseIdeaProjectJdk(true);
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
   }
 
   public void testCompileIncrementalImports() throws Throwable {
@@ -166,27 +159,28 @@ public class NoopCompileTest extends OSSPantsIntegrationTest {
 
     // If a project uses incremental imports, then noop should never happen.
     PantsSettings settings = PantsSettings.getInstance(myProject);
-    settings.setEnableIncrementalImport(true);
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
+    settings.setEnableIncrementalImport(Optional.of(1));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
   }
+
 
   public void testShouldCompileAfterCleanAll() throws Throwable {
     importScalaHello();
 
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
-    assertPantsCompileNoop(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileNoop(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
     cmd("./pants", "clean-all");
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
   }
 
   public void testShouldCompileAfterOutOfBandPantsCLI() throws Throwable {
     importScalaHello();
 
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
-    assertPantsCompileNoop(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileNoop(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
     cmd("./pants", "export-classpath", "--manifest-jar-only", "examples/tests/java/org/pantsbuild/example/hello/greet");
     // Recompile because the sha of manifest.jar will change.
-    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaProjectData.HELLO_SRC_JAVA_MODULE));
+    assertPantsCompileExecutesAndSucceeds(pantsCompileModule(ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE));
   }
 }

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsImportTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsImportTest.java
@@ -1,0 +1,48 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.integration;
+
+import com.twitter.intellij.pants.settings.PantsProjectSettings;
+import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+
+public class OSSPantsImportTest extends OSSPantsIntegrationTest {
+  public void testIncrementalImportsDeep() {
+    PantsProjectSettings settings = new PantsProjectSettings();
+    settings.incrementalImportDepth = 100;
+    settings.incrementalImportEnabled = true;
+    setProjectSettings(settings);
+    doImport(ScalaWelcomeProjectData.path);
+    assertFirstSourcePartyModules(
+      ScalaWelcomeProjectData.HELLO_RESOURCES_MODULE,
+      ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE,
+      ScalaWelcomeProjectData.HELLO_SRC_SCALA_MODULE,
+      ScalaWelcomeProjectData.HELLO_TEST_MODULE
+    );
+  }
+
+  public void testNoIncrementalImportsDeep() {
+    PantsProjectSettings settings = new PantsProjectSettings();
+    settings.incrementalImportEnabled = false;
+    setProjectSettings(settings);
+    doImport(ScalaWelcomeProjectData.path);
+    assertFirstSourcePartyModules(
+      ScalaWelcomeProjectData.HELLO_RESOURCES_MODULE,
+      ScalaWelcomeProjectData.HELLO_SRC_JAVA_MODULE,
+      ScalaWelcomeProjectData.HELLO_SRC_SCALA_MODULE,
+      ScalaWelcomeProjectData.HELLO_TEST_MODULE
+    );
+  }
+
+  public void testIncrementalImportsShallow() {
+    PantsProjectSettings settings = new PantsProjectSettings();
+    settings.incrementalImportDepth = 1;
+    settings.incrementalImportEnabled = true;
+    setProjectSettings(settings);
+    doImport(ScalaWelcomeProjectData.path);
+    assertFirstSourcePartyModules(
+      ScalaWelcomeProjectData.HELLO_SRC_SCALA_MODULE,
+      ScalaWelcomeProjectData.HELLO_TEST_MODULE
+    );
+  }
+}

--- a/tests/com/twitter/intellij/pants/integration/OSSProjectInfoResolveTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSProjectInfoResolveTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 
 public class OSSProjectInfoResolveTest extends OSSPantsIntegrationTest {
   private static Consumer<String> STRING_CONSUMER = new Consumer<String>() {
@@ -36,14 +37,15 @@ public class OSSProjectInfoResolveTest extends OSSPantsIntegrationTest {
     final boolean libsWithSourcesAndDocs = true;
     final boolean useIdeaProjectJdk = false;
     final boolean isExportDepAsJar = false;
-    final boolean isEnableIncrementalImport = false;
+    final Optional<Integer> incrementalImportDepth = Optional.empty();
     final boolean isUseIntelliJCompiler = false;
+
     PantsExecutionSettings settings = new PantsExecutionSettings(
       Collections.singletonList(targetSpec),
       libsWithSourcesAndDocs,
       useIdeaProjectJdk,
       isExportDepAsJar,
-      isEnableIncrementalImport,
+      incrementalImportDepth,
       isUseIntelliJCompiler
     );
 

--- a/tests/com/twitter/intellij/pants/integration/PantsCompileOptionsExecutorTest.java
+++ b/tests/com/twitter/intellij/pants/integration/PantsCompileOptionsExecutorTest.java
@@ -9,6 +9,7 @@ import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.Optional;
 
 public class PantsCompileOptionsExecutorTest extends OSSPantsIntegrationTest {
 
@@ -21,7 +22,7 @@ public class PantsCompileOptionsExecutorTest extends OSSPantsIntegrationTest {
       false, // include libs and sources. does not matter here
       false, // use idea project jdk. does not matter here.
       false, // pants qexport dep as jar
-      false, // incremental imports. does not matter here.
+      Optional.empty(), // incremental imports. does not matter here.
       false // use intellij compiler
     );
 

--- a/tests/com/twitter/intellij/pants/integration/ScalaWelcomeProjectData.java
+++ b/tests/com/twitter/intellij/pants/integration/ScalaWelcomeProjectData.java
@@ -1,0 +1,12 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.integration;
+
+public class ScalaWelcomeProjectData {
+  static final String path = "examples/tests/scala/org/pantsbuild/example/hello/welcome";
+  static final String HELLO_SRC_JAVA_MODULE = "examples_src_java_org_pantsbuild_example_hello_greet_greet";
+  static final String HELLO_SRC_SCALA_MODULE = "examples_src_scala_org_pantsbuild_example_hello_welcome_welcome";
+  static final String HELLO_TEST_MODULE = "examples_tests_scala_org_pantsbuild_example_hello_welcome_welcome";
+  static final String HELLO_RESOURCES_MODULE = "examples_src_resources_org_pantsbuild_example_hello_hello";
+}


### PR DESCRIPTION
This commit was already merged to master, but reverted due to https://github.com/pantsbuild/intellij-pants-plugin/issues/471

ORIGINAL MESSAGE:

Before this commit, IntelliJ plugin was asking for incremental import
depth each time, even when doing refresh. The depth value was not
saved anywhere.

Now, the incremental import depth parameter is saved alongside other
settings, and may be configured in the same place as others.