### PR TITLE
Make "$PantsFilePathRelativeToBuildRoot$" macro working for sources jar

### DIFF
--- a/src/com/twitter/intellij/pants/bsp/JarMappings.java
+++ b/src/com/twitter/intellij/pants/bsp/JarMappings.java
@@ -125,7 +125,7 @@ public class JarMappings {
     return String.join("/", targetPath) + ":" + targetName;
   }
 
-  private boolean isProjectInternalDependency(VirtualFile jar) {
+  public boolean isProjectInternalDependency(VirtualFile jar) {
     Path jarPath = Paths.get(jar.getPath());
     return isBloopJarPath(jarPath) || isSourcesJarPath(jarPath);
   }

--- a/src/com/twitter/intellij/pants/bsp/PantsBspData.java
+++ b/src/com/twitter/intellij/pants/bsp/PantsBspData.java
@@ -34,6 +34,10 @@ final public class PantsBspData {
     return myPantsRoot;
   }
 
+  public static Set<VirtualFile> pantsRoots(Project project) {
+    return importsFor(project).stream().map(PantsBspData::getPantsRoot).collect(Collectors.toSet());
+  }
+
   public static Set<PantsBspData> importsFor(Project project) {
     return
       Arrays.stream(ModuleManager.getInstance(project).getModules())

--- a/src/com/twitter/intellij/pants/macro/FilePathRelativeToBuiltRootMacro.java
+++ b/src/com/twitter/intellij/pants/macro/FilePathRelativeToBuiltRootMacro.java
@@ -6,37 +6,80 @@ package com.twitter.intellij.pants.macro;
 import com.intellij.ide.macro.Macro;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.twitter.intellij.pants.bsp.JarMappings;
+import com.twitter.intellij.pants.bsp.PantsBspData;
+import com.twitter.intellij.pants.bsp.PantsTargetAddress;
 import com.twitter.intellij.pants.util.PantsUtil;
+import org.jetbrains.annotations.NotNull;
 
+import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 
 public class FilePathRelativeToBuiltRootMacro extends Macro {
   /**
    * @return corresponding name of this macro
    */
+  @NotNull
   @Override
   public String getName() {
     return "PantsFilePathRelativeToBuildRoot";
   }
 
+  @NotNull
   @Override
   public String getDescription() {
     return "Relative path from build root";
   }
 
+  private Optional<String> jarFilePath(Project project, VirtualFile vFile) {
+    Optional<VirtualFile> jarFile = JarMappings.getParentJar(vFile);
+    if(jarFile.isPresent()) {
+      JarMappings mappings = JarMappings.getInstance(project);
+      Optional<Path> target = mappings
+        .findTargetForJar(jarFile.get())
+        .flatMap(PantsTargetAddress::tryParse)
+        .map(PantsTargetAddress::getPath);
+      if (target.isPresent()){
+        String relativePath = target.get().resolve(vFile.getName()).toString();
+        Set<VirtualFile> pantsRoots = PantsBspData.pantsRoots(project);
+        boolean pathExists = pantsRoots.stream()
+          .anyMatch(x -> x.findFileByRelativePath(relativePath) != null);
+        if (pathExists) {
+          return Optional.of(relativePath);
+        } else {
+          return Optional.empty();
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+
   @Override
-  public String expand(final DataContext dataContext) {
+  public String expand(@NotNull final DataContext dataContext) {
     VirtualFile fileSelected = CommonDataKeys.VIRTUAL_FILE.getData(dataContext);
     if (fileSelected == null) {
       return null;
     }
+
     Optional<VirtualFile> buildRoot = PantsUtil.findBuildRoot(fileSelected);
-    if (!buildRoot.isPresent()) {
-      return null;
+    if (buildRoot.isPresent()) {
+      return FileUtil.getRelativePath(VfsUtil.virtualToIoFile(buildRoot.get()), VfsUtil.virtualToIoFile(fileSelected));
     }
-    return FileUtil.getRelativePath(VfsUtil.virtualToIoFile(buildRoot.get()), VfsUtil.virtualToIoFile(fileSelected));
+
+    Project project = CommonDataKeys.PROJECT.getData(dataContext);
+    if(project != null) {
+      Optional<String> jarFile = jarFilePath(project, fileSelected);
+      if(jarFile.isPresent()){
+        return jarFile.get();
+      }
+    }
+
+    return "";
   }
 }


### PR DESCRIPTION
For dependencies that are not directly specified in config spec, fastpass
generates "*-sources.jar" files. PantsFilePathRelativeToBuildRoot was
not working for sources in these files.