### PR TITLE
Bug fixes after upgrade to 2021.2

### DIFF
--- a/src/com/twitter/intellij/pants/components/impl/PantsInitImpl.java
+++ b/src/com/twitter/intellij/pants/components/impl/PantsInitImpl.java
@@ -1,34 +1,28 @@
-// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 package com.twitter.intellij.pants.components.impl;
 
+import com.intellij.ide.AppLifecycleListener;
 import com.intellij.openapi.externalSystem.util.ExternalSystemConstants;
 import com.intellij.openapi.util.registry.Registry;
-import com.twitter.intellij.pants.components.PantsInitComponent;
 import com.twitter.intellij.pants.metrics.PantsMetrics;
 import com.twitter.intellij.pants.util.PantsConstants;
 import com.twitter.intellij.pants.util.PantsUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class PantsInitComponentImpl implements PantsInitComponent {
-  @NotNull
-  @Override
-  public String getComponentName() {
-    return "pants.init";
-  }
+import java.util.List;
 
-  public PantsInitComponentImpl() {
-    // The Pants plugin doesn't do so many computations for building a project
-    // to start an external JVM each time.
-    // The plugin only calls `export` goal and parses JSON response.
-    // So it will be in process all the time.
+public class PantsInitImpl implements AppLifecycleListener {
+
+  @Override
+  public void appFrameCreated(@NotNull List<String> commandLineArgs) {
     final String key = PantsConstants.SYSTEM_ID.getId() + ExternalSystemConstants.USE_IN_PROCESS_COMMUNICATION_REGISTRY_KEY_SUFFIX;
     Registry.get(key).setValue(true);
   }
 
   @Override
-  public void dispose() {
+  public void appWillBeClosed(boolean isRestart) {
     PantsUtil.scheduledThreadPool.shutdown();
     PantsMetrics.globalCleanup();
   }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -25,14 +25,6 @@
   <depends optional="true" config-file="pants-python.xml">Pythonid</depends>
   <depends optional="true" config-file="pants-python.xml">PythonCore</depends>
 
-
-  <application-components>
-    <component>
-      <interface-class>com.twitter.intellij.pants.components.PantsInitComponent</interface-class>
-      <implementation-class>com.twitter.intellij.pants.components.impl.PantsInitComponentImpl</implementation-class>
-    </component>
-  </application-components>
-
   <actions>
     <!--  This group adds "Import Project" action which to the Welcome screen which was removed in 2020.1  -->
     <group id="WelcomeScreen.QuickStart.Pants">
@@ -179,6 +171,8 @@
   </extensions>
 
   <applicationListeners>
+    <listener class="com.twitter.intellij.pants.components.impl.PantsInitImpl"
+              topic="com.intellij.ide.AppLifecycleListener"/>
     <listener class="com.twitter.intellij.pants.components.impl.PantsProjectComponentImpl"
               topic="com.intellij.openapi.project.ProjectManagerListener"/>
   </applicationListeners>

--- a/src/main/scala/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
+++ b/src/main/scala/com/twitter/intellij/pants/components/impl/FastpassUpdater.java
@@ -82,7 +82,7 @@ public class FastpassUpdater {
     @Override
     public void update(@NotNull AnActionEvent e) {
       Project project = e.getProject();
-      if(project != null) {
+      if(project != null && PantsUtil.isFastpassProject(project)) {
         boolean show = FastpassUtils.getFastpassPath(project).isPresent();
         e.getPresentation().setEnabledAndVisible(show);
       } else {

--- a/src/main/scala/com/twitter/intellij/pants/ui/PantsConsoleViewPanel.java
+++ b/src/main/scala/com/twitter/intellij/pants/ui/PantsConsoleViewPanel.java
@@ -131,6 +131,7 @@ public class PantsConsoleViewPanel extends JPanel {
     JPanel toolbarPanel = new JPanel(new BorderLayout());
     ActionManager actionManager = ActionManager.getInstance();
     ActionToolbar leftToolbar = actionManager.createActionToolbar(ActionPlaces.COMPILER_MESSAGES_TOOLBAR, leftUpdateableActionGroup, false);
+    leftToolbar.setTargetComponent(toolbarPanel);
     toolbarPanel.add(leftToolbar.getComponent(), BorderLayout.WEST);
 
     return toolbarPanel;


### PR DESCRIPTION
3 Bug fixes after upgrade to 2021.2:
- Added check if project isFastpassProject in FastpassUpdater, which resolved problem with "not a fastpass project"
- Changed PantsInitComponentImpl to PantsInitImp implementing AppLifecycleListener now as a version before caused problems with "wrong stage of building"
-  Added setTargetComponent for leftToolbar in PantsConsoleViewPanel.java, which resolved problem with "not Ui component"