### PR TITLE
Use isSynthetic over isCodegen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Let's check an output of `./pants export examples/src/java/org/pantsbuild/exampl
     "libraries": {},
     "targets": {
         "examples/src/java/org/pantsbuild/example/hello/greet:greet": {
-            "is_code_gen": false,
+            "is_synthetic": false,
             "target_type": "SOURCE",
             "libraries": [],
             "pants_target_type": "java_library",
@@ -27,7 +27,7 @@ Let's check an output of `./pants export examples/src/java/org/pantsbuild/exampl
             ]
         },
         "examples/src/java/org/pantsbuild/example/hello/main:main-bin": {
-            "is_code_gen": false,
+            "is_synthetic": false,
             "target_type": "SOURCE",
             "libraries": [],
             "pants_target_type": "jvm_binary",
@@ -43,7 +43,7 @@ Let's check an output of `./pants export examples/src/java/org/pantsbuild/exampl
             ]
         },
         "examples/src/resources/org/pantsbuild/example/hello:hello": {
-            "is_code_gen": false,
+            "is_synthetic": false,
             "target_type": "RESOURCE",
             "libraries": [],
             "pants_target_type": "resources",
@@ -61,7 +61,7 @@ Let's check an output of `./pants export examples/src/java/org/pantsbuild/exampl
 
 The plugin will create three modules. One for the imported target, examples/src/java/com/pants/examples/hello/main:main-bin
 and two for the targets it depends on. It also will configure source roots for the modules and will use `target_type`
-and `is_code_gen` fields to figure out types of source roots(there are several types of source roots: sources,
+and `is_synthetic` fields to figure out types of source roots(there are several types of source roots: sources,
 test sources, resources, test resources, generated sources, etc).
 
 ## Contributing Guidelines:

--- a/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
+++ b/common/com/twitter/intellij/pants/model/TargetAddressInfo.java
@@ -28,10 +28,10 @@ public class TargetAddressInfo {
    */
   private String pants_target_type = null;
 
-  private boolean is_code_gen;
+  private boolean is_synthetic;
 
-  public boolean isCodeGen() {
-    return is_code_gen;
+  public boolean isSynthetic() {
+    return is_synthetic;
   }
 
   public void setIsTargetRoot(boolean is_target_root) {

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -536,9 +536,9 @@ public class PantsUtil {
   }
 
   @NotNull
-  public static PantsSourceType getSourceTypeForTargetType(@Nullable String targetType, Boolean isCodeGen) {
+  public static PantsSourceType getSourceTypeForTargetType(@Nullable String targetType, Boolean isSynthetic) {
     try {
-      if(isCodeGen && targetType != null) {
+      if(isSynthetic && targetType != null) {
         return PantsSourceType.SOURCE_GENERATED;
       }
       return targetType == null ? PantsSourceType.SOURCE :

--- a/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
+++ b/src/com/twitter/intellij/pants/service/project/model/TargetInfo.java
@@ -126,7 +126,7 @@ public class TargetInfo {
       new Condition<TargetAddressInfo>() {
         @Override
         public boolean value(TargetAddressInfo info) {
-          return PantsUtil.getSourceTypeForTargetType(info.getTargetType(), info.isCodeGen()).toExternalSystemSourceType().isTest();
+          return PantsUtil.getSourceTypeForTargetType(info.getTargetType(), info.isSynthetic()).toExternalSystemSourceType().isTest();
         }
       }
     );
@@ -140,7 +140,7 @@ public class TargetInfo {
     // e.g. if source and resources get combined, the common module should be source type.
 
     Set<PantsSourceType> allTypes = getAddressInfos().stream()
-      .map(s -> PantsUtil.getSourceTypeForTargetType(s.getTargetType(), s.isCodeGen()))
+      .map(s -> PantsUtil.getSourceTypeForTargetType(s.getTargetType(), s.isSynthetic()))
       .collect(Collectors.toSet());
 
     Optional<PantsSourceType> topRankedType = Arrays.stream(PantsSourceType.values())


### PR DESCRIPTION
Context:
Pants export deprecated `is_code_gen` a while ago and need to use `is_synthetic` instead.