### PR TITLE
New "Project Files by Target Specs" view

### DIFF
--- a/common/com/twitter/intellij/pants/PantsBundle.properties
+++ b/common/com/twitter/intellij/pants/PantsBundle.properties
@@ -9,6 +9,7 @@ pants.library.no.pex.folder=Couldn't find a folder with pex files\!
 pants.library.no.pex.file=Couldn't find pex file for version ''{0}''
 
 pants.title.project.files=Project Files Tree
+pants.title.target.spec.files=Project Files by Target Specs
 
 pants.info.python.plugin.missing=Please install Python Support plugin for code assistance in BUILD files.
 pants.info.python.facet.missing=Automatically add Python interpreter for a module containing this BUILD file.

--- a/common/com/twitter/intellij/pants/PantsBundle.properties
+++ b/common/com/twitter/intellij/pants/PantsBundle.properties
@@ -9,7 +9,7 @@ pants.library.no.pex.folder=Couldn't find a folder with pex files\!
 pants.library.no.pex.file=Couldn't find pex file for version ''{0}''
 
 pants.title.project.files=Project Files Tree
-pants.title.target.spec.files=Project Files by Target Specs
+pants.title.target.spec.files=Pants Targets
 
 pants.info.python.plugin.missing=Please install Python Support plugin for code assistance in BUILD files.
 pants.info.python.facet.missing=Automatically add Python interpreter for a module containing this BUILD file.

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -503,6 +503,10 @@ public class PantsUtil {
     return ExternalProjectUtil.isExternalProject(project, PantsConstants.SYSTEM_ID);
   }
 
+  public static boolean isFastpassProject(@NotNull Project project) {
+    return PantsUtil.findPantsExecutable(project).isPresent() && PantsUtil.isBspProject(project);
+  }
+
   /**
    * Determine whether a project is trigger by Pants `idea-plugin` goal by
    * looking at the "pants_idea_plugin_version" property.

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -164,6 +164,7 @@
 
     <treeStructureProvider implementation="com.twitter.intellij.pants.projectview.PantsTreeStructureProvider"/>
     <projectViewPane implementation="com.twitter.intellij.pants.projectview.ProjectFilesViewPane"/>
+    <projectViewPane implementation="com.twitter.intellij.pants.projectview.TargetSpecsViewPane"/>
 
     <toolWindow id="Pants" anchor="right" icon="PantsIcons.Icon"
                 factoryClass="com.twitter.intellij.pants.ui.PantsToolWindowFactory"

--- a/src/com/twitter/intellij/pants/bsp/FastpassUtils.java
+++ b/src/com/twitter/intellij/pants/bsp/FastpassUtils.java
@@ -12,11 +12,13 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -85,7 +87,10 @@ final public class FastpassUtils {
   public static CompletableFuture<Set<String>> selectedTargets(PantsBspData basePath) {
     return CompletableFuture.supplyAsync(() -> {
       try {
-        JsonReader reader = new JsonReader(new FileReader(basePath.getBspPath().resolve(Paths.get(".bsp", "bloop.json")).toFile()));
+        VirtualFile bloopJsonFile =
+          VirtualFileManager.getInstance().findFileByNioPath(basePath.getBspPath().resolve(Paths.get(".bsp", "bloop.json")));
+        byte[] bytes = bloopJsonFile.contentsToByteArray(true);
+        InputStreamReader reader = new InputStreamReader(new ByteArrayInputStream(bytes));
         Gson gson = new Gson();
         BloopConfig res = gson.fromJson(reader, BloopConfig.class);
         return new HashSet<>(res.getPantsTargets());

--- a/src/com/twitter/intellij/pants/projectview/TargetSpecsFileTreeNode.java
+++ b/src/com/twitter/intellij/pants/projectview/TargetSpecsFileTreeNode.java
@@ -1,0 +1,107 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.projectview;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.projectView.PresentationData;
+import com.intellij.ide.projectView.ProjectView;
+import com.intellij.ide.projectView.ProjectViewNode;
+import com.intellij.ide.projectView.ViewSettings;
+import com.intellij.ide.projectView.impl.ProjectViewImpl;
+import com.intellij.ide.projectView.impl.nodes.PsiFileNode;
+import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.util.Function;
+import com.intellij.util.containers.ContainerUtil;
+import com.twitter.intellij.pants.util.PantsUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class TargetSpecsFileTreeNode extends ProjectViewNode<VirtualFile> {
+  private final Boolean myIsRoot;
+
+  public TargetSpecsFileTreeNode(
+    @NotNull Project project,
+    @NotNull VirtualFile virtualFile,
+    @NotNull ViewSettings viewSettings,
+    @NotNull Boolean isRoot
+  ) {
+    super(project, virtualFile, viewSettings);
+    myIsRoot = isRoot;
+  }
+
+  @Nullable
+  @Override
+  public VirtualFile getVirtualFile() {
+    return getValue();
+  }
+
+  @Override
+  public int getWeight() {
+    final ProjectView projectView = ProjectView.getInstance(myProject);
+    final boolean foldersOnTop = projectView instanceof ProjectViewImpl && !((ProjectViewImpl)projectView).isFoldersAlwaysOnTop();
+    return foldersOnTop && getValue().isDirectory() ? 20 : 0;
+  }
+
+  @Override
+  public boolean contains(@NotNull VirtualFile file) {
+    final VirtualFile myFile = getValue();
+    return myFile.isDirectory() && VfsUtil.isAncestor(myFile, file, true);
+  }
+
+  @Override
+  protected void update(@NotNull PresentationData presentation) {
+    final PsiManager psiManager = PsiManager.getInstance(myProject);
+    final VirtualFile virtualFile = getValue();
+    PsiDirectory psiFile = psiManager.findDirectory(virtualFile);
+    Module module = psiFile != null ? ModuleUtil.findModuleForPsiElement(psiFile) : null;
+
+
+    String path = myIsRoot ? PantsUtil.getRelativeProjectPath(virtualFile.getPath()).orElse(virtualFile.getName()) : virtualFile.getName();
+    presentation.clearText();
+    presentation.addText(path, SimpleTextAttributes.REGULAR_ATTRIBUTES);
+    if(module != null) {
+      boolean moduleRoot = Arrays.asList(ModuleRootManager.getInstance(module).getContentRoots()).contains(virtualFile);
+      if(moduleRoot) {
+        presentation.addText(" [" + module.getName() + "]", SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES);
+      }
+    }
+    presentation.setIcon(virtualFile.isDirectory() ? AllIcons.Nodes.Folder : virtualFile.getFileType().getIcon());
+  }
+
+  @NotNull
+  @Override
+  public Collection<? extends AbstractTreeNode<?>> getChildren() {
+    final VirtualFile virtualFile = getValue();
+    final PsiManager psiManager = PsiManager.getInstance(myProject);
+
+    return ContainerUtil.mapNotNull(
+      virtualFile.isValid() && virtualFile.isDirectory() ? virtualFile.getChildren() : VirtualFile.EMPTY_ARRAY,
+      (Function<VirtualFile, AbstractTreeNode<?>>) file -> {
+        final PsiElement psiElement = file.isDirectory() ? psiManager.findDirectory(file) : psiManager.findFile(file);
+        if (psiElement instanceof PsiDirectory) {
+          return new TargetSpecsFileTreeNode(myProject, file, getSettings(), false);
+        }
+        else if(psiElement != null) {
+          return new PsiFileNode(myProject, (PsiFile) psiElement, getSettings());
+        } else {
+          return null;
+        }
+      }
+    );
+  }
+}

--- a/src/com/twitter/intellij/pants/projectview/TargetSpecsSelectInTarget.java
+++ b/src/com/twitter/intellij/pants/projectview/TargetSpecsSelectInTarget.java
@@ -1,0 +1,68 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.projectview;
+
+import com.intellij.ide.SelectInContext;
+import com.intellij.ide.SelectInManager;
+import com.intellij.ide.impl.ProjectViewSelectInTarget;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFileSystemItem;
+import com.twitter.intellij.pants.bsp.PantsBspData;
+import com.twitter.intellij.pants.util.PantsUtil;
+
+import java.util.Optional;
+
+public class TargetSpecsSelectInTarget extends ProjectViewSelectInTarget {
+  protected TargetSpecsSelectInTarget(Project project) {
+    super(project);
+  }
+
+  @Override
+  public String getMinorViewId() {
+    return TargetSpecsViewPane.ID;
+  }
+
+  @Override
+  public float getWeight() {
+    return 240;
+  }
+
+  @Override
+  public boolean canSelect(PsiFileSystemItem file) {
+    if (!super.canSelect(file)) return false;
+    final VirtualFile vFile = file.getVirtualFile();
+    return canSelect(vFile);
+  }
+
+  @Override
+  public boolean isSubIdSelectable(String subId, SelectInContext context) {
+    return canSelect(context);
+  }
+
+  private boolean canSelect(final VirtualFile vFile) {
+      if (vFile != null && vFile.isValid()) {
+        ProjectFileIndex projectFileIndex = ProjectRootManager.getInstance(myProject).getFileIndex();
+        if (projectFileIndex.isInLibraryClasses(vFile) || projectFileIndex.isInLibrarySource(vFile)) {
+          return true;
+        }
+        if(PantsBspData.importsFor(myProject).stream().map(PantsBspData::getPantsRoot).anyMatch(root -> VfsUtil.isAncestor(root, vFile, false))) {
+          return true;
+        }
+
+        final Optional<VirtualFile> buildRoot = PantsUtil.findBuildRoot(myProject.getBaseDir());
+
+        return buildRoot.isPresent() && VfsUtil.isAncestor(buildRoot.get(), vFile, false);
+      }
+
+      return false;
+  }
+
+  public String toString() {
+    return SelectInManager.getProject();
+  }
+}

--- a/src/com/twitter/intellij/pants/projectview/TargetSpecsViewPane.java
+++ b/src/com/twitter/intellij/pants/projectview/TargetSpecsViewPane.java
@@ -14,6 +14,7 @@ import com.intellij.ide.util.treeView.AbstractTreeNode;
 import com.intellij.ide.util.treeView.AbstractTreeUpdater;
 import com.intellij.openapi.project.Project;
 import com.twitter.intellij.pants.PantsBundle;
+import com.twitter.intellij.pants.util.PantsUtil;
 import icons.PantsIcons;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -52,6 +53,11 @@ public class TargetSpecsViewPane extends AbstractProjectViewPSIPane {
   @Override
   public int getWeight() {
     return 240;
+  }
+
+  @Override
+  public boolean isDefaultPane(@NotNull Project project) {
+    return PantsUtil.isPantsProject(project) || PantsUtil.isFastpassProject(project);
   }
 
   @NotNull

--- a/src/com/twitter/intellij/pants/projectview/TargetSpecsViewPane.java
+++ b/src/com/twitter/intellij/pants/projectview/TargetSpecsViewPane.java
@@ -1,0 +1,107 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.projectview;
+
+import com.intellij.ide.SelectInTarget;
+import com.intellij.ide.projectView.ViewSettings;
+import com.intellij.ide.projectView.impl.AbstractProjectViewPSIPane;
+import com.intellij.ide.projectView.impl.ProjectAbstractTreeStructureBase;
+import com.intellij.ide.projectView.impl.ProjectTreeStructure;
+import com.intellij.ide.projectView.impl.ProjectViewTree;
+import com.intellij.ide.util.treeView.AbstractTreeBuilder;
+import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.ide.util.treeView.AbstractTreeUpdater;
+import com.intellij.openapi.project.Project;
+import com.twitter.intellij.pants.PantsBundle;
+import icons.PantsIcons;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.Icon;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+
+public class TargetSpecsViewPane extends AbstractProjectViewPSIPane {
+  @NonNls public static final String ID = "TargetSpecsViewPane";
+  private boolean myShowExcludedFiles = true;
+  private boolean myShowOnlyLoadedFiles = false;
+
+  public TargetSpecsViewPane(Project project) {
+    super(project);
+  }
+
+  @NotNull
+  @Override
+  public String getTitle() {
+    return PantsBundle.message("pants.title.target.spec.files");
+  }
+
+  @NotNull
+  @Override
+  public Icon getIcon() {
+    return PantsIcons.Icon;
+  }
+
+  @Override
+  @NotNull
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public int getWeight() {
+    return 240;
+  }
+
+  @NotNull
+  @Override
+  protected ProjectAbstractTreeStructureBase createStructure() {
+    return new ProjectViewPaneTreeStructure();
+  }
+
+  @NotNull
+  @Override
+  protected ProjectViewTree createTree(@NotNull DefaultTreeModel treeModel) {
+    return new ProjectViewTree(myProject, treeModel) {
+      @Override
+      public DefaultMutableTreeNode getSelectedNode() {
+        return TargetSpecsViewPane.this.getSelectedNode();
+      }
+    };
+  }
+
+ @NotNull
+ @Override
+ protected AbstractTreeUpdater createTreeUpdater(@NotNull AbstractTreeBuilder treeBuilder) {
+   return new AbstractTreeUpdater(treeBuilder);
+ }
+
+  @NotNull
+  @Override
+  public SelectInTarget createSelectInTarget() {
+    return new TargetSpecsSelectInTarget(myProject);
+  }
+
+  private class ProjectViewPaneTreeStructure extends ProjectTreeStructure implements PantsViewSettings {
+    public ProjectViewPaneTreeStructure() {
+      super(TargetSpecsViewPane.this.myProject, ID);
+    }
+
+    @Override
+    protected AbstractTreeNode<?> createRoot(@NotNull final Project project, @NotNull ViewSettings settings) {
+      return new TargetSpecsViewProjectNode(project, settings);
+    }
+
+    @Override
+    public boolean isShowExcludedFiles() {
+      return myShowExcludedFiles;
+    }
+
+    @Override
+    public boolean isShowOnlyLoadedFiles() {
+      return myShowOnlyLoadedFiles;
+    }
+  }
+
+}

--- a/src/com/twitter/intellij/pants/projectview/TargetSpecsViewProjectNode.java
+++ b/src/com/twitter/intellij/pants/projectview/TargetSpecsViewProjectNode.java
@@ -1,0 +1,106 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.twitter.intellij.pants.projectview;
+
+import com.intellij.ide.projectView.ViewSettings;
+import com.intellij.ide.projectView.impl.ModuleGroup;
+import com.intellij.ide.projectView.impl.nodes.AbstractProjectNode;
+import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettings;
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.twitter.intellij.pants.PantsBundle;
+import com.twitter.intellij.pants.bsp.FastpassUtils;
+import com.twitter.intellij.pants.bsp.PantsBspData;
+import com.twitter.intellij.pants.bsp.PantsTargetAddress;
+import com.twitter.intellij.pants.settings.PantsProjectSettings;
+import com.twitter.intellij.pants.util.PantsConstants;
+import com.twitter.intellij.pants.util.PantsUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class TargetSpecsViewProjectNode extends AbstractProjectNode {
+
+  public TargetSpecsViewProjectNode(Project project, ViewSettings viewSettings) {
+    super(project, project, viewSettings);
+  }
+
+  @NotNull
+  @Override
+  protected AbstractTreeNode<?> createModuleGroup(@NotNull Module module)
+    throws NoSuchMethodException {
+    // should be never called
+    throw new NoSuchMethodException(PantsBundle.message("pants.error.not.implemented"));
+  }
+
+  @NotNull
+  @Override
+  protected AbstractTreeNode<?> createModuleGroupNode(@NotNull ModuleGroup moduleGroup)
+    throws NoSuchMethodException {
+    // should be never called
+    throw new NoSuchMethodException(PantsBundle.message("pants.error.not.implemented"));
+  }
+
+  @NotNull
+  @Override
+  public Collection<? extends AbstractTreeNode<?>> getChildren() {
+    Set<VirtualFile> topLevelNodes = PantsUtil.isFastpassProject(myProject)
+                                      ? fastpassTargetSpecViewTopLevelNodes(myProject)
+                                      : PantsUtil.isPantsProject(myProject)
+                                        ? regularPantsTargetSpecViewTopLevelNodes(myProject)
+                                        : Collections.emptySet();
+    return topLevelNodes
+      .stream()
+      .sorted(Comparator.comparing(VirtualFile::toString))
+      .map(file -> new TargetSpecsFileTreeNode(myProject, file, getSettings(), true))
+      .collect(Collectors.toList());
+  }
+
+  private Set<VirtualFile> fastpassTargetSpecViewTopLevelNodes(Project project) {
+    Set<PantsBspData> linkedProjects = PantsBspData.importsFor(project);
+    Set<CompletableFuture<Set<VirtualFile>>> futures = linkedProjects.stream().map(pantsBspData -> {
+      VirtualFile pantsRoot = pantsBspData.getPantsRoot();
+      return FastpassUtils.selectedTargets(pantsBspData).thenApply(
+        targetSpecs -> targetSpecs.stream()
+          .map(targetSpecsItem -> pantsRoot.findFileByRelativePath(PantsTargetAddress.fromString(targetSpecsItem).getPath().toString()))
+          .collect(Collectors.toSet())
+      );
+    }).collect(Collectors.toSet());
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenApply(
+      __ -> futures.stream().flatMap(x -> x.join().stream()).collect(Collectors.toSet())
+    ).join();
+  }
+
+  @NotNull
+  private Set<VirtualFile> regularPantsTargetSpecViewTopLevelNodes(Project project) {
+    AbstractExternalSystemSettings<?, ?, ?> systemSettings =
+      ExternalSystemApiUtil.getSettings(project, PantsConstants.SYSTEM_ID);
+    List<PantsTargetAddress> roots =
+      systemSettings.getLinkedProjectsSettings().stream()
+        .flatMap(s -> ((PantsProjectSettings) (s)).getSelectedTargetSpecs().stream())
+        .map(PantsTargetAddress::fromString)
+        .collect(Collectors.toList());
+    return roots.stream().map(address -> LocalFileSystem.getInstance().findFileByNioFile(address.getPath()))
+      .collect(Collectors.toSet());
+  }
+
+  @Override
+  public boolean contains(@NotNull VirtualFile file) {
+    final Optional<VirtualFile> projectBuildRoot = PantsUtil.findBuildRoot(myProject.getBaseDir());
+    return super.contains(file) ||
+           (projectBuildRoot.isPresent() && VfsUtil.isAncestor(projectBuildRoot.get(), file, true));
+  }
+}


### PR DESCRIPTION
Add a new tab to the "Project" panel, that may be used to browse
filesystem, but limits visible directories only to the ones that
directly match rules defined in Target Specs, so it does not show
folders containing dependencies unless they are not outside the target
spec directories.