### PR TITLE
Shorten target names in bsp library origin names

### DIFF
--- a/resources/META-INF/pants-scala.xml
+++ b/resources/META-INF/pants-scala.xml
@@ -13,6 +13,7 @@
   <extensions defaultExtensionNs="com.intellij">
     <externalProjectDataService implementation="com.twitter.intellij.pants.service.scala.PantsScalaDataService" order="last"/>
     <highlightVisitor implementation="com.twitter.intellij.pants.highlight.PantsScalaHighlightVisitor"/>
+    <bspResolverNamingExtension implementation="com.twitter.intellij.pants.service.scala.PantsBspResolverNamingExtension"/>
   </extensions>
   <extensions defaultExtensionNs="com.intellij.plugins.pants">
     <projectResolver implementation="com.twitter.intellij.pants.service.scala.ScalaSdkResolver"/>

--- a/src/com/twitter/intellij/pants/service/scala/PantsBspResolverNamingExtension.scala
+++ b/src/com/twitter/intellij/pants/service/scala/PantsBspResolverNamingExtension.scala
@@ -1,0 +1,21 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.service.scala
+
+import org.jetbrains.bsp.project.resolver.BspResolverNamingExtension
+import org.jetbrains.bsp.project.resolver.BspResolverDescriptors.ModuleDescription
+
+class PantsBspResolverNamingExtension extends BspResolverNamingExtension {
+
+  def libraryData(moduleDescription: ModuleDescription): Option[String] = shortName("dependencies", moduleDescription)
+
+  def libraryTestData(moduleDescription: ModuleDescription): Option[String] = shortName("test dependencies", moduleDescription)
+
+  private def shortName(suffix: String, moduleDescription: ModuleDescription): Option[String] = {
+    val name = moduleDescription.data.name
+    val shortName = name.split(":").last
+    Some(s"$shortName $suffix")
+  }
+
+}


### PR DESCRIPTION
Depends on
https://github.com/JetBrains/intellij-scala/pull/529