### PR TITLE
Enable python facet setup

### DIFF
--- a/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTestWithPython.java
+++ b/testFramework/com/twitter/intellij/pants/testFramework/OSSPantsIntegrationTestWithPython.java
@@ -1,0 +1,37 @@
+package com.twitter.intellij.pants.testFramework;
+
+import com.intellij.facet.Facet;
+import com.intellij.facet.FacetManager;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.jetbrains.python.facet.PythonFacetSettings;
+import com.jetbrains.python.module.PyModuleService;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+abstract public class OSSPantsIntegrationTestWithPython extends OSSPantsIntegrationTest {
+
+  @Override
+  public void tearDown() throws Exception {
+    Predicate<Sdk> predicate = jdk -> jdk.getName().startsWith("python");
+    removeJdks(predicate);
+    unsetPythonSdks(predicate);
+    super.tearDown();
+  }
+
+  private void unsetPythonSdks(@NotNull final Predicate<Sdk> pred) {
+    Arrays.stream(ProjectManager.getInstance().getOpenProjects())
+      .flatMap(project -> Arrays.stream(ModuleManager.getInstance(project).getModules()))
+      .filter(PyModuleService.getInstance()::isPythonModule)
+      .flatMap(module -> Arrays.stream(FacetManager.getInstance(module).getAllFacets()))
+      .map(Facet::getConfiguration)
+      .filter(f -> f instanceof PythonFacetSettings)
+      .map(f -> (PythonFacetSettings) f)
+      .filter(f -> pred.test(f.getSdk()))
+      .forEach(f -> f.setSdk(null));
+  }
+
+}

--- a/tests/com/twitter/intellij/pants/execution/OSSPantsPythonRunConfigurationIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/execution/OSSPantsPythonRunConfigurationIntegrationTest.java
@@ -24,7 +24,7 @@ import com.jetbrains.python.psi.types.PyClassLikeType;
 import com.jetbrains.python.psi.types.PyClassTypeImpl;
 import com.jetbrains.python.psi.types.TypeEvalContext;
 import com.jetbrains.python.testing.PythonUnitTestUtil;
-import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTestWithPython;
 import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
@@ -33,13 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class OSSPantsPythonRunConfigurationIntegrationTest extends OSSPantsIntegrationTest {
-
-  @Override
-  public void tearDown() throws Exception {
-    removeJdks(jdk -> jdk.getName().startsWith("python"));
-    super.tearDown();
-  }
+public class OSSPantsPythonRunConfigurationIntegrationTest extends OSSPantsIntegrationTestWithPython {
 
   public void testPyTestRunConfiguration() throws Throwable {
     doImport("examples/tests/python/example_test/hello");

--- a/tests/com/twitter/intellij/pants/integration/python/OSSPantsPythonIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/python/OSSPantsPythonIntegrationTest.java
@@ -5,15 +5,9 @@ package com.twitter.intellij.pants.integration.python;
 
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess;
 import com.intellij.util.ArrayUtil;
-import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTest;
+import com.twitter.intellij.pants.testFramework.OSSPantsIntegrationTestWithPython;
 
-public class OSSPantsPythonIntegrationTest extends OSSPantsIntegrationTest {
-
-  @Override
-  public void tearDown() throws Exception {
-    removeJdks(jdk -> jdk.getName().startsWith("python"));
-    super.tearDown();
-  }
+public class OSSPantsPythonIntegrationTest extends OSSPantsIntegrationTestWithPython {
 
   @Override
   protected String[] getRequiredPluginIds() {


### PR DESCRIPTION
I uncommented the code to bring back the feature that was disabled. I also changed it to be synchronous as if it is async, the map with interpreters it is supposed to fill will be empty, and the code later can't use it. Also moved setting up sdk paths out of write action. 

The changes in test teardown are related to https://youtrack.jetbrains.com/issue/IDEA-246356 bug that I found.