### PR TITLE
Create synthetic root modules modules for target specs

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
+++ b/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.externalSystem.model.ProjectKeys;
 import com.intellij.openapi.externalSystem.model.project.ContentRootData;
 import com.intellij.openapi.externalSystem.model.project.ModuleData;
 import com.intellij.openapi.externalSystem.model.project.ProjectData;
+import com.intellij.openapi.module.ModuleTypeId;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.containers.ContainerUtil;
@@ -19,15 +20,24 @@ import com.twitter.intellij.pants.service.project.model.ProjectInfo;
 import com.twitter.intellij.pants.service.project.model.TargetInfo;
 import com.twitter.intellij.pants.service.project.model.graph.BuildGraph;
 import com.twitter.intellij.pants.util.PantsConstants;
+import org.apache.commons.compress.utils.Lists;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class PantsSourceRootsExtension implements PantsResolverExtension {
 
@@ -66,6 +76,72 @@ public class PantsSourceRootsExtension implements PantsResolverExtension {
       final DataNode<ModuleData> moduleDataNode = modules.get(targetAddress);
 
       createContentRoots(moduleDataNode, targetInfo);
+    }
+    installSyntheticModules(executor, projectDataNode, modules);
+  }
+
+  /**
+   * Takes a set of paths. Returns a new set without paths that are children of any other path in the set
+   * Ex. for [A, A/B, A/B/C, B, C/D] the result set is [A, B, C/D]
+   */
+  public static Set<String> removeChildren(Set<String> paths) {
+    if(paths.size() > 0 ) {
+      List<String> sorted = paths.stream().sorted().collect(Collectors.toList());
+      String current = sorted.get(0);
+      List<String> buf = new ArrayList<>();
+      buf.add(current);
+      for (String s : sorted.stream().skip(1).collect(Collectors.toList())) {
+        if (!s.startsWith(current)) {
+          current = s;
+          buf.add(s);
+        }
+      }
+      return new HashSet<>(buf);
+    }
+    return Collections.emptySet();
+  }
+
+  private void installSyntheticModules(
+    @NotNull PantsCompileOptionsExecutor executor,
+    @NotNull DataNode<ProjectData> projectDataNode,
+    @NotNull Map<String, DataNode<ModuleData>> modules
+  ) {
+    Path projectPath = Paths.get(executor.getBuildRoot().getAbsolutePath());
+    Set<String> targetSpecPaths =
+      executor.getOptions().getSelectedTargetSpecs().stream()
+        .map(x -> x.replaceFirst("/?:.*", ""))
+        .map(x -> Paths.get(x).isAbsolute() ? projectPath.relativize(Paths.get(x)).toString() : x)
+        .collect(Collectors.toSet());
+    Set<String> targetSpecPathsWithoutChildren = removeChildren(targetSpecPaths);
+    Set<String> allContentRoots =
+      modules.values().stream()
+        .flatMap(x -> x.getChildren()
+        .stream())
+        .map(x -> x.getData(ProjectKeys.CONTENT_ROOT))
+        .filter(Objects::nonNull)
+        .map(x -> x.getRootPath())
+        .collect(Collectors.toSet());
+
+    // todo - optimize from m*n to m * log(n)
+    targetSpecPathsWithoutChildren.removeIf(targetSpec -> allContentRoots.stream().anyMatch(contentRoot ->  projectPath.resolve(targetSpec).startsWith(contentRoot)));
+
+    for (String targetPath: targetSpecPathsWithoutChildren) {
+      String relativePath = targetPath;
+      String moduleName = relativePath.replaceAll("/", "_") + "-project-root";
+      final ModuleData moduleData = new ModuleData(
+        moduleName,
+        PantsConstants.SYSTEM_ID,
+        ModuleTypeId.JAVA_MODULE,
+        moduleName,
+        targetPath,
+        new File(executor.getBuildRoot(), relativePath).getAbsolutePath()
+      );
+      DataNode<ModuleData> moduleDataNode = projectDataNode.createChild(ProjectKeys.MODULE, moduleData);
+      modules.put(moduleName , moduleDataNode);
+
+      final ContentRootData contentRoot =
+        new ContentRootData(PantsConstants.SYSTEM_ID, targetPath);
+      moduleDataNode.createChild(ProjectKeys.CONTENT_ROOT, contentRoot);
     }
   }
 

--- a/tests/com/twitter/intellij/pants/execution/OSSPantsCompileCancellationTest.java
+++ b/tests/com/twitter/intellij/pants/execution/OSSPantsCompileCancellationTest.java
@@ -34,7 +34,8 @@ public class OSSPantsCompileCancellationTest extends OSSPantsIntegrationTest {
       "examples_src_java_org_pantsbuild_example_hello_main_main-bin",
       "examples_src_java_org_pantsbuild_example_hello_module",
       "examples_src_java_org_pantsbuild_example_hello_main_readme",
-      "examples_src_java_org_pantsbuild_example_hello_main_common_sources"
+      "examples_src_java_org_pantsbuild_example_hello_main_common_sources",
+      "examples_src_java_org_pantsbuild_example_hello-project-root"
     };
 
     assertFirstSourcePartyModules(

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsExamplesMultiTargetsIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsExamplesMultiTargetsIntegrationTest.java
@@ -19,7 +19,8 @@ public class OSSPantsExamplesMultiTargetsIntegrationTest extends OSSPantsIntegra
       "examples_src_java_org_pantsbuild_example_hello_main_main-bin",
       "examples_src_java_org_pantsbuild_example_hello_module",
       "examples_src_java_org_pantsbuild_example_hello_main_readme",
-      "examples_src_java_org_pantsbuild_example_hello_main_common_sources"
+      "examples_src_java_org_pantsbuild_example_hello_main_common_sources",
+      "examples_src_java_org_pantsbuild_example_hello-project-root"
     };
 
     assertFirstSourcePartyModules(initialModules);
@@ -33,7 +34,8 @@ public class OSSPantsExamplesMultiTargetsIntegrationTest extends OSSPantsIntegra
       "examples_src_scala_org_pantsbuild_example_hello_module",
       "examples_src_scala_org_pantsbuild_example_hello_hello",
       "examples_src_scala_org_pantsbuild_example_hello_welcome_welcome",
-      "examples_src_scala_org_pantsbuild_example_hello_exe_exe"
+      "examples_src_scala_org_pantsbuild_example_hello_exe_exe",
+      "examples_src_scala_org_pantsbuild_example_hello-project-root"
     };
 
     assertFirstSourcePartyModules((String[]) ArrayUtils.

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsFromScriptIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsFromScriptIntegrationTest.java
@@ -22,7 +22,8 @@ public class OSSPantsFromScriptIntegrationTest extends OSSPantsIntegrationTest {
       "examples_src_scala_org_pantsbuild_example_hello_exe_exe",
       "examples_src_java_org_pantsbuild_example_hello_main_readme",
       "examples_src_java_org_pantsbuild_example_hello_main_common_sources",
-      "export1_module"
+      "export1_module",
+      "intellij-integration_export1.sh-project-root"
     );
 
     assertPantsCompileExecutesAndSucceeds(pantsCompileProject());

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsJavaExamplesIntegrationTest.java
@@ -70,7 +70,8 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
       "examples_src_java_org_pantsbuild_example_hello_main_main-bin",
       "examples_src_java_org_pantsbuild_example_hello_module",
       "examples_src_java_org_pantsbuild_example_hello_main_readme",
-      "examples_src_java_org_pantsbuild_example_hello_main_common_sources"
+      "examples_src_java_org_pantsbuild_example_hello_main_common_sources",
+      "examples_src_java_org_pantsbuild_example_hello-project-root"
     };
 
     assertFirstSourcePartyModules(
@@ -123,7 +124,8 @@ public class OSSPantsJavaExamplesIntegrationTest extends OSSPantsIntegrationTest
 
     assertFirstSourcePartyModules(
       "intellij-integration_src_java_org_pantsbuild_testproject_excludes2_excludes2",
-      "intellij-integration_src_java_org_pantsbuild_testproject_excludes2_module"
+      "intellij-integration_src_java_org_pantsbuild_testproject_excludes2_module",
+      "intellij-integration_src_java_org_pantsbuild_testproject_excludes2-project-root"
     );
 
     assertPantsCompileExecutesAndSucceeds(

--- a/tests/com/twitter/intellij/pants/integration/OSSPantsScalaExamplesIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/OSSPantsScalaExamplesIntegrationTest.java
@@ -30,7 +30,8 @@ public class OSSPantsScalaExamplesIntegrationTest extends OSSPantsIntegrationTes
       "examples_src_scala_org_pantsbuild_example_hello_hello",
       "examples_src_scala_org_pantsbuild_example_hello_welcome_welcome",
       "examples_src_java_org_pantsbuild_example_hello_greet_greet",
-      "examples_src_scala_org_pantsbuild_example_hello_exe_exe"
+      "examples_src_scala_org_pantsbuild_example_hello_exe_exe",
+      "examples_src_scala_org_pantsbuild_example_hello-project-root"
     );
 
     assertModuleModuleDeps(

--- a/tests/com/twitter/intellij/pants/integration/ResolveIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/ResolveIntegrationTest.java
@@ -32,7 +32,8 @@ public class ResolveIntegrationTest extends OSSPantsIntegrationTest {
       resourceModuleName,
       commonModuleName,
       "intellij-integration_extras_src_main_java_org_pantsbuild_testproject_lib",
-      "intellij-integration_extras_module"
+      "intellij-integration_extras_module",
+      "intellij-integration_extras-project-root"
     );
 
     Module testModule = getModule(testModuleName);

--- a/tests/com/twitter/intellij/pants/resolve/SyntheticModulesTest.java
+++ b/tests/com/twitter/intellij/pants/resolve/SyntheticModulesTest.java
@@ -1,0 +1,28 @@
+// Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.resolve;
+
+import com.intellij.testFramework.UsefulTestCase;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.twitter.intellij.pants.service.project.resolver.PantsSourceRootsExtension.*;
+
+public class SyntheticModulesTest extends UsefulTestCase {
+  public void testRemoveChildren() {
+    HashSet<String> input = new HashSet<>(Arrays.asList("A", "A/B", "A/B/C", "B", "C/D"));
+    Set<String> actual = removeChildren(input);
+    HashSet<String> expected = new HashSet<>(Arrays.asList("A", "B", "C/D"));
+    assertEquals(expected, actual);
+  }
+
+  public void testRemoveChildrenEmptySet() {
+    HashSet<String> input = new HashSet<>();
+    Set<String> actual = removeChildren(input);
+    HashSet<String> expected = new HashSet<>();
+    assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
Thanks to this we decrease the number of separate module graphs, which hopefully improves performance of VCS-related IntelliJ features.