### PR TITLE
Add automatic fastpass update notification

### DIFF
--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -620,7 +620,7 @@ public class PantsUtil {
     }
   }
 
-  private static boolean isBspProject(Project project) {
+  public static boolean isBspProject(Project project) {
     ProjectSystemId id = ProjectSystemId.findById("BSP");
     return id != null && ExternalProjectUtil.isExternalProject(project, id);
   }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -73,6 +73,10 @@
               class="com.twitter.intellij.pants.ui.PantsToBspProjectAction"
               text="Create new BSP project based on this Pants project">
       </action>
+      <action id="com.twitter.intellij.pants.components.impl.FastpassUpdater.Action"
+              class="com.twitter.intellij.pants.components.impl.FastpassUpdater$Action"
+              text="Update fastpass version">
+      </action>
     </group>
 
     <group id="Pants.Compile" text="Pants Compile" description="Pants compilation options" icon="PantsIcons.Icon"

--- a/src/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
+++ b/src/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
@@ -104,8 +104,8 @@ public class FastpassUpdater {
     }
   }
 
-  public static void initialize() {
-    if (!initialized) {
+  public static void initialize(Project project) {
+    if (PantsUtil.isBspProject(project) && !initialized) {
       synchronized (FastpassUpdater.class) {
         if (!initialized) {
           ScheduledExecutorService timer = Executors.newScheduledThreadPool(1);

--- a/src/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
+++ b/src/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
@@ -1,0 +1,208 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.components.impl;
+
+import com.google.gson.Gson;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.notification.EventLog;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationListener;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.twitter.intellij.pants.util.PantsConstants;
+import com.twitter.intellij.pants.util.PantsUtil;
+import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.event.HyperlinkEvent;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class FastpassUpdater {
+
+  private static final Logger LOG = Logger.getInstance(FastpassUpdater.class);
+
+  public static final String FASTPASS_PATH = "/opt/twitter_mde/bin/fastpass";
+  public static final String BLOOP_PATH = "/opt/twitter_mde/bin/bloop";
+
+  private static final String NOTIFICATION_TITLE = "Fastpass version changed";
+  public static final String NOTIFICATION_HREF = "fastpass-update";
+
+  private static boolean initialized = false;
+
+  private static class BloopSettings {
+    public List<String> refreshProjectsCommand;
+  }
+
+  private static class FastpassData {
+    public String version;
+    public String projectName;
+    public FastpassData(String version, String projectName) {
+      this.version = version;
+      this.projectName = projectName;
+    }
+  }
+
+  public static void initialize() {
+    if (!initialized) {
+      synchronized (FastpassUpdater.class) {
+        if (!initialized) {
+          ScheduledExecutorService timer = Executors.newScheduledThreadPool(1);
+          timer.scheduleWithFixedDelay(FastpassUpdater::checkForFastpassUpdates, 1, 60, TimeUnit.MINUTES);
+          initialized = true;
+        }
+      }
+    }
+  }
+
+  private static void checkForFastpassUpdates() {
+    VirtualFile fastpassBinary = LocalFileSystem.getInstance().findFileByPath(FASTPASS_PATH);
+    if (fastpassBinary != null && fastpassBinary.exists()) {
+      systemVersion(fastpassBinary.getPath())
+        .ifPresent(systemVersion -> allOpenBspProjects()
+          .forEach(project -> extractFastpassData(project)
+            .ifPresent(data -> {
+              if (!data.version.equals(systemVersion)) {
+                showUpdateNotification(project, systemVersion, data);
+              }
+            })));
+    }
+  }
+
+  private static void showUpdateNotification(Project project, String systemVersion, FastpassData data) {
+    if (!hasNotification(project)) {
+      Notification notification = new NotificationGroup(PantsConstants.PANTS, NotificationDisplayType.STICKY_BALLOON, true)
+        .createNotification(
+          NOTIFICATION_TITLE,
+          "<a href='" + NOTIFICATION_HREF + "'>Update</a> fastpass to version: " + systemVersion,
+          NotificationType.INFORMATION,
+          new NotificationListener.Adapter() {
+            @Override
+            protected void hyperlinkActivated(@NotNull Notification notification, @NotNull HyperlinkEvent e) {
+              if (NOTIFICATION_HREF.equals(e.getDescription())) {
+                updateFastpassVersion(project, data);
+              }
+              notification.expire();
+            }
+          }
+        );
+
+      notification.notify(project);
+    }
+  }
+
+  private static boolean hasNotification(Project project) {
+    ArrayList<Notification> notifications = EventLog.getLogModel(project).getNotifications();
+    return notifications.stream().anyMatch(s -> s.getTitle().equals(NOTIFICATION_TITLE));
+  }
+
+  private static void updateFastpassVersion(Project project, FastpassData data) {
+    ProgressManager.getInstance().run(new Task.Backgroundable(project, "Updating fastpass version") {
+      @Override
+      public void run(@NotNull ProgressIndicator indicator) {
+        indicator.setText("Exiting bloop");
+        exitBloop();
+        indicator.setText("Running fastpass refresh");
+        boolean ok = runFastpassRefresh(data, project);
+        if (ok) {
+          indicator.setText("Refreshing BSP project after fastpass update");
+          PantsUtil.refreshAllProjects(project);
+        }
+      }
+    });
+  }
+
+  private static void exitBloop() {
+    try {
+      new ProcessBuilder(BLOOP_PATH, "exit").start().waitFor();
+    } catch (Exception e) {
+      LOG.warn(e);
+    }
+  }
+
+  private static boolean runFastpassRefresh(FastpassData data, Project project) {
+    try {
+      GeneralCommandLine commandLine = PantsUtil.defaultCommandLine(project);
+      commandLine.setExePath(FASTPASS_PATH);
+      commandLine.addParameters(
+        "refresh",
+        "--intellij",
+        "--intellijLauncher", "echo", // to avoid opening project again
+        data.projectName
+      );
+      Process refresh = commandLine.createProcess();
+      refresh.waitFor();
+      return refresh.exitValue() == 0;
+    } catch (Exception e) {
+      LOG.warn(e);
+      return false;
+    }
+  }
+
+  private static Optional<FastpassData> extractFastpassData(Project project) {
+    try {
+      String path = project.getBasePath();
+      if (path != null) {
+        Path bloopSettingsPath = Paths.get(path, ".bloop", "bloop.settings.json");
+        VirtualFile bloopSettings =
+          LocalFileSystem.getInstance().findFileByIoFile(bloopSettingsPath.toFile());
+        if (bloopSettings != null && bloopSettings.exists()) {
+          String content = new String(bloopSettings.contentsToByteArray());
+          Gson gson = new Gson();
+          BloopSettings settings = gson.fromJson(content, BloopSettings.class);
+          Pattern pattern = Pattern.compile("org\\.scalameta:metals_2\\.12:(.*)");
+          Optional<String> version =
+            settings.refreshProjectsCommand.stream().map(pattern::matcher).filter(Matcher::find).map(m -> m.group(1)).findFirst();
+          return version.map(fastpassVersion -> {
+            String projectName = settings.refreshProjectsCommand.get(settings.refreshProjectsCommand.size() - 1);
+            return new FastpassData(fastpassVersion, projectName);
+          });
+        }
+      }
+    }
+    catch (Exception e) {
+      LOG.warn("Failed to extract fastpass data from " + project, e);
+    }
+    return Optional.empty();
+  }
+
+  @NotNull
+  private static Stream<Project> allOpenBspProjects() {
+    return Arrays.stream(ProjectManager.getInstance().getOpenProjects())
+      .filter(PantsUtil::isBspProject);
+  }
+
+  private static Optional<String> systemVersion(String fastpass) {
+    try {
+      Process process = new ProcessBuilder(fastpass, "version").start();
+      process.waitFor();
+      String version = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8).trim();
+      return Optional.of(version);
+    }
+    catch (Exception e) {
+      LOG.warn("Failed to check fastpass version", e);
+      return Optional.empty();
+    }
+  }
+}

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -95,7 +95,7 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
       new Runnable() {
         @Override
         public void run() {
-          FastpassUpdater.initialize();
+          FastpassUpdater.initialize(myProject);
           if (PantsUtil.isSeedPantsProject(myProject)) {
             convertToPantsProject();
             // projectOpened() is called on the dispatch thread, while

--- a/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsProjectComponentImpl.java
@@ -95,6 +95,7 @@ public class PantsProjectComponentImpl extends AbstractProjectComponent implemen
       new Runnable() {
         @Override
         public void run() {
+          FastpassUpdater.initialize();
           if (PantsUtil.isSeedPantsProject(myProject)) {
             convertToPantsProject();
             // projectOpened() is called on the dispatch thread, while


### PR DESCRIPTION
After loading first project there is a thread that starts watching the system fastpass version located at `/opt/twitter_mde/bin/fastpass`. If version is different (read from bloop.settings.json) it creates a notification with "Update" link. When clicked it kills bloop, runs `fastpass refresh` command (with the system version) and triggers project refresh.
