### PR TITLE
Fix `Failed to write settings` error

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
+++ b/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
@@ -127,14 +127,15 @@ public class PantsSourceRootsExtension implements PantsResolverExtension {
 
     for (String targetPath: targetSpecPathsWithoutChildren) {
       String relativePath = targetPath;
+      String absolutePath = new File(executor.getBuildRoot(), relativePath).getAbsolutePath();
       String moduleName = relativePath.replaceAll("/", "_") + "-project-root";
       final ModuleData moduleData = new ModuleData(
         moduleName,
         PantsConstants.SYSTEM_ID,
         ModuleTypeId.JAVA_MODULE,
         moduleName,
-        targetPath,
-        new File(executor.getBuildRoot(), relativePath).getAbsolutePath()
+        absolutePath,
+        absolutePath
       );
       DataNode<ModuleData> moduleDataNode = projectDataNode.createChild(ProjectKeys.MODULE, moduleData);
       modules.put(moduleName , moduleDataNode);


### PR DESCRIPTION
Previously, IntelliJ would try to write the settings at the root of the
filesystem, which would be likely to fail. This commit fixes this
behavior by specifying the absolute path where the settings should be
written.