### PR TITLE
Improve "BSP Amend" testability

### DIFF
--- a/resources/META-INF/pants-scala.xml
+++ b/resources/META-INF/pants-scala.xml
@@ -4,7 +4,7 @@
 <idea-plugin version="2">
   <actions>
     <action id="com.twitter.intellij.pants.compiler.actions.BspAmendProjectAction"
-            class="com.twitter.intellij.pants.bsp.FastpassBspAmendAction"
+            class="com.twitter.intellij.pants.bsp.OpenBspAmendWindowAction"
             text="Amend BSP project">
       <add-to-group group-id="Pants.Menu"/>
     </action>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -72,6 +72,9 @@
       </action>
     </group>
 
+    <action class="com.twitter.intellij.pants.bsp.AmendAction"
+            id="com.twitter.intellij.pants.bsp.AmendAction"/>
+
     <group id="Pants.Compile" text="Pants Compile" description="Pants compilation options" icon="PantsIcons.Icon"
            popup="true" class="com.twitter.intellij.pants.compiler.actions.PantsCompileActionGroup">
       <add-to-group group-id="ProjectViewCompileGroup"/>

--- a/src/com/twitter/intellij/pants/bsp/AmendAction.java
+++ b/src/com/twitter/intellij/pants/bsp/AmendAction.java
@@ -1,0 +1,48 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.bsp;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataKey;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.Project;
+import com.twitter.intellij.pants.util.ExternalProjectUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.bsp.BSP;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class AmendAction extends AnAction {
+  Logger logger = Logger.getInstance(AmendAction.class);
+
+  public static final DataKey<AmendData> amendDataKey = DataKey.create("amendData");
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent event) {
+    try {
+      AmendData amendData = event.getData(amendDataKey);
+      refreshProjectsWithNewTargetsList(event.getProject(), amendData.getTargetSpecs(), amendData.getPantsBspData());
+    } catch (Throwable e) {
+      logger.error(e);
+    }
+  }
+
+  private void refreshProjectsWithNewTargetsList(
+    @NotNull Project project,
+    Collection<String> newTargets,
+    PantsBspData basePath
+  ) {
+    ProgressManager.getInstance().runProcessWithProgressSynchronously(() -> {
+      try {
+        FastpassUtils.amendAll(basePath, new ArrayList<>(newTargets), project).get();
+        ExternalProjectUtil.refresh(project, BSP.ProjectSystemId());
+      } catch (Throwable e){
+        logger.error(e);
+      }
+    }, "Amending", false, project);
+  }
+}

--- a/src/com/twitter/intellij/pants/bsp/AmendData.java
+++ b/src/com/twitter/intellij/pants/bsp/AmendData.java
@@ -1,0 +1,32 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.bsp;
+
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public class AmendData {
+  @NotNull
+  private final PantsBspData myPantsBspData;
+
+  @NotNull
+  private final Collection<String> myTargetSpecs;
+
+  public AmendData(@NotNull PantsBspData pantsBspData, @NotNull Collection<String> targetSpecs){
+    myPantsBspData = pantsBspData;
+    myTargetSpecs = targetSpecs;
+  }
+
+  @NotNull
+  public PantsBspData getPantsBspData() {
+    return myPantsBspData;
+  }
+
+  @NotNull
+  public Collection<String> getTargetSpecs() {
+    return myTargetSpecs;
+  }
+}

--- a/src/com/twitter/intellij/pants/bsp/ConvertToSourceDependencyEditorNotificationsProvider.java
+++ b/src/com/twitter/intellij/pants/bsp/ConvertToSourceDependencyEditorNotificationsProvider.java
@@ -39,7 +39,7 @@ class ConvertToSourceDependencyEditorNotificationsProvider extends EditorNotific
       EditorNotificationPanel panel = new EditorNotificationPanel();
       panel.createActionLabel(PantsBundle.message("pants.bsp.editor.convert.button"), () -> {
         try {
-          FastpassBspAmendAction.bspAmendWithDialog(project, Collections.singleton(targetName.get().toAddressString()));
+          OpenBspAmendWindowAction.bspAmendWithDialog(project, Collections.singleton(targetName.get().toAddressString()));
         } catch (Throwable e) {
           logger.error(e);
         }


### PR DESCRIPTION
Allow amending programatically, bypassing the "BSP Amend" window. Potentially useful when testing