### PR TITLE
Update jetbrains token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     # Make the build time faster for Pants.
     # Runtime perf is less important because this is a small repo.
     - MODE="debug"
-    - secure: I4u7KTGW3UJnDF/Dy+4ubnqtHSgyry0g4wLk2xPv8NVyFdl2zu5aV4KxstAAQPGxGZ3iwHJWwBWjI3V3LnpFRFYIKA3esYcCK37m8o8Rdsaf/nHB4qqh29f6+RMeGSKLxPAX3T20G8VORTs+N9dVuwJqU4bMt2kwtrHhD9oz6Xo=
+    - secure: "Ppl8EyaKALpPDshzwT5MoaIJU1hVqZybBtwzQHaFCymqJvZx7icQSJAtCLpZIqmMsB6kBqL8uqVAALhQ7tb1Bg9eudP/XymvFYrcwnAjrsvvrNnZBr61chv8WPbBUXKEdhvpcDb57WhanT7iljRKNfL1kUBHLFa6JVAEOvhmTaI="
 
 # General policy is to support pants for the past 10 releases and the latest master.
 matrix:


### PR DESCRIPTION
Post travis security incident: https://travis-ci.community/t/security-bulletin/12081

Old token was removed from jetbrains account.