### PR TITLE
Fix field mapping in PythonSetupData

### DIFF
--- a/src/com/twitter/intellij/pants/service/python/PythonSetupData.java
+++ b/src/com/twitter/intellij/pants/service/python/PythonSetupData.java
@@ -20,7 +20,7 @@ public class PythonSetupData extends AbstractExternalEntityData {
   private final PythonInterpreterInfo myInterpreterInfo;
   private final ModuleData myOwnerModuleData;
 
-  @PropertyMapping({"myOwnerModuleData", "interpreterInfo"})
+  @PropertyMapping({"myOwnerModuleData", "myInterpreterInfo"})
   public PythonSetupData(ModuleData ownerModuleData, @NotNull PythonInterpreterInfo interpreterInfo) {
     super(PantsConstants.SYSTEM_ID);
     myOwnerModuleData = ownerModuleData;


### PR DESCRIPTION
There is a test that checks the serialization/deserialization of this class, called `PythonSetupDataTest.java`, which should fail. I don't know why it doesn't fail on Travis