### PR TITLE
Support for refreshing bsp projects on BUILD file change

### DIFF
--- a/common/com/twitter/intellij/pants/util/ExternalProjectUtil.java
+++ b/common/com/twitter/intellij/pants/util/ExternalProjectUtil.java
@@ -1,0 +1,50 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.util;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder;
+import com.intellij.openapi.externalSystem.model.ProjectSystemId;
+import com.intellij.openapi.externalSystem.service.execution.ProgressExecutionMode;
+import com.intellij.openapi.externalSystem.util.ExternalSystemConstants;
+import com.intellij.openapi.externalSystem.util.ExternalSystemUtil;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class ExternalProjectUtil {
+
+  public static void refresh(@NotNull Project project, ProjectSystemId id) {
+    // This code needs to run on the dispatch thread, but in some cases
+    // refreshAllProjects() is called on a non-dispatch thread; we use
+    // invokeLater() to run in the dispatch thread.
+    ApplicationManager.getApplication().invokeAndWait(
+      () -> {
+        ApplicationManager.getApplication().runWriteAction(() -> FileDocumentManager.getInstance().saveAllDocuments());
+
+        final ImportSpecBuilder specBuilder = new ImportSpecBuilder(project, id);
+        ProgressExecutionMode executionMode = ApplicationManager.getApplication().isUnitTestMode() ?
+                                              ProgressExecutionMode.MODAL_SYNC : ProgressExecutionMode.IN_BACKGROUND_ASYNC;
+        specBuilder.use(executionMode);
+        ExternalSystemUtil.refreshProjects(specBuilder);
+      });
+  }
+
+  public static boolean isExternalProject(@NotNull Project project, ProjectSystemId id) {
+    return ContainerUtil.exists(
+      ModuleManager.getInstance(project).getModules(),
+      module -> isExternalModule(module, id)
+    );
+  }
+
+  public static boolean isExternalModule(@NotNull Module module, ProjectSystemId id) {
+    final String systemId = module.getOptionValue(ExternalSystemConstants.EXTERNAL_SYSTEM_ID_KEY);
+    return StringUtil.equals(systemId, id.getId());
+  }
+
+}


### PR DESCRIPTION
There is already a file watcher that creates a popup notification with link to project refresh when BUILD file changes.
This PR updates the method that the hyperlink points to - `PantsUtil.refreshAllProjects`, so that in case of project imported from bsp rather than from pants, it would also refresh the project correctly.

Also the change in findBuildRoot was needed (look for pants root in module content roots if it was not found from .iml file) as otherwise the root module could not be found given layout generated by fastpass. Because of that the file watcher was never setup.