### PR TITLE
Remove unused line in TargetInfoDeserializer

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/model/TargetInfoDeserializer.java
+++ b/src/com/twitter/intellij/pants/service/project/model/TargetInfoDeserializer.java
@@ -34,7 +34,6 @@ public class TargetInfoDeserializer implements JsonDeserializer<TargetInfo> {
       }
     );
     final TargetAddressInfo addressInfo = context.deserialize(element, TargetAddressInfo.class);
-    final boolean isCodeGen = object.getAsJsonPrimitive("is_code_gen").getAsBoolean();
     return new TargetInfo(
       new HashSet<>(Collections.singleton(addressInfo)),
       new HashSet<>(targets),


### PR DESCRIPTION
It could even cause crash in some certain scenarios. is_code_gen value
is taken from JSON-deserializatoin to TargetAddressInfo.