### PR TITLE
Reduce number of calls to findPantsRoot

### DIFF
--- a/src/com/twitter/intellij/pants/bsp/JarMappings.java
+++ b/src/com/twitter/intellij/pants/bsp/JarMappings.java
@@ -41,10 +41,12 @@ public class JarMappings {
     project.getMessageBus().connect().subscribe(VirtualFileManager.VFS_CHANGES, new BulkFileListener() {
       @Override
       public void after(@NotNull List<? extends VFileEvent> events) {
+        Optional<VirtualFile> libraries = librariesFile();
         events.forEach(event -> {
           if (event instanceof VFileContentChangeEvent &&
               event.getFile() != null &&
-              event.getFile().equals(librariesFile())) {
+              libraries.isPresent() &&
+              event.getFile().equals(libraries.get())) {
             librariesFileIsUpToDate = false;
           }
         });
@@ -152,7 +154,7 @@ public class JarMappings {
 
   @NotNull
   private static Optional<String> bspDir(@NotNull Project project) {
-    return PantsBspData.importsFor(project).stream().findFirst().map(PantsBspData::getBspPath).map(Path::toString);
+    return PantsBspData.bspRoot(project).map(Path::toString);
   }
 
   private Optional<VirtualFile> librariesFile() {

--- a/src/com/twitter/intellij/pants/bsp/OpenBspAmendWindowAction.java
+++ b/src/com/twitter/intellij/pants/bsp/OpenBspAmendWindowAction.java
@@ -13,12 +13,14 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.twitter.intellij.pants.PantsBundle;
 import com.twitter.intellij.pants.bsp.ui.FastpassManagerDialog;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.bsp.BspUtil;
 
 import javax.swing.SwingUtilities;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -56,25 +58,16 @@ public class OpenBspAmendWindowAction extends AnAction {
 
   public static void bspAmendWithDialog(Project project, Collection<String> targetsToAppend) {
     if (project != null) {
-      Set<PantsBspData> linkedProjects = PantsBspData.importsFor(project);
-      if (linkedProjects.size() > 1) {
-        Messages.showErrorDialog(
-          PantsBundle.message("pants.bsp.error.failed.more.than.one.bsp.project.not.supported.message"),
-          PantsBundle.message("pants.bsp.error.action.not.supported.title")
-        );
-      }
-      else if (linkedProjects.size() < 1) {
+      Optional<PantsBspData> imports = PantsBspData.importsFor(project);
+      if (imports.isPresent()) {
+        startAmendProcedure(project, imports.get(), targetsToAppend);
+      } else {
         Messages.showErrorDialog(
           PantsBundle.message("pants.bsp.error.failed.not.a.bsp.pants.project.message"),
           PantsBundle.message("pants.bsp.error.action.not.supported.title")
         );
       }
-      else {
-        PantsBspData importData = linkedProjects.stream().findFirst().get();
-        startAmendProcedure(project, importData, targetsToAppend);
-      }
-    }
-    else {
+    } else {
       Messages.showErrorDialog(
         PantsBundle.message("pants.bsp.error.no.project.found"),
         PantsBundle.message("pants.bsp.error.action.not.supported.title")

--- a/src/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
+++ b/src/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
@@ -218,7 +218,7 @@ public class FastpassUpdater {
 
   private static Optional<FastpassData> extractFastpassData(Project project) {
     try {
-      Optional<String> path = PantsBspData.importsFor(project).stream().findFirst().map(p -> p.getBspPath().toString());
+      Optional<String> path = PantsBspData.bspRoot(project).map(Path::toString);
       if (path.isPresent()) {
         Optional<FastpassData> fromBsp = readJsonFile(Paths.get(path.get(), ".bsp", "bloop.json"), BspSettings.class)
           .flatMap(settings -> {

--- a/src/com/twitter/intellij/pants/macro/FilePathRelativeToBuiltRootMacro.java
+++ b/src/com/twitter/intellij/pants/macro/FilePathRelativeToBuiltRootMacro.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.intellij.openapi.fileEditor.impl.LoadTextUtil.loadText;
 
@@ -49,9 +48,8 @@ public class FilePathRelativeToBuiltRootMacro extends Macro {
         .map(PantsTargetAddress::getPath);
       if (target.isPresent()){
         String relativePath = target.get().resolve(vFile.getName()).toString();
-        Set<VirtualFile> pantsRoots = PantsBspData.pantsRoots(project);
-        boolean pathExists = pantsRoots.stream()
-          .anyMatch(x -> x.findFileByRelativePath(relativePath) != null);
+        Optional<VirtualFile> pantsRoots = PantsBspData.pantsRoots(project);
+        boolean pathExists = pantsRoots.map(x -> x.findFileByRelativePath(relativePath) != null).orElse(false);
         if (pathExists) {
           return Optional.of(relativePath);
         } else {

--- a/src/com/twitter/intellij/pants/projectview/PantsProjectPaneSelectInTarget.java
+++ b/src/com/twitter/intellij/pants/projectview/PantsProjectPaneSelectInTarget.java
@@ -10,11 +10,14 @@ import com.intellij.ide.impl.ProjectViewSelectInTarget;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.impl.http.LocalFileStorage;
 import com.intellij.psi.PsiFileSystemItem;
 import com.twitter.intellij.pants.bsp.PantsBspData;
 import com.twitter.intellij.pants.util.PantsUtil;
+import org.jaxen.function.ext.LocaleFunctionSupport;
 
 import java.util.Optional;
 import java.util.Set;
@@ -52,7 +55,7 @@ public class PantsProjectPaneSelectInTarget extends ProjectViewSelectInTarget {
       if (projectFileIndex.isInLibraryClasses(vFile) || projectFileIndex.isInLibrarySource(vFile)) {
         return true;
       }
-      if(PantsBspData.importsFor(myProject).stream().map(PantsBspData::getPantsRoot).anyMatch(root -> VfsUtil.isAncestor(root, vFile, false))) {
+      if(PantsBspData.pantsRoots(myProject).map(root -> VfsUtil.isAncestor(root, vFile, false)).orElse(false)) {
         return true;
       }
 

--- a/src/com/twitter/intellij/pants/projectview/TargetSpecsSelectInTarget.java
+++ b/src/com/twitter/intellij/pants/projectview/TargetSpecsSelectInTarget.java
@@ -9,6 +9,7 @@ import com.intellij.ide.impl.ProjectViewSelectInTarget;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFileSystemItem;
@@ -50,7 +51,7 @@ public class TargetSpecsSelectInTarget extends ProjectViewSelectInTarget {
         if (projectFileIndex.isInLibraryClasses(vFile) || projectFileIndex.isInLibrarySource(vFile)) {
           return true;
         }
-        if(PantsBspData.importsFor(myProject).stream().map(PantsBspData::getPantsRoot).anyMatch(root -> VfsUtil.isAncestor(root, vFile, false))) {
+        if(PantsBspData.pantsRoots(myProject).map(root -> VfsUtil.isAncestor(root, vFile, false)).orElse(false)) {
           return true;
         }
 


### PR DESCRIPTION
1. findPantsRoot was called indirectly by JarMappings::librariesFile.
This was happening on each VFS event, so could be expensive
2. librariesFile needs BSP roots path. Previously it was extracted from expensive
`importsFor` method.
3. Now, the `importsFor` method is simplified, so it just takes BSP root from `getBasePath`. This means
we don't support cases when two `.bloop` projects are imported into a single IJ project. Anyways, the
support for this was never used or tested.