### PR TITLE
Workaround for "Find Usages broken" bug in Scala Plugin

### DIFF
--- a/src/com/twitter/intellij/pants/service/scala/PantsScalaDataService.scala
+++ b/src/com/twitter/intellij/pants/service/scala/PantsScalaDataService.scala
@@ -52,16 +52,16 @@ class PantsScalaDataService extends ProjectDataService[ScalaModelData, Library] 
     // This happens when a project is imported, the module creation starts after opening then. 
     project.getMessageBus().connect().subscribe(ProjectTopics.MODULES, new ModuleListener {
       var done = false
+
       override def moduleAdded(project: Project,
-                               module: Module): Unit =  {
-        if(!done) {
+                               module: Module): Unit = {
+        if (!done) {
           if (PantsUtil.isPantsModule(module)) {
             ScalaCompilerReferenceService(project).projectOpened()
             done = true;
           }
         }
       }
-
     });
 
   }

--- a/src/com/twitter/intellij/pants/service/scala/PantsScalaDataService.scala
+++ b/src/com/twitter/intellij/pants/service/scala/PantsScalaDataService.scala
@@ -7,15 +7,20 @@ import java.io.File
 import java.util
 import java.util.Collections
 
+import com.intellij.ProjectTopics
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.externalSystem.model.project.ProjectData
 import com.intellij.openapi.externalSystem.model.{DataNode, ExternalSystemException, Key, ProjectKeys}
 import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider
 import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataService
-import com.intellij.openapi.project.Project
+import com.intellij.openapi.module.{Module, ModuleManager}
+import com.intellij.openapi.project.{ModuleListener, Project, ProjectManager}
 import com.intellij.openapi.roots.impl.libraries.LibraryEx.ModifiableModelEx
 import com.intellij.openapi.roots.libraries.Library
 import com.intellij.openapi.util.Computable
+import com.twitter.intellij.pants.util.PantsUtil
+import org.jetbrains.plugins.scala.findUsages.compilerReferences.ScalaCompilerReferenceService
 import org.jetbrains.plugins.scala.project.{LibraryExt, ScalaLanguageLevel, ScalaLibraryProperties, ScalaLibraryType, Version}
 
 import scala.collection.JavaConverters.{asScalaSetConverter, iterableAsScalaIterableConverter}
@@ -37,6 +42,28 @@ class PantsScalaDataService extends ProjectDataService[ScalaModelData, Library] 
     modelsProvider: IdeModifiableModelsProvider
   ): Unit = {
     toImport.asScala.toSet.foreach[Unit](doImport(_, modelsProvider))
+
+
+    // Workaround for bug in Scala Plugin https://youtrack.jetbrains.com/issue/SCL-16768
+    //
+    // Correct initialization of `ScalaCompilerReferenceService` is required for "Find usages"
+    // feature to work correcly. Unfortunately, it's broken in that way, it does nothing when
+    // there are no modules in the project right after the moment, when the project is opened.
+    // This happens when a project is imported, the module creation starts after opening then. 
+    project.getMessageBus().connect().subscribe(ProjectTopics.MODULES, new ModuleListener {
+      var done = false
+      override def moduleAdded(project: Project,
+                               module: Module): Unit =  {
+        if(!done) {
+          if (PantsUtil.isPantsModule(module)) {
+            ScalaCompilerReferenceService(project).projectOpened()
+            done = true;
+          }
+        }
+      }
+
+    });
+
   }
 
   private def doImport(scalaNode: DataNode[ScalaModelData], modelsProvider: IdeModifiableModelsProvider) {


### PR DESCRIPTION
Bug tracker: https://youtrack.jetbrains.com/issue/SCL-16768

Correct initialization of `ScalaCompilerReferenceService` is required for "Find usages"                                                                   feature to work correcly. Unfortunately, it's broken in that way, it does nothing when                                                                    there are no modules in the project right after the moment, when the project is opened.                                                                   This happens when a project is imported, the module creation starts after opening then.