### PR TITLE
Pass the right path to iml directory on module creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
 script:
   # Test a single Java target without scala plugin
   - ENABLE_SCALA_PLUGIN=false ./scripts/run-tests-ci.sh --test-junit-test=com.twitter.intellij.pants.integration.OSSPantsJavaExamplesIntegrationTest
-  - travis_wait 90 ./scripts/run-tests-ci.sh
+  - travis_wait 105 ./scripts/run-tests-ci.sh
 
 after_success:
   - scripts/deploy/deploy.sh

--- a/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
+++ b/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
@@ -133,7 +133,7 @@ public class PantsSourceRootsExtension implements PantsResolverExtension {
         PantsConstants.SYSTEM_ID,
         ModuleTypeId.JAVA_MODULE,
         moduleName,
-        targetPath,
+        projectDataNode.getData().getIdeProjectFileDirectoryPath() + "/" + moduleName,
         new File(executor.getBuildRoot(), relativePath).getAbsolutePath()
       );
       DataNode<ModuleData> moduleDataNode = projectDataNode.createChild(ProjectKeys.MODULE, moduleData);


### PR DESCRIPTION
Fixes "failed to save settings" error that sometimes occur