### PR TITLE
Idea 201.5259.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,13 @@ addons:
       - python-dev
 
 before_install:
-  - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-  - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+  - PATH="/usr/lib/jvm/java-11-openjdk-amd64/jre/bin":$PATH
+  - JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 install: ./scripts/setup-ci-environment.sh
+
+jdk:
+  - openjdk11
 
 # General policy is to support pants for the past 10 releases and the latest master.
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
 script:
   # Test a single Java target without scala plugin
   - ENABLE_SCALA_PLUGIN=false ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest
-  - ./scripts/run-tests-ci.sh
+  - travis_wait 90 ./scripts/run-tests-ci.sh
 
 after_success:
   - scripts/deploy/deploy.sh

--- a/3rdparty/intellij/BUILD
+++ b/3rdparty/intellij/BUILD
@@ -1,7 +1,7 @@
 import os
 import re
 
-_jdk_jar_paths = os.environ['JDK_JARS'].split('\n')
+_jdk_jar_paths = os.environ['JDK_JARS'].split('\n') if 'JDK_JARS' in os.environ else []
 
 _is_ultimate = os.getenv('IJ_ULTIMATE', 'false') == 'true'
 

--- a/pants.ini
+++ b/pants.ini
@@ -42,6 +42,7 @@ options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 default_platform: java8
 platforms: {
     'java8': {'source': '8', 'target': '8', 'args': [] },
+    'java11': {'source': '11', 'target': '11', 'args': [] },
   }
 
 [test.junit]
@@ -62,7 +63,6 @@ strict_deps: True
 
 [jvm-distributions]
 minimum_version: 1.8.0
-maximum_version: 1.8.999
 
 [resolver]
 resolver: coursier

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
   <version>1.14.0</version>
   <vendor>Twitter, Inc.</vendor>
 
-  <idea-version since-build="193.0" until-build="193.*"/>
+  <idea-version since-build="193.0" until-build="201.*"/>
 
   <!--Add gradle as a dep because of Pants runner requires it.-->
   <depends>com.intellij.gradle</depends>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
   <version>1.14.0</version>
   <vendor>Twitter, Inc.</vendor>
 
-  <idea-version since-build="193.0" until-build="201.*"/>
+  <idea-version since-build="201.0" until-build="201.*"/>
 
   <!--Add gradle as a dep because of Pants runner requires it.-->
   <depends>com.intellij.gradle</depends>

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -12,8 +12,8 @@ fi
 export CWD=$(pwd)
 # Normally, IJ_VERSION is of the form YEAR.x[.y[.z]]
 # But for EAPs, set IJ_VERSION to the same as IJ_BUILD_NUMBER
-export IJ_VERSION="2019.3.3"
-export IJ_BUILD_NUMBER="193.6494.35"
+export IJ_VERSION="201.5259.13"
+export IJ_BUILD_NUMBER="201.5259.13"
 
 # This is for bootstrapping Pants, since this repo does not do Pants intensive operations,
 # we can optimize for build time.

--- a/scripts/prepare-ci-environment.sh
+++ b/scripts/prepare-ci-environment.sh
@@ -15,6 +15,9 @@ export CWD=$(pwd)
 export IJ_VERSION="201.5259.13"
 export IJ_BUILD_NUMBER="201.5259.13"
 
+# tests run from within pants repository must use java 8
+export PANTS_TEST_JUNIT_STRICT_JVM_VERSION=true
+
 # This is for bootstrapping Pants, since this repo does not do Pants intensive operations,
 # we can optimize for build time.
 # https://github.com/pantsbuild/pants/blob/16bd8fffb6db89779f5862604a0fe8745c8e50c4/build-support/bin/native/bootstrap_code.sh#L27
@@ -88,4 +91,8 @@ append_intellij_jvm_options() {
   echo $cmd
 }
 
-export JDK_JARS="$(printf "%s\n" 'sa-jdi.jar' 'tools.jar')"
+# on java 9+ these jars are not available
+if [ -f "$JAVA_HOME/lib/tools.jar" ]; then
+  JDK_JARS="$(printf "%s\n" 'sa-jdi.jar' 'tools.jar')"
+fi
+export JDK_JARS

--- a/scripts/setup-ci-environment.sh
+++ b/scripts/setup-ci-environment.sh
@@ -25,9 +25,9 @@ CACHE_JDK_LIB_DIR='.cache/jdk-libs'
 mkdir -p "$CACHE_JDK_LIB_DIR"
 
 for jar_file in $JDK_JARS; do
+  src_jar="$JDK_LIB_DIR/$jar_file"
   dest_jar="$CACHE_JDK_LIB_DIR/$jar_file"
-  if [ ! -f "$dest_jar" ]; then
-    src_jar="$JDK_LIB_DIR/$jar_file"
+  if [ -f "$src_jar" ] && [ ! -f "$dest_jar" ]; then
     cp "$src_jar" "$dest_jar"
   fi
 done

--- a/src/com/twitter/intellij/pants/projectview/PantsTreeStructureProvider.java
+++ b/src/com/twitter/intellij/pants/projectview/PantsTreeStructureProvider.java
@@ -32,9 +32,9 @@ import java.util.Optional;
 public class PantsTreeStructureProvider implements TreeStructureProvider {
   @NotNull
   @Override
-  public Collection<AbstractTreeNode> modify(
-    @NotNull final AbstractTreeNode node,
-    @NotNull Collection<AbstractTreeNode> collection,
+  public Collection<AbstractTreeNode<?>> modify(
+    @NotNull final AbstractTreeNode<?> node,
+    @NotNull Collection<AbstractTreeNode<?>> collection,
     ViewSettings settings
   ) {
     final Project project = node.getProject();
@@ -66,7 +66,7 @@ public class PantsTreeStructureProvider implements TreeStructureProvider {
                 data.setIcon(PantsIcons.Icon);
               }
             };
-            final List<AbstractTreeNode> modifiedCollection = new ArrayList<>(collection);
+            final List<AbstractTreeNode<?>> modifiedCollection = new ArrayList<>(collection);
             modifiedCollection.add(buildNode);
             return modifiedCollection;
           }
@@ -78,7 +78,7 @@ public class PantsTreeStructureProvider implements TreeStructureProvider {
 
   @Nullable
   @Override
-  public Object getData(Collection<AbstractTreeNode> collection, String s) {
+  public Object getData(Collection<AbstractTreeNode<?>> collection, String s) {
     return null;
   }
 }

--- a/src/com/twitter/intellij/pants/projectview/ProjectFilesViewProjectNode.java
+++ b/src/com/twitter/intellij/pants/projectview/ProjectFilesViewProjectNode.java
@@ -44,14 +44,14 @@ public class ProjectFilesViewProjectNode extends AbstractProjectNode {
 
   @NotNull
   @Override
-  public Collection<? extends AbstractTreeNode> getChildren() {
+  public Collection<? extends AbstractTreeNode<?>> getChildren() {
     final Optional<VirtualFile> buildRoot = PantsUtil.findBuildRoot(myProject);
     final VirtualFile projectDir = buildRoot.orElse(myProject.getBaseDir());
     if (projectDir == null) {
       LOG.warn(String.format("Couldn't find project directory for project '%s'", myProject.getName()));
       return Collections.emptyList();
     }
-    final AbstractTreeNode root = new VirtualFileTreeNode(myProject, projectDir, getSettings());
+    final AbstractTreeNode<?> root = new VirtualFileTreeNode(myProject, projectDir, getSettings());
     if (getSettings().isShowLibraryContents()) {
       return Arrays.asList(
         root,

--- a/src/com/twitter/intellij/pants/projectview/VirtualFileTreeNode.java
+++ b/src/com/twitter/intellij/pants/projectview/VirtualFileTreeNode.java
@@ -76,14 +76,14 @@ public class VirtualFileTreeNode extends ProjectViewNode<VirtualFile> {
 
   @NotNull
   @Override
-  public Collection<? extends AbstractTreeNode> getChildren() {
+  public Collection<? extends AbstractTreeNode<?>> getChildren() {
     final PsiManager psiManager = PsiManager.getInstance(myProject);
     final VirtualFile virtualFile = getValue();
     return ContainerUtil.mapNotNull(
       virtualFile.isValid() && virtualFile.isDirectory() ? virtualFile.getChildren() : VirtualFile.EMPTY_ARRAY,
-      new Function<VirtualFile, AbstractTreeNode>() {
+      new Function<VirtualFile, AbstractTreeNode<?>>() {
         @Override
-        public AbstractTreeNode fun(VirtualFile file) {
+        public AbstractTreeNode<?> fun(VirtualFile file) {
           final PsiElement psiElement = file.isDirectory() ? psiManager.findDirectory(file) : psiManager.findFile(file);
           if (psiElement instanceof PsiDirectory && ModuleUtil.findModuleForPsiElement(psiElement) != null) {
             // PsiDirectoryNode doesn't render files outside of a project

--- a/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTest.java
@@ -12,7 +12,6 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.roots.LanguageLevelProjectExtension;
 import com.intellij.openapi.roots.ProjectRootManager;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.pom.java.LanguageLevel;

--- a/testFramework/com/twitter/intellij/pants/testFramework/RunResult.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/RunResult.java
@@ -1,0 +1,34 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.testFramework;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class RunResult {
+  private final int exitCode;
+  private final List<String> output;
+  private final List<String> errorOutput;
+
+  RunResult(int exitCode, List<String> output, List<String> errorOutput) {
+    this.exitCode = exitCode;
+    this.output = output;
+    this.errorOutput = errorOutput;
+  }
+
+  public int getExitCode() {
+    return exitCode;
+  }
+
+  @Override
+  public String toString() {
+    return "exit code: " + exitCode +
+           "\nOUT:\n" + join(output) +
+           "\nERR:\n" + join(errorOutput);
+  }
+
+  private String join(List<String> list) {
+    return list.stream().map(text -> "\t" + text).collect(Collectors.joining(""));
+  }
+}

--- a/testFramework/com/twitter/intellij/pants/testFramework/performance/PantsPerformanceBenchmark.scala
+++ b/testFramework/com/twitter/intellij/pants/testFramework/performance/PantsPerformanceBenchmark.scala
@@ -81,7 +81,7 @@ class PantsPerformanceBenchmark(projectFolder: File, pluginsToDisable: Set[Strin
   override protected def getProjectFolder = projectFolder
 
   override protected def getRequiredPluginIds = {
-    val allPluginIds = PluginManagerCore.loadDescriptors().map(_.getPluginId.getIdString).toSet
+    val allPluginIds = PluginManagerCore.loadUncachedDescriptors.map(_.getPluginId.getIdString).toSet
     (allPluginIds -- pluginsToDisable).toArray
   }
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -17,6 +17,7 @@ target(name='sources-and-libs',
 
 junit_tests(
   name='misc',
+  platform='java11',
   dependencies=[
     ':sources-and-libs',
   ],
@@ -44,6 +45,7 @@ junit_tests(
 
 junit_tests(
   name='jvm-integration',
+  platform='java11',
   dependencies=[
     ':sources-and-libs',
   ],
@@ -54,6 +56,7 @@ junit_tests(
 
 junit_tests(
   name='py-integration',
+  platform='java11',
   dependencies=[
     ':sources-and-libs',
   ],
@@ -64,6 +67,7 @@ junit_tests(
 
 junit_tests(
   name='metrics',
+  platform='java11',
   dependencies=[
     ':sources-and-libs',
   ],

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
@@ -8,6 +8,7 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.CapturingAnsiEscapesAwareProcessHandler;
 import com.intellij.execution.process.CapturingProcessHandler;
 import com.intellij.execution.process.ProcessOutput;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.twitter.intellij.pants.execution.PantsExecuteTaskResult;
 import com.twitter.intellij.pants.settings.PantsSettings;
@@ -148,18 +149,20 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
 
     assertFirstSourcePartyModules(
       "examples_src_java_org_pantsbuild_example_hello_greet_greet"
-
     );
+
     PantsSettings settings = PantsSettings.getInstance(myProject);
     settings.setUseIdeaProjectJdk(true);
     PantsExecuteTaskResult result = pantsCompileProject();
     assertPantsCompileExecutesAndSucceeds(result);
     assertContainsSubstring(result.output.get(), PantsConstants.PANTS_CLI_OPTION_JVM_DISTRIBUTIONS_PATHS);
+    assertContainsSubstring(result.output.get(), PantsUtil.getJdkPathFromIntelliJCore());
 
     settings.setUseIdeaProjectJdk(false);
     PantsExecuteTaskResult resultB = pantsCompileProject();
     assertPantsCompileExecutesAndSucceeds(result);
-    assertNotContainsSubstring(resultB.output.get(), PantsConstants.PANTS_CLI_OPTION_JVM_DISTRIBUTIONS_PATHS);
+    assertContainsSubstring(resultB.output.get(), PantsConstants.PANTS_CLI_OPTION_JVM_DISTRIBUTIONS_PATHS);
+    assertContainsSubstring(resultB.output.get(), ProjectRootManager.getInstance(myProject).getProjectSdk().getHomePath());
   }
 
   private String[] getModulesNamesFromPantsDependencies(String targetName) throws ProjectBuildException {

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsTestExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsTestExamplesIntegrationTest.java
@@ -3,10 +3,10 @@
 
 package com.twitter.intellij.pants.integration;
 
-import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.util.ArrayUtil;
 import com.twitter.intellij.pants.execution.PantsExecuteTaskResult;
 import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+import com.twitter.intellij.pants.testFramework.RunResult;
 
 public class OSSPantsTestExamplesIntegrationTest extends OSSPantsIntegrationTest {
   @Override
@@ -25,12 +25,12 @@ public class OSSPantsTestExamplesIntegrationTest extends OSSPantsIntegrationTest
     assertTrue(result.output.get().contains("compile intellij-integration/tests/java/org/pantsbuild/testprojects:testprojects"));
     assertSuccessfulTest(
       "intellij-integration_tests_java_org_pantsbuild_testprojects_testprojects", "org.pantsbuild.testprojects.JUnitIntegrationTest");
-    final OSProcessHandler processHandler = runJUnitTest(
+    RunResult runResult = runJUnitTest(
       "intellij-integration_tests_java_org_pantsbuild_testprojects_testprojects",
       "org.pantsbuild.testprojects.JUnitIntegrationTest",
       "-DPANTS_FAIL_TEST=true"
     );
-    assertTrue("Tests should fail!", processHandler.getProcess().exitValue() != 0);
+    assertTrue("Tests should fail!", runResult.getExitCode() != 0);
   }
 
   public void testScopedJUnitTests() throws Throwable {


### PR DESCRIPTION
The major obstacle was that scala plugin for 2020 is being compiled with jdk 11, hence we can no longer run the pants-plugin test suite with the jdk 8.
Our solution is to:
A) set the 'java11' platform for test targets(misc, jvm-ibtegration and so on)
B) force pants-plugin to use JDK 8 when running pants within test cases but use JDK 11 to run the test cases.
