### PR TITLE
[IDEA 201.x] Remove macro registration hack

### DIFF
--- a/src/com/twitter/intellij/pants/macro/FilePathRelativeToBuiltRootMacro.java
+++ b/src/com/twitter/intellij/pants/macro/FilePathRelativeToBuiltRootMacro.java
@@ -3,7 +3,6 @@
 
 package com.twitter.intellij.pants.macro;
 
-import com.intellij.application.options.PathMacrosImpl;
 import com.intellij.ide.macro.Macro;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
@@ -16,14 +15,11 @@ import java.util.Optional;
 
 public class FilePathRelativeToBuiltRootMacro extends Macro {
   /**
-   * Have to use one of the names listed in {@link PathMacrosImpl#ourToolsMacros} as a workaround due to
-   * https://intellij-support.jetbrains.com/hc/en-us/community/posts/206103709-Custom-macro
-   *
    * @return corresponding name of this macro
    */
   @Override
   public String getName() {
-    return "FileRelativePath";
+    return "PantsFilePathRelativeToBuiltRoot";
   }
 
   @Override

--- a/tests/com/twitter/intellij/pants/macro/FilePathRelativeToBuiltRootMacroTest.java
+++ b/tests/com/twitter/intellij/pants/macro/FilePathRelativeToBuiltRootMacroTest.java
@@ -26,7 +26,7 @@ public class FilePathRelativeToBuiltRootMacroTest extends OSSPantsIntegrationTes
     String expected = String.format("%s/testprojects/tests/java/%s.java", githubRepo, testClass.getQualifiedName().replace('.', '/'));
 
     VirtualFile fileSelected = testClass.getContainingFile().getVirtualFile();
-    String actual = MacroManager.getInstance().expandMacrosInString(githubRepo + "/$FileRelativePath$", false, getFakeContext(fileSelected));
+    String actual = MacroManager.getInstance().expandMacrosInString(githubRepo + "/$PantsFilePathRelativeToBuildRoot$", false, getFakeContext(fileSelected));
 
     assertEquals(expected, actual);
   }


### PR DESCRIPTION
In old versions of IntelliJ platform it was only possible to register
macros of custom names. The only way to provide custom macro was to
override one of the existing macros. We've been overriding
`FileRelativePath` macro.

Unfortunately, since version 201.x of IntelliJ platform the hack does
not work, because the data structure to keep the macros has been
changed from a HashMap to a List. This means, the entries are not
overriden, but appended to the end of the list. MacroManager looks up
only for the first ocurrence of the name, so the one in the end of the
list will never be found if the name is not unique. The change was
done in this commit https://github.com/JetBrains/intellij-community/commit/61838067fdd286140a51df64c9fcdbebc1543786

Luckily, the hack is not needed since
https://github.com/JetBrains/intellij-community/commit/fdf6dbcb8ccace8d9cad4f7e6400df834e197687.
This means, we can use any custom name for the macro