### PR TITLE
Fix module directory structure in the presence of globs

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
@@ -41,6 +41,9 @@ public class TargetInfo {
    */
   protected Set<ContentRoot> roots = Collections.emptySet();
 
+  // TODO: This is a hack and should never be merged
+  public Set<ContentRoot> roots_copy = Collections.emptySet();
+
   public TargetInfo(TargetAddressInfo... addressInfos) {
     setAddressInfos(ContainerUtil.newHashSet(addressInfos));
   }
@@ -57,6 +60,7 @@ public class TargetInfo {
     setExcludes(excludes);
     setTargets(targets);
     setRoots(roots);
+    roots_copy = roots.stream().collect(Collectors.toSet());
   }
 
   public Set<TargetAddressInfo> getAddressInfos() {

--- a/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
+++ b/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
@@ -6,6 +6,7 @@ package com.twitter.intellij.pants.service.project.resolver;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.ProjectKeys;
 import com.intellij.openapi.externalSystem.model.project.ContentRootData;
+import com.intellij.openapi.externalSystem.model.project.ExternalSystemSourceType;
 import com.intellij.openapi.externalSystem.model.project.ModuleData;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
 import com.intellij.openapi.util.io.FileUtil;
@@ -13,6 +14,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.containers.ContainerUtilRt;
 import com.twitter.intellij.pants.model.PantsSourceType;
+import com.twitter.intellij.pants.model.TargetAddressInfo;
 import com.twitter.intellij.pants.service.PantsCompileOptionsExecutor;
 import com.twitter.intellij.pants.service.project.PantsResolverExtension;
 import com.twitter.intellij.pants.service.project.model.ContentRoot;
@@ -22,6 +24,8 @@ import com.twitter.intellij.pants.service.project.model.graph.BuildGraph;
 import com.twitter.intellij.pants.util.PantsConstants;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +96,26 @@ public class PantsSourceRootsExtension implements PantsResolverExtension {
           catch (IllegalArgumentException e) {
             LOG.warn(e);
             // todo(fkorotkov): log and investigate exceptions from ContentRootData.storePath(ContentRootData.java:94)
+          }
+        }
+      }
+
+      if (targetInfo.getAddressInfos().stream().anyMatch(TargetAddressInfo::isScala)) {
+        for (ContentRoot sourceRoot : targetInfo.roots_copy) {
+          File baseRootFile = new File(baseRoot);
+          List<File> subdirs = Arrays.asList(baseRootFile.listFiles());
+          for (File subdir : subdirs) {
+            ContentRootData.SourceRoot subdirPath = new ContentRootData.SourceRoot(subdir.getPath(), "");
+            if (subdir.isDirectory() &&
+                !contentRoot.getPaths(ExternalSystemSourceType.SOURCE).contains(subdirPath) &&
+                !contentRoot.getPaths(ExternalSystemSourceType.RESOURCE).contains(subdirPath) &&
+                !contentRoot.getPaths(ExternalSystemSourceType.TEST).contains(subdirPath) &&
+                !contentRoot.getPaths(ExternalSystemSourceType.TEST_RESOURCE).contains(subdirPath)) {
+              contentRoot.storePath(
+                ExternalSystemSourceType.EXCLUDED,
+                subdir.getPath()
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
NOTE: This PR still has a hack in it (described in point 1 of "Solution"). We should either fix it or formalize it before merging.

## Problem

By default IntelliJ will include subdirectories of a module as source files when compiling it. Pants allows targets to decide whether subdirectories should be included or not (via `globs` and `rglobs` in the `sources` field of a target). 

Some targets have broken subdirectories (they do not compile), which is allowed and compliant with the 1:1:1 recommendation of pants, provided that they don't use `rglobs` to declare their `sources`. For instance, consider the following folder structure:
```
\_ server/
   \_ BUILD (sources=glob("*.java"))
      ServerBuilder.java
      Server.java
   \_ config/
      \_ BUILD
         ServerConfig.java // This file is broken and doesn't compile.
```

In this case, IntelliJ will try to include the sources in `server/config` when compiling `server`, which leads to a false failure.

## Solution

There were two major changes to solve this:
1.- Manually exclude all the subfolders of a module that are not content roots.
     This is made possible because `export-dep-as-jar` expands the globs in the source fields and reports as content roots the complete set of subfolders covered by it. However, the `PantsSourceRootCompressor` messes with the `roots` field of `TargetInfo`, and therefore a hack was introduced (the first commit) to keep that information around.
2.- We stopped marking content roots as `SOURCE` and `TEST`. Marking them as such leads the IntelliJ compiler to fail with double-imports when compiling a project. It's not really necessary to mark anything but the base content roots (the directories where the BUILD file lives) as SOURCES, since IntelliJ modules will recursively include subfolders that are not excluded (this is what go us into this mess in the first place).