### PR TITLE
Enabling external-api.jar generation for IJ 2021.1.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,8 @@ When GH Action is successful, and the release is done, update link in `scripts/p
             <root id="archive" name="external-system-test-api.jar">
               <element id="module-test-output" name="intellij.platform.externalSystem.impl" />
               <element id="module-test-output" name="intellij.platform.externalSystem.tests" />
+              <element id="module-output" name="intellij.platform.externalSystem.api" />
+              <element id="module-output" name="intellij.platform.externalSystem.impl" />
             </root>
           </artifact>
         </component>

--- a/build-external-api-jar/project/Dependencies.scala
+++ b/build-external-api-jar/project/Dependencies.scala
@@ -8,13 +8,13 @@ object Dependencies {
 
   object ideProbe {
 
-    val version = "0.3.0+28-b36b0a51+20210114-1358-SNAPSHOT"
+    val version = "0.9.0"
     val resolvers = Seq(
       Resolver.sonatypeRepo("public"),
       Resolver.sonatypeRepo("snapshots"),
       MavenRepository(
         "jetbrains-3rd",
-        "https://jetbrains.bintray.com/intellij-third-party-dependencies")
+        "https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
     )
 
     def apply(name: String): ModuleID = {

--- a/build-external-api-jar/run.sh
+++ b/build-external-api-jar/run.sh
@@ -2,8 +2,11 @@
 # IDEA_VERSION=202.6109.22
 # IDEA_SHA=b8d2a1567fc29fa7514666aead10e70b23f2f94b301e489817a01ed34f5e46d3
 
-IDEA_VERSION=203.5981.114
-IDEA_SHA=94b17f42465b8f2af7bc8b9bf0ced1b9989877596d1c2758e4104b089b931b55
+#IDEA_VERSION=203.5981.114
+#IDEA_SHA=94b17f42465b8f2af7bc8b9bf0ced1b9989877596d1c2758e4104b089b931b55
+
+IDEA_VERSION=211.7142.45
+IDEA_SHA=57f4547abb3814348eddf2f4c4a2df852b297f0ad8c60ec06194f132cd0f901c
 SOURCES_DIR="/tmp/idea-sources"
 DIR=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 GIT_ROOT=$DIR/..
@@ -19,6 +22,9 @@ set -e
     cd $DIR
     export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 
     export IDEPROBE_DISPLAY=xvfb
+    # Disable IntelliJ Data Sharing
+    mkdir -p ~/.local/share/JetBrains/consentOptions/
+    echo -n rsch.send.usage.stat:1.1:0:1574939222872 > ~/.local/share/JetBrains/consentOptions/accepted
     sbt test
 )
 (

--- a/build-external-api-jar/tests/src/test/resources/OpenProjectAndBuildArtifacts.conf
+++ b/build-external-api-jar/tests/src/test/resources/OpenProjectAndBuildArtifacts.conf
@@ -1,7 +1,7 @@
 versions {
   intellij {
-    build = "203.5981.41"
-    release = "2020.3"
+    build = "211.7142.45"
+    release = "2021.1.1"
   }
 }
 

--- a/build-external-api-jar/tests/src/test/scala/org/virtuslab/tests/OpenProjectAndBuildArtifacts.scala
+++ b/build-external-api-jar/tests/src/test/scala/org/virtuslab/tests/OpenProjectAndBuildArtifacts.scala
@@ -2,7 +2,10 @@ package org.virtuslab.tests
 
 import org.junit.Test
 import org.virtuslab.ideprobe.junit4.IdeProbeTestSuite
+import org.virtuslab.ideprobe.WaitLogic
 import org.virtuslab.ideprobe.ProbeExtensions
+
+import scala.concurrent.duration.DurationInt
 
 import java.nio.file.Paths
 
@@ -121,6 +124,8 @@ object OpenProjectAndBuildArtifacts
         |    <root id="archive" name="external-system-test-api.jar">
         |      <element id="module-test-output" name="intellij.platform.externalSystem.impl" />
         |      <element id="module-test-output" name="intellij.platform.externalSystem.tests" />
+        |      <element id="module-output" name="intellij.platform.externalSystem.api" />
+        |      <element id="module-output" name="intellij.platform.externalSystem.impl" />
         |    </root>
         |  </artifact>
         |
@@ -145,7 +150,7 @@ class OpenProjectAndBuildArtifacts extends IdeProbeTestSuite with ProbeExtension
   )
 
   @Test def build: Unit = fixtureFromConfig().run { intelliJ =>
-    val project = intelliJ.probe.openProject(intelliJ.workspace)
+    val project = intelliJ.probe.openProject(intelliJ.workspace, WaitLogic.emptyNamedBackgroundTasks(atMost = 1.hour))
 
     def waitUntilTrueForAllTasks(predicate: Seq[String] => Boolean) = synchronized {
       var scanning = false


### PR DESCRIPTION
In order to continue with the update, we must generate new IJ API jar and publish it, so that the build could use it.