### PR TITLE
Allow setting project name

### DIFF
--- a/common/com/twitter/intellij/pants/PantsBundle.properties
+++ b/common/com/twitter/intellij/pants/PantsBundle.properties
@@ -13,6 +13,7 @@ pants.title.project.files=Project Files Tree
 pants.info.python.plugin.missing=Please install Python Support plugin for code assistance in BUILD files.
 pants.info.mistreated.build.file=This file looks like a Pants BUILD file. Do you want to treat it as such?
 
+pants.settings.text.project.name=Project name\:
 pants.settings.text.targets=Choose targets\:
 pants.settings.text.with.sources.and.docs=Load sources and docs for libraries
 pants.settings.text.with.jdk.enforcement=Use IDEA Project JDK for Pants compilation
@@ -25,6 +26,8 @@ pants.project.generated.with.old.version=Project ''{0}'' was imported with a dif
 
 pants.command.terminated=\nPants command was terminated\!
 
+pants.error.project.name.empty=Project name is empty\!
+pants.error.project.name.tooLong="Project name is too long (over 200 characters)"\!
 pants.error.file.not.exists=Project file ''{0}'' doesn't exist\!
 pants.error.no.pants.executable.by.path=Can''t find a Pants executable for path ''{0}''\!
 pants.error.no.targets.are.selected=No targets are selected\!

--- a/src/com/twitter/intellij/pants/PantsManager.java
+++ b/src/com/twitter/intellij/pants/PantsManager.java
@@ -129,6 +129,7 @@ public class PantsManager implements
         if (projectSettings instanceof PantsProjectSettings) {
           PantsProjectSettings pantsProjectSettings = (PantsProjectSettings) projectSettings;
           return new PantsExecutionSettings(
+            pantsProjectSettings.getProjectName(),
             pantsProjectSettings.getSelectedTargetSpecs(),
             pantsProjectSettings.libsWithSources,
             pantsProjectSettings.useIdeaProjectJdk,

--- a/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
+++ b/src/com/twitter/intellij/pants/service/PantsCompileOptionsExecutor.java
@@ -109,7 +109,7 @@ public class PantsCompileOptionsExecutor {
 
   @NotNull
   @Nls
-  public String getProjectName() {
+  public String getDefaultProjectName() {
     final String buildRootName = getBuildRoot().getName();
     List<String> buildRootPrefixedSpecs = myOptions.getSelectedTargetSpecs().stream()
       .map(s -> buildRootName + File.separator + s)

--- a/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsExecutionSettings.java
@@ -10,8 +10,10 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class PantsExecutionSettings extends ExternalSystemExecutionSettings implements PantsExecutionOptions {
+  private final String myName;
   private final boolean myLibsWithSourcesAndDocs;
   private final boolean myUseIdeaProjectJdk;
   private final boolean myEnableIncrementalImport;
@@ -19,6 +21,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
   private final boolean myImportSourceDepsAsJars;
   private final List<String> myTargetSpecs;
 
+  private static final String DEFAULT_PROJECT_NAME = null;
   private static final List<String> DEFAULT_TARGET_SPECS = Collections.emptyList();
   private static final boolean DEFAULT_WITH_SOURCES_AND_DOCS = true;
   private static final boolean DEFAULT_USE_IDEA_PROJECT_SDK = false;
@@ -28,6 +31,7 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
 
   public static PantsExecutionSettings createDefault() {
     return new PantsExecutionSettings(
+      DEFAULT_PROJECT_NAME,
       DEFAULT_TARGET_SPECS,
       DEFAULT_WITH_SOURCES_AND_DOCS,
       DEFAULT_USE_IDEA_PROJECT_SDK,
@@ -35,6 +39,24 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
       DEFAULT_ENABLE_INCREMENTAL_IMPORT,
       DEFAULT_USE_INTELLIJ_COMPILER
     );
+  }
+
+  public PantsExecutionSettings(
+    String name,
+    List<String> targetSpecs,
+    boolean libsWithSourcesAndDocs,
+    boolean useIdeaProjectJdk,
+    boolean importSourceDepsAsJars,
+    boolean enableIncrementalImport,
+    boolean useIntellijCompiler
+  ){
+    myName = name;
+    myTargetSpecs = targetSpecs;
+    myLibsWithSourcesAndDocs = libsWithSourcesAndDocs;
+    myUseIdeaProjectJdk = useIdeaProjectJdk;
+    myImportSourceDepsAsJars = importSourceDepsAsJars;
+    myEnableIncrementalImport = enableIncrementalImport;
+    myUseIntellijCompiler = useIntellijCompiler;
   }
 
   /**
@@ -51,12 +73,12 @@ public class PantsExecutionSettings extends ExternalSystemExecutionSettings impl
     boolean enableIncrementalImport,
     boolean useIntellijCompiler
   ) {
-    myTargetSpecs = targetSpecs;
-    myLibsWithSourcesAndDocs = libsWithSourcesAndDocs;
-    myUseIdeaProjectJdk = useIdeaProjectJdk;
-    myImportSourceDepsAsJars = importSourceDepsAsJars;
-    myEnableIncrementalImport = enableIncrementalImport;
-    myUseIntellijCompiler = useIntellijCompiler;
+    this(DEFAULT_PROJECT_NAME, targetSpecs, libsWithSourcesAndDocs, useIdeaProjectJdk, importSourceDepsAsJars, enableIncrementalImport, useIntellijCompiler);
+  }
+
+  public Optional<String> getProjectName(){
+    return Optional.ofNullable(myName)
+      .filter(name -> !name.isEmpty());
   }
 
   @NotNull

--- a/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
+++ b/src/com/twitter/intellij/pants/settings/PantsProjectSettings.java
@@ -6,12 +6,14 @@ package com.twitter.intellij.pants.settings;
 import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
 import com.twitter.intellij.pants.model.PantsCompileOptions;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public class PantsProjectSettings extends ExternalProjectSettings implements PantsCompileOptions {
+  private String projectName;
   private List<String> mySelectedTargetSpecs = new ArrayList<>();
   private List<String> myAllAvailableTargetSpecs = new ArrayList<>();
   public boolean libsWithSources;
@@ -63,7 +65,8 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
       return false;
     }
     PantsProjectSettings other = (PantsProjectSettings) obj;
-    return Objects.equals(libsWithSources, other.libsWithSources)
+    return Objects.equals(projectName, other.projectName)
+           && Objects.equals(libsWithSources, other.libsWithSources)
            && Objects.equals(myAllAvailableTargetSpecs, other.myAllAvailableTargetSpecs)
            && Objects.equals(enableIncrementalImport, other.enableIncrementalImport)
            && Objects.equals(mySelectedTargetSpecs, other.mySelectedTargetSpecs)
@@ -84,6 +87,7 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
   protected void copyTo(@NotNull ExternalProjectSettings receiver) {
     super.copyTo(receiver);
     if (receiver instanceof PantsProjectSettings) {
+      ((PantsProjectSettings) receiver).setProjectName(getProjectName());
       ((PantsProjectSettings) receiver).setSelectedTargetSpecs(getSelectedTargetSpecs());
       ((PantsProjectSettings) receiver).setAllAvailableTargetSpecs(getAllAvailableTargetSpecs());
       ((PantsProjectSettings) receiver).libsWithSources = libsWithSources;
@@ -126,4 +130,12 @@ public class PantsProjectSettings extends ExternalProjectSettings implements Pan
     return this.importSourceDepsAsJars;
   }
 
+  void setProjectName(String projectName) {
+    this.projectName = projectName;
+  }
+
+  @Nullable
+  public String getProjectName() {
+    return projectName;
+  }
 }

--- a/tests/com/twitter/intellij/pants/integration/PantsCompileOptionsExecutorTest.java
+++ b/tests/com/twitter/intellij/pants/integration/PantsCompileOptionsExecutorTest.java
@@ -30,7 +30,7 @@ public class PantsCompileOptionsExecutorTest extends OSSPantsIntegrationTest {
       settings
     );
 
-    String projectName = executor.getProjectName();
+    String projectName = executor.getDefaultProjectName();
     assertNotContainsSubstring(projectName, File.separator);
     assertEquals(PantsCompileOptionsExecutor.PROJECT_NAME_LIMIT, projectName.length());
   }

--- a/tests/com/twitter/intellij/pants/settings/PantsProjectSettingsTest.java
+++ b/tests/com/twitter/intellij/pants/settings/PantsProjectSettingsTest.java
@@ -61,6 +61,9 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
     CheckBoxList<String> checkBoxList = getTargetSpecCheckBoxList();
     assertFalse("Check box list should be disabled, but it is not.", checkBoxList.isEnabled());
 
+    String expectedProjectName = defaultProjectName("examples/src/java/org/pantsbuild/example/hello");
+    assertEquals(expectedProjectName, myFromPantsControl.getProjectSettings().getProjectName());
+
     assertEquals(
       ContainerUtil.newArrayList("examples/src/java/org/pantsbuild/example/hello/::"),
       myFromPantsControl.getProjectSettings().getSelectedTargetSpecs()
@@ -74,6 +77,9 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
     );
 
     updateSettingsBasedOnGuiStates();
+
+    String expectedProjectName = defaultProjectName("examples/src/java/org/pantsbuild/example/hello/main");
+    assertEquals(expectedProjectName, myFromPantsControl.getProjectSettings().getProjectName());
 
     // Checkbox is made, but it none of the targets should be selected.
     assertEquals(
@@ -157,5 +163,11 @@ public class PantsProjectSettingsTest extends OSSPantsImportIntegrationTest {
     updateSettingsBasedOnGuiStates();
     assertPantsProjectNotFound();
     assertNoTargets();
+  }
+
+  private String defaultProjectName(String relativePath) {
+    String buildRoot = getProjectFolder().getName();
+    String projectPath = buildRoot + File.separator + relativePath;
+    return projectPath.replace(File.separator, ".");
   }
 }


### PR DESCRIPTION
Previously, project name was derived from the targets used for importing it. Now, user can specify it when importing.

The import window looks as follows
![import-project-window-with-name](https://user-images.githubusercontent.com/3709537/73538035-3cf18d80-442a-11ea-8a28-2c538f643f8a.png)

And the resulting structure is:
![imported-modules](https://user-images.githubusercontent.com/3709537/73538181-96f25300-442a-11ea-88b5-d91252b23043.png)

The project view:
![project-list](https://user-images.githubusercontent.com/3709537/73538263-d91b9480-442a-11ea-9799-e41669e6c84b.png)

The name field is being automatically populated if and only if it was not changed by the user.
![autogenerated-name](https://user-images.githubusercontent.com/3709537/73542468-11c06b80-4435-11ea-90c3-6ff45f644b4c.png)

The strategy for generation of project name tries to mimic current approach (with a change of prepending the build root directory name). Since I don't have much experience with using the pants build tool, I could use some suggestions on how those automatically generated names could look like to actually useful.