### PR TITLE
Dealias content root directories.

### DIFF
--- a/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
+++ b/src/com/twitter/intellij/pants/service/project/resolver/PantsSourceRootsExtension.java
@@ -20,6 +20,7 @@ import com.twitter.intellij.pants.service.project.model.ProjectInfo;
 import com.twitter.intellij.pants.service.project.model.TargetInfo;
 import com.twitter.intellij.pants.service.project.model.graph.BuildGraph;
 import com.twitter.intellij.pants.util.PantsConstants;
+import com.twitter.intellij.pants.util.PantsUtil;
 import org.apache.commons.compress.utils.Lists;
 import org.jetbrains.annotations.NotNull;
 
@@ -188,7 +189,7 @@ public class PantsSourceRootsExtension implements PantsResolverExtension {
     final List<String> baseRoots = new ArrayList<>();
     for (String root : sortedRoots) {
       if (!hasAnAncestorRoot(baseRoots, root)) {
-        baseRoots.add(root);
+        baseRoots.add(PantsUtil.resolveSymlinks(root));
       }
     }
     return baseRoots;


### PR DESCRIPTION
The goal of this change is to reduce the number of IntelliJ UI freezes
by reducing the number of external file events in IntelliJ.

Previously, content roots for generated sources under
`.pants.d/gen/scrooge` pointed to symbolic links. This could cause
IntelliJ to observe a large number of external file events when users
ran Pants commands from the terminal after a git pull. Now, we dealias
the content roots so that they are not affected by Pants commands that
are executed outside of IntelliJ.