### PR TITLE
Avoid null pointer exception on error

### DIFF
--- a/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
+++ b/src/com/twitter/intellij/pants/execution/PantsMakeBeforeRun.java
@@ -250,7 +250,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
       commandLine.addParameter(PantsUtil.getJvmDistributionPathParameter(javaHome));
     }
     catch (Exception e) {
-      showPantsMakeTaskMessage(e.getMessage(), ConsoleViewContentType.ERROR_OUTPUT, currentProject);
+      showPantsMakeTaskMessage(e.getMessage() != null ? e.getMessage() : e.toString(), ConsoleViewContentType.ERROR_OUTPUT, currentProject);
       return PantsExecuteTaskResult.emptyFailure();
     }
 
@@ -268,7 +268,7 @@ public class PantsMakeBeforeRun extends ExternalSystemBeforeRunTaskProvider {
       process = commandLine.createProcess();
     }
     catch (ExecutionException e) {
-      showPantsMakeTaskMessage(e.getMessage(), ConsoleViewContentType.ERROR_OUTPUT, currentProject);
+      showPantsMakeTaskMessage(e.getMessage() != null ? e.getMessage() : e.toString(), ConsoleViewContentType.ERROR_OUTPUT, currentProject);
       return PantsExecuteTaskResult.emptyFailure();
     }
 


### PR DESCRIPTION
I found this bug while trying to run junit tests, which triggered prebuild step which failed because of unset jdk. The actual error, was a fatal NPE from pants console api, message can never be null there, and for some exceptions the message is null. This is a quick fix to make sure we provide some error info so something is displayed, otherwise it is very hard to guess what actually went wrong.