### PR TITLE
Use new artifact for fastpass

### DIFF
--- a/src/com/twitter/intellij/pants/bsp/FastpassUtils.java
+++ b/src/com/twitter/intellij/pants/bsp/FastpassUtils.java
@@ -98,8 +98,8 @@ final public class FastpassUtils {
 
 
   private static List<String> coursierPart(){
-    return Arrays.asList("launch", "org.scalameta:metals_2.12:latest.stable",
-                         "--main", "scala.meta.internal.pantsbuild.BloopPants",
+    return Arrays.asList("launch", "org.scalameta:fastpass_2.12:latest.stable",
+                         "--main", "scala.meta.internal.fastpass.pantsbuild.BloopPants",
                          "--"
     );
   }

--- a/src/com/twitter/intellij/pants/bsp/FastpassUtils.java
+++ b/src/com/twitter/intellij/pants/bsp/FastpassUtils.java
@@ -99,7 +99,7 @@ final public class FastpassUtils {
 
   private static List<String> coursierPart(){
     return Arrays.asList("launch", "org.scalameta:fastpass_2.12:latest.stable",
-                         "--main", "scala.meta.internal.fastpass.pantsbuild.BloopPants",
+                         "--main", "scala.meta.fastpass.Fastpass",
                          "--"
     );
   }

--- a/src/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
+++ b/src/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
@@ -230,7 +230,7 @@ public class FastpassUpdater {
 
         Supplier<Optional<FastpassData>> fromBloopSettings =
           () -> readJsonFile(Paths.get(path, ".bloop", "bloop.settings.json"), BloopSettings.class).flatMap(settings -> {
-            Pattern pattern = Pattern.compile("org\\.scalameta:metals_2\\.12:(.*)");
+            Pattern pattern = Pattern.compile("org\\.scalameta:fastpass_2\\.12:(.*)");
             Optional<String> version =
               settings.refreshProjectsCommand.stream().map(pattern::matcher).filter(Matcher::find).map(m -> m.group(1)).findFirst();
             return version.map(fastpassVersion -> {


### PR DESCRIPTION
Fastpass used to be part of the Metals repository, but it was recently
moved to its own repository. It is no longer published as part of
metals.