### PR TITLE
Target spec view fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ language: python
 cache:
   directories:
     - ${HOME}/.cache/pants
-    - .cache/bootstrap # See pants.ini [cache.bootstrap]
-    - .cache/pants     # Pants downloaded by scripts/setup-ci-environment.sh
   timeout: 1200
 notifications:
   email:

--- a/common/com/twitter/intellij/pants/util/PantsUtil.java
+++ b/common/com/twitter/intellij/pants/util/PantsUtil.java
@@ -889,7 +889,7 @@ public class PantsUtil {
   public static Optional<VirtualFile> findPantsExecutable(@NotNull Project project) {
     Module[] modules = ModuleManager.getInstance(project).getModules();
     if (modules.length == 0) {
-      throw new PantsException("No module found in project.");
+      return Optional.empty();
     }
     for (Module module : modules) {
       Optional<VirtualFile> buildRoot = findBuildRoot(module);

--- a/src/com/twitter/intellij/pants/bsp/PantsTargetAddress.java
+++ b/src/com/twitter/intellij/pants/bsp/PantsTargetAddress.java
@@ -72,6 +72,9 @@ public class PantsTargetAddress {
       return Optional.of(new PantsTargetAddress(Paths.get(strings[0]), AddressKind.ALL_TARGETS_DEEP, Optional.empty()));
     } else if (strings.length >= 1 && s.endsWith(":")) {
       return Optional.of(new PantsTargetAddress(Paths.get(strings[0]), AddressKind.ALL_TARGETS_FLAT, Optional.empty()));
+    } else if(!s.contains(":")) {
+      Path target = Paths.get(s).getFileName();
+      return Optional.of(new PantsTargetAddress(Paths.get(s), AddressKind.SINGLE_TARGET, Optional.of(target.toString())));
     } else {
       return Optional.empty();
     }

--- a/tests/com/twitter/intellij/pants/bsp/PantsTargetAddressTest.java
+++ b/tests/com/twitter/intellij/pants/bsp/PantsTargetAddressTest.java
@@ -24,6 +24,11 @@ public class PantsTargetAddressTest extends UsefulTestCase {
     assertEquals(t.get(), PantsTargetAddress.allTargetsInDirFlat(Paths.get("project")));
   }
 
+  public void testJustPath() {
+    Optional<PantsTargetAddress> t = PantsTargetAddress.tryParse("a/b/c");
+    assertEquals(t.get(), PantsTargetAddress.oneTargetInDir(Paths.get("a/b/c"), "c"));
+  }
+
   public void testJustColon() {
     Optional<PantsTargetAddress> t = PantsTargetAddress.tryParse(":");
     assertFalse(t.isPresent());

--- a/tests/com/twitter/intellij/pants/integration/BspPantsIntegrationTest.java
+++ b/tests/com/twitter/intellij/pants/integration/BspPantsIntegrationTest.java
@@ -42,17 +42,17 @@ public class BspPantsIntegrationTest extends OSSPantsIntegrationTest {
     assertEquals(1, parsedDeepDirectoryRule.values().stream().findFirst().get().size());
 
     // Test single target rule
-    Map<PantsTargetAddress, Collection<PantsTargetAddress>> parsedSingeTargetRule =
+    Map<PantsTargetAddress, Collection<PantsTargetAddress>> parsedSingleTargetRule =
       parse(Collections.singleton("examples/tests/java/org/pantsbuild/example/hello/greet:greet"));
-    assertEquals(1, parsedSingeTargetRule.size());
-    assertEquals(1, parsedSingeTargetRule.values().stream().findFirst().get().size());
+    assertEquals(1, parsedSingleTargetRule.size());
+    assertEquals(1, parsedSingleTargetRule.values().stream().findFirst().get().size());
 
-    // Throws for malformed target
-    assertThrows(
-      InvalidTargetException.class,
-      "Malformed address",
-      () -> parse(Collections.singleton("examples/tests/java/org/pantsbuild/example/hello/greet"))
-    );
+    // Test single target rule with implied target
+    Map<PantsTargetAddress, Collection<PantsTargetAddress>> parsedDefaultTargetRule =
+      parse(Collections.singleton("examples/tests/java/org/pantsbuild/example/hello/greet"));
+    assertEquals(1, parsedDefaultTargetRule.size());
+    assertEquals(1, parsedDefaultTargetRule.values().stream().findFirst().get().size());
+    assertEquals("greet", parsedDefaultTargetRule.values().stream().findFirst().get().iterator().next().getTargets().get());
 
     // Throws for non-existing folder
     assertThrows(


### PR DESCRIPTION
### Commit 1: 
Support non-canonical Pants addresses
Before, the only supported formats were:
  PATH:
  PATH::
  PATH:TARGET

Now we support also address without colon:
  a/b/c
which is equivalent to a/b/c:c

### Commit 2:
Handle the case when LinkedProjectPath is relative
Relative paths were set in case if user has extended project with the "+" button in "Pants"
window

### Commit 3:
Unify failures in findPantsExecutable
As it's return type is Optional, one might not expect it throws

[EDIT][WARNING]:
Commit 6503d33 disables cache. It seems that our cache is too big, so Travis constantly fails to start.